### PR TITLE
修复文件夹路径拼写问题，单反斜杠（Windows），单斜杠（Linux）

### DIFF
--- a/main/Util/TempFile.cs
+++ b/main/Util/TempFile.cs
@@ -1,4 +1,4 @@
-﻿
+
 namespace NPOI.Util
 {
     using System;
@@ -21,13 +21,13 @@ namespace NPOI.Util
 
             if (dir == null)
             {
-                dir = Directory.CreateDirectory(Path.GetTempPath() + @"\poifiles").FullName;
+                dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "poifiles")).FullName;
             }
             // Generate a unique new filename 
-            string file= dir + "\\" + prefix + Guid.NewGuid().ToString() + suffix;
+            string file = Path.Combine(dir, prefix + Guid.NewGuid().ToString() + suffix);
             while (File.Exists(file))
             {
-                file = dir + "\\" + prefix + Guid.NewGuid().ToString() + suffix;
+                file = Path.Combine(dir, prefix + Guid.NewGuid().ToString() + suffix);
                 Thread.Sleep(1);
             }
             FileStream newFile = new FileStream(file, FileMode.CreateNew, FileAccess.ReadWrite);
@@ -40,12 +40,12 @@ namespace NPOI.Util
         {
             if (dir == null)
             {
-                dir = Directory.CreateDirectory(Path.GetTempPath() + @"\poifiles").FullName;
+                dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "poifiles")).FullName;
             }
             Random rnd = new Random(DateTime.Now.Millisecond);
             Thread.Sleep(10);
             //return prefix + rnd.Next() + suffix;
-            return dir + "\\" + prefix + rnd.Next() + suffix;
+            return Path.Combine(dir, prefix + rnd.Next() + suffix);
         }
     }
 }


### PR DESCRIPTION
修复文件夹路径拼写问题，单反斜杠（Windows），单斜杠（Linux）。

在 Linux 系统下，会错误的创建名称为 \poifiles 文件夹，并且将临时文件直接存储到到 /tmp 目录下面，并非 /tmp/poifiles 目录。

BUG 截图

[![](https://attach.itsvse.com/bug/bug.jpg)](https://attach.itsvse.com/bug/bug.jpg)

修复后

[![](https://attach.itsvse.com/bug/fixedbug.jpg)](https://attach.itsvse.com/bug/fixedbug.jpg)

从 Windows 和 Linux 测试通过。

