### PR TITLE
XSSFFont.CloneStyleFrom now always clones

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFFont.cs
+++ b/ooxml/XSSF/UserModel/XSSFFont.cs
@@ -662,26 +662,19 @@ namespace NPOI.XSSF.UserModel
 
         public void CloneStyleFrom(IFont src)
         {
-            if (src != null)
-            {
-                if (src is XSSFFont)
-                {
-                    _ctFont = ((XSSFFont)src)._ctFont;
-                }
-                else
-                {
-                    FontName = src.FontName;
-                    FontHeight = src.FontHeight;
-                    IsBold = src.IsBold;
-                    Boldweight = src.Boldweight;
-                    IsItalic = src.IsItalic;
-                    IsStrikeout = src.IsStrikeout;
-                    Color = src.Color;
-                    Underline = src.Underline;
-                    Charset = src.Charset;
-                    TypeOffset = src.TypeOffset;
-                }
-            }
+            if (src == null)
+                return;
+
+            FontName = src.FontName;
+            FontHeight = src.FontHeight;
+            IsBold = src.IsBold;
+            Boldweight = src.Boldweight;
+            IsItalic = src.IsItalic;
+            IsStrikeout = src.IsStrikeout;
+            Color = src.Color;
+            Underline = src.Underline;
+            Charset = src.Charset;
+            TypeOffset = src.TypeOffset;
         }
     }
 }


### PR DESCRIPTION
As reported here #317, the `CloneStyleFrom` method on `XSSFFont` copies the internal reference across, instead of copying over its attributes. This can lead to unexpected mutations. 