### PR TITLE
Fix XLSX file corruption when saving an existing file containing images

### DIFF
--- a/ooxml/OpenXmlFormats/Drawing/SpreadsheetDrawing.cs
+++ b/ooxml/OpenXmlFormats/Drawing/SpreadsheetDrawing.cs
@@ -1661,11 +1661,11 @@ namespace NPOI.OpenXmlFormats.Dml.Spreadsheet
                 }
                 else if (childNode.LocalName == "pic")
                 {
-                    oneCellAnchor.connector = CT_Connector.Parse(childNode, namespaceManager);
+                    oneCellAnchor.picture = CT_Picture.Parse(childNode, namespaceManager);
                 }
                 else if (childNode.LocalName == "cxnSp")
                 {
-                    oneCellAnchor.groupShape = CT_GroupShape.Parse(childNode, namespaceManager);
+                    oneCellAnchor.connector = CT_Connector.Parse(childNode, namespaceManager);
                 }
                 else if (childNode.LocalName == "grpSp")
                 {
@@ -1723,11 +1723,11 @@ namespace NPOI.OpenXmlFormats.Dml.Spreadsheet
                 }
                 else if (childNode.LocalName == "pic")
                 {
-                    absCellAnchor.connector = CT_Connector.Parse(childNode, namespaceManager);
+                    absCellAnchor.picture = CT_Picture.Parse(childNode, namespaceManager);
                 }
                 else if (childNode.LocalName == "cxnSp")
                 {
-                    absCellAnchor.groupShape = CT_GroupShape.Parse(childNode, namespaceManager);
+                    absCellAnchor.connector = CT_Connector.Parse(childNode, namespaceManager);
                 }
                 else if (childNode.LocalName == "grpSp")
                 {


### PR DESCRIPTION
I have a situation where I am using an existing XLSX file as a template. The single sheet in this file contains an image (OneCellAnchor). The resulting file was becoming corrupt when I opened, modified, and saved it.

I noticed a few of the parse conditions for CT_OneCellAnchor and CT_AbsoluteCellAnchor are incorrect.
