### PR TITLE
Ensure tests run linux and macOS

### DIFF
--- a/main/SS/Format/CellFormatPart.cs
+++ b/main/SS/Format/CellFormatPart.cs
@@ -57,7 +57,7 @@ namespace NPOI.SS.Format
 
 
 
-            #region IEqualityComparer<string> ≥…‘±
+            #region IEqualityComparer<string> ÔøΩÔøΩ‘±
 
             public bool Equals(string x, string y)
             {
@@ -597,7 +597,7 @@ namespace NPOI.SS.Format
 
                 // Now the pass for quoted chars: Replace any \u0000 with ''
                 pos = 0;
-                while ((pos = fmt.ToString().IndexOf("\u0000", pos)) >= 0)
+                while ((pos = fmt.ToString().IndexOf('\u0000', pos)) >= 0)
                 {
                     //fmt.Replace(pos, pos + 1, "''");
                     fmt.Remove(pos, 1);

--- a/main/SS/Format/CellFormatPart.cs
+++ b/main/SS/Format/CellFormatPart.cs
@@ -57,7 +57,7 @@ namespace NPOI.SS.Format
 
 
 
-            #region IEqualityComparer<string> ��Ա
+            #region IEqualityComparer<string>
 
             public bool Equals(string x, string y)
             {

--- a/main/Util/CodePageUtil.cs
+++ b/main/Util/CodePageUtil.cs
@@ -29,6 +29,13 @@ namespace NPOI.Util
      */
     public class CodePageUtil
     {
+        static CodePageUtil() 
+        {
+            #if NETSTANDARD2_1 || NETSTANDARD2_0
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+            #endif
+        }
+
         /** <p>Codepage 037, a special case</p> */
         public const int CP_037 = 37;
 

--- a/testcases/main/HSSF/UserModel/TestSanityChecker.cs
+++ b/testcases/main/HSSF/UserModel/TestSanityChecker.cs
@@ -136,12 +136,15 @@ namespace TestCases.HSSF.UserModel
 
         private static void ConfirmBadRecordOrder(SanityChecker.CheckRecord[] Check, Record[] recs)
         {
-
+            TestSanityChecker.check = Check;
             TestSanityChecker.recs = recs;
 
-            ThreadStart ts = new ThreadStart(Run);
-            Thread thread = new Thread(ts);
-            thread.Start();
+            // ThreadStart ts = new ThreadStart(Run);
+            // Thread thread = new Thread(ts);
+            // thread.Start();
+            // thread.Join();
+            Run();
+            
         }
     }
 }


### PR DESCRIPTION
This PR fixes a few small issues with unit tests that result in tests not being able to run on Linux and macOS using dotnet core.

- Fixes an infinite loop resulting from replacing null terminator within strings
- Registers the code page provider within the CodePageUtil to ensure availability in dotnet standard
- Corrects missing checks in the test sanity checker and removes unsafe thread usage

It would be much appreciated if you could add the `hacktoberfest-accepted` label to this PR. I believe that this is a valid contribution to the NPOI project, and this label will indicate this to the Hacktoberfest event.