### PR TITLE
Fix for not being able to unlock cell.

### DIFF
--- a/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_CellProtection.cs
+++ b/ooxml/OpenXmlFormats/Spreadsheet/Styles/CT_CellProtection.cs
@@ -40,8 +40,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            if(this.locked)
-                XmlHelper.WriteAttribute(sw, "locked", this.locked);
+            XmlHelper.WriteAttribute(sw, "locked", this.locked);
             XmlHelper.WriteAttribute(sw, "hidden", this.hidden);
             sw.Write("/>");
         }


### PR DESCRIPTION
Since the last commit to this file, the locked attribute was only persisted when it was set to true, thus we are not able to unlock cells where it is set to false. 

Now, it is always persisted (=> cells can be locked + unlocked).
