### PR TITLE
Fix for issue 12727: Update for XSSFHyperlink.cs

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFHyperlink.cs
+++ b/ooxml/XSSF/UserModel/XSSFHyperlink.cs
@@ -82,7 +82,14 @@ namespace NPOI.XSSF.UserModel
                 else
                 {
                     Uri target = _externalRel.TargetUri;
-                    _location = target.ToString();
+                    try
+                    {
+                        _location = target.ToString();
+                    }
+                    catch (UriFormatException)
+                    {
+                        _location = target.OriginalString;
+                    }
 
                     // Try to figure out the type
                     if (_location.StartsWith("http://") || _location.StartsWith("https://")


### PR DESCRIPTION
Fix for issue http://npoi.codeplex.com/workitem/12727 (Crash when opening a file with a broken link)
