### PR TITLE
Fix XLSX vertical alignment being set to top when only horizontal alignment is set

### DIFF
--- a/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_CellAlignment.cs
+++ b/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_CellAlignment.cs
@@ -23,6 +23,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
     public enum ST_VerticalAlignment
     {
+        general,
         top,
         center,
         bottom,
@@ -94,9 +95,10 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            if(this.horizontal!= ST_HorizontalAlignment.general)
+            if(this.horizontal != ST_HorizontalAlignment.general)
                 XmlHelper.WriteAttribute(sw, "horizontal", this.horizontal.ToString());
-            XmlHelper.WriteAttribute(sw, "vertical", this.vertical.ToString());
+            if (this.vertical != ST_VerticalAlignment.general)
+                XmlHelper.WriteAttribute(sw, "vertical", this.vertical.ToString());
             XmlHelper.WriteAttribute(sw, "textRotation", this.textRotation);
             if(this.wrapText)
                 XmlHelper.WriteAttribute(sw, "wrapText", this.wrapText);
@@ -146,7 +148,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
         [XmlAttribute]
-        [DefaultValue(ST_VerticalAlignment.top)]
+        [DefaultValue(ST_VerticalAlignment.general)]
         public ST_VerticalAlignment vertical
         {
             get


### PR DESCRIPTION
I am using an existing XLSX file as a template. On some cells, only the horizontal alignment is set to something other than the default. When this is the case, an "alignment" node exists in the XML. The CT_CellAlignment class is currently setting the vertical alignment to top when a "vertical" attribute does not even exist on the "alignment" node. The default vertical value in Excel is bottom align, so most of my cell alignment is being overridden with top when I write to the file.
