### PR TITLE
Issue in CT_Colors leads to corrupted Excel Indexed colors

### DIFF
--- a/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_Colors.cs
+++ b/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_Colors.cs
@@ -34,7 +34,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                     ctObj.indexedColors = new List<CT_RgbColor>();
                     foreach (XmlNode c2Node in childNode.ChildNodes)
                     {
-                        ctObj.indexedColors.Add(CT_RgbColor.Parse(childNode, namespaceManager));
+                        ctObj.indexedColors.Add(CT_RgbColor.Parse(c2Node, namespaceManager));
                     }
                 }
                 else if (childNode.LocalName == "mruColors")


### PR DESCRIPTION
When reading existing xls file and then saving it, there is an issue (looks like a typo) in CT_Colors.Parse that leads to corrupted indexedColors. While quering indexed colors nodes in styles.xml c2Node should be used instead of childNode as argument of CT_RgbColor.Parse.
