### PR TITLE
fix FormatException in formula parser

### DIFF
--- a/main/SS/Formula/FormulaParser.cs
+++ b/main/SS/Formula/FormulaParser.cs
@@ -1776,7 +1776,7 @@ namespace NPOI.SS.Formula
                 number.Append(number1);
             }
 
-            number.Append('.');
+            number.Append(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
             number.Append(number2);
 
             if (exponent != null)


### PR DESCRIPTION
NumberPtg's constructor calls Double.Parse with current culture, so I got FormatException here.
