### PR TITLE
Username length information can be wrong

### DIFF
--- a/main/HSSF/Record/FileSharingRecord.cs
+++ b/main/HSSF/Record/FileSharingRecord.cs
@@ -57,6 +57,13 @@ namespace NPOI.HSSF.Record
                 // TODO - Current examples(3) from junits only have zero Length username. 
                 field_3_username_unicode_options = (byte)in1.ReadByte();
                 field_3_username_value = in1.ReadCompressedUnicode(nameLen);
+                
+                if (field_3_username_value == null)
+                {
+                   // In some cases the user name can be null after reading from
+                   // the input stream so we make sure this has a value
+                   field_3_username_value = "";
+                }
             }
             else
             {


### PR DESCRIPTION
The length information of the user name can be wrong so that it's value can be `null` after leaving the constructor which then leads to `NullReferenceException`s all over the place (in my case I encountered one while accessing the `DataSize` getter. 

I'm pretty sure this situation is due to a malformed `HSSFWorkbook` file. I'm currently writing a class for conversion between `XSSF`<->`HSSF` files. While the `XSSF->HSSF` part seems to work (at least sufficiently for my use case) reading the converted `HSSFWorkbook` back into an `XSSFWorkbook` got me this `NullReferenceException`. 

I guess it's not really the fault of `HSSF.Record.FileSharingRecord` but rather a problem with the `XSSF->HSSF` part but I think catching such cases isn't a bad idea anyways?
