### PR TITLE
Update SheetUtill.cs to fix memory issue with AutoSizeColumn for large w...

### DIFF
--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -224,7 +224,6 @@ namespace NPOI.SS.Util
             using (Bitmap bmp = new Bitmap(2048, 100))
             using (Graphics g = Graphics.FromImage(bmp))
             {
-                Graphics g = Graphics.FromImage(bmp);
                 if (cellType == CellType.String)
                 {
                     IRichTextString rt = cell.RichStringCellValue;


### PR DESCRIPTION
...orksheets

AutoSizeColumn would regularly fail in sheets with > 30000 rows. The
call to "new Bitmap(2048,100)" would throw ArgumentException with "Parameter is not valid" (on a system that otherwise low on memory). Disposing of the Graphics object each time helps avoid this.
