### PR TITLE
Add ArrayEval for Row Function when using a range address

### DIFF
--- a/main/NPOI.csproj
+++ b/main/NPOI.csproj
@@ -282,9 +282,11 @@
     <Compile Include="SS\Formula\Atp\IfError.cs" />
     <Compile Include="SS\Formula\Atp\NetworkdaysFunction.cs" />
     <Compile Include="SS\Formula\BaseFormulaEvaluator.cs" />
+    <Compile Include="SS\Formula\Eval\ArrayEval.cs" />
     <Compile Include="SS\Formula\Eval\NotImplementedFunctionException.cs" />
     <Compile Include="SS\Formula\Atp\WorkdayCalculator.cs" />
     <Compile Include="SS\Formula\Atp\WorkdayFunction.cs" />
+    <Compile Include="SS\Formula\Eval\NumberValueArrayEval.cs" />
     <Compile Include="SS\Formula\Functions\Averageifs.cs" />
     <Compile Include="SS\Formula\Functions\BaseNumberUtils.cs" />
     <Compile Include="SS\Formula\Functions\Bin2Dec.cs" />

--- a/main/SS/Formula/Eval/ArrayEval.cs
+++ b/main/SS/Formula/Eval/ArrayEval.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NPOI.SS.Formula.Eval
+{
+    public interface ArrayEval : ValueEval
+    {
+    }
+}

--- a/main/SS/Formula/Eval/NumberValueArrayEval.cs
+++ b/main/SS/Formula/Eval/NumberValueArrayEval.cs
@@ -1,0 +1,19 @@
+﻿using NPOI.SS.Formula.Functions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NPOI.SS.Formula.Eval
+{
+    public class NumberValueArrayEval : ArrayEval
+    {
+        public double[] NumberValues { get; set; }
+
+        public NumberValueArrayEval(double[] values)
+        {
+            NumberValues = values;
+        }
+    }
+}

--- a/main/SS/Formula/Functions/MultiOperandNumericFunction.cs
+++ b/main/SS/Formula/Functions/MultiOperandNumericFunction.cs
@@ -232,6 +232,11 @@ namespace NPOI.SS.Formula.Functions
                 }
                 return;
             }
+            if (ve is NumberValueArrayEval nvae)
+            {
+                temp.Add(nvae.NumberValues);
+                return;
+            }
             throw new InvalidOperationException("Invalid ValueEval type passed for conversion: ("
                     + ve.GetType() + ")");
         }

--- a/main/SS/Formula/Functions/Row.cs
+++ b/main/SS/Formula/Functions/Row.cs
@@ -33,9 +33,15 @@ namespace NPOI.SS.Formula.Functions
         {
             int rnum;
 
-            if (arg0 is AreaEval)
+            if (arg0 is AreaEval areaArg0)
             {
-                rnum = ((AreaEval)arg0).FirstRow;
+
+                double[] rnums = new double[areaArg0.Height];
+                for (int i = 0; i < areaArg0.Height; i++)
+                {
+                    rnums[i] = areaArg0.FirstRow + i + 1;
+                }
+                return new NumberValueArrayEval(rnums);
             }
             else if (arg0 is RefEval)
             {


### PR DESCRIPTION
The Row function start to support a range area value since Excel2007. But the Row class is still using the first value of the row which causes several problems.