### PR TITLE
Fix Bug: Paragraph ReplaceText/SearchText In Several Runs

### DIFF
--- a/ooxml/XWPF/Usermodel/XWPFParagraph.cs
+++ b/ooxml/XWPF/Usermodel/XWPFParagraph.cs
@@ -1338,11 +1338,11 @@ namespace NPOI.XWPF.UserModel
             int startRun = startPos.Run,
                 startText = startPos.Text,
                 startChar = startPos.Char;
-            int beginRunPos = 0, candCharPos = 0;
+            int beginRunPos = 0, beginTextPos = 0, beginCharPos = 0,candCharPos = 0;
             bool newList = false;
             for (int runPos = startRun; runPos < paragraph.GetRList().Count; runPos++)
             {
-                int beginTextPos = 0, beginCharPos = 0, textPos = 0, charPos = 0;
+                int  textPos = 0, charPos = 0;
                 CT_R ctRun = paragraph.GetRList()[runPos];
                 foreach (object o in ctRun.Items)
                 {

--- a/testcases/ooxml/XWPF/UserModel/TestXWPFParagraph.cs
+++ b/testcases/ooxml/XWPF/UserModel/TestXWPFParagraph.cs
@@ -589,6 +589,41 @@ namespace TestCases.XWPF.UserModel
             String s = str.ToString();
             Assert.IsFalse(s.Contains("This is another Test"));
         }
+        
+        [Test]
+        public void Testpullrequest404()
+        {
+            XWPFDocument doc = new XWPFDocument();
+            var paragraph = doc.CreateParagraph();
+            paragraph.CreateRun().AppendText("abc");
+            paragraph.CreateRun().AppendText("de");
+            paragraph.CreateRun().AppendText("f");
+            paragraph.CreateRun().AppendText("g"); 
+            var result = paragraph.SearchText("cdefg",new PositionInParagraph());
+            Assert.AreEqual(result.BeginRun, 0);
+            Assert.AreEqual(result.EndRun, 3);
+            Assert.AreEqual(result.BeginText, 0);
+            Assert.AreEqual(result.EndText, 0);
+            Assert.AreEqual(result.BeginChar, 2);
+            Assert.AreEqual(result.EndChar, 0);
+        }
+        [Test]
+        public void Testpullrequest404_1()
+        {
+            XWPFDocument doc = new XWPFDocument();
+            var paragraph = doc.CreateParagraph();
+            paragraph.CreateRun().AppendText("abc");
+            paragraph.CreateRun().AppendText("de");
+            paragraph.CreateRun().AppendText("fg");
+            paragraph.CreateRun().AppendText("hi"); 
+            var result = paragraph.SearchText("cdefg",new PositionInParagraph());
+            Assert.AreEqual(result.BeginRun, 0);
+            Assert.AreEqual(result.EndRun, 2);
+            Assert.AreEqual(result.BeginText, 0);
+            Assert.AreEqual(result.EndText, 0);
+            Assert.AreEqual(result.BeginChar, 2);
+            Assert.AreEqual(result.EndChar, 1);
+        }
     }
 
 }


### PR DESCRIPTION
Bug Cases:

Four runs in paragraph:
["abc","de","f","g"]
Search 'cdefg'
First run, 'c' was found and beginCharPos = 2.
Second run, the beginCharPos been set to 0 again.
In the end, the function will return 
{
    Run = 0,
    Text = 0,
    Char = 0
}
However, the result should be 
{
    Run = 0,
    Text = 0,
    Char = 2
}

The pull request fix this bug.

XWPFParagraph SearchIndex In Several Paragraph Reset BeginCharPos Each Time Move To Next Run