### PR TITLE
Fix XSSFExcelExtractor regression to emit empty cells

### DIFF
--- a/ooxml/XSSF/Extractor/XSSFExcelExtractor.cs
+++ b/ooxml/XSSF/Extractor/XSSFExcelExtractor.cs
@@ -219,9 +219,7 @@ namespace NPOI.XSSF.Extractor
                         bool firsttime = true;
                         for (int j = 0; j < row.LastCellNum; j++)
                         {
-                            ICell cell = row.GetCell(j);
-                            if (cell == null)
-                                continue;
+                            // Add a tab delimiter for each empty cell.
                             if (!firsttime)
                             {
                                 text.Append("\t");
@@ -230,7 +228,10 @@ namespace NPOI.XSSF.Extractor
                             {
                                 firsttime = false;
                             }
-                            
+
+                            ICell cell = row.GetCell(j);
+                            if (cell == null)
+                                continue;
 
                             // Is it a formula one?
                             if (cell.CellType == CellType.Formula)

--- a/testcases/ooxml/XSSF/Extractor/TestXSSFExcelExtractor.cs
+++ b/testcases/ooxml/XSSF/Extractor/TestXSSFExcelExtractor.cs
@@ -216,7 +216,6 @@ namespace TestCases.XSSF.Extractor
         }
 
         [Test]
-        [Ignore("not found in poi")]
         public void TestEmptyCells()
         {
             XSSFExcelExtractor extractor = GetExtractor("SimpleNormal.xlsx");


### PR DESCRIPTION
This fixes the issue addressed in PR #241 to emit a tab when an empty cell is encountered. Without it, any Excel file with an empty cell cannot be effectively parsed as CSV (TSV) since the cells don't line up with their expected columns. This fix does not affect any other tests.