### PR TITLE
Allow inserting a picture when Windows FIPS Compliance is turned on.

### DIFF
--- a/main/HSSF/UserModel/HSSFWorkbook.cs
+++ b/main/HSSF/UserModel/HSSFWorkbook.cs
@@ -1695,9 +1695,9 @@ namespace NPOI.HSSF.UserModel
             InitDrawings();
 
             byte[] uid;
-            using (MD5 md5 = MD5.Create())
+            using (var hasher = SHA256.Create())
             {
-                uid = md5.ComputeHash(pictureData);
+                uid = hasher.ComputeHash(pictureData);
             }
             EscherBitmapBlip blipRecord = new EscherBitmapBlip();
             blipRecord.RecordId = (short)(EscherBitmapBlip.RECORD_ID_START + format);


### PR DESCRIPTION
MD5 is not an approved in FIPS. I know this isn't a security function, but Windows doesn't care. To avoid pain, I propose using a FIPS approved hash function here.
