### PR TITLE
Add null check

### DIFF
--- a/main/SS/Formula/Functions/Sumifs.cs
+++ b/main/SS/Formula/Functions/Sumifs.cs
@@ -140,7 +140,7 @@ namespace NPOI.SS.Formula.Functions
                         AreaEval aeRange = ranges[i];
                         IMatchPredicate mp = predicates[i];
 
-                        if (!mp.Matches(aeRange.GetRelativeValue(r, c)))
+                        if (mp == null || !mp.Matches(aeRange.GetRelativeValue(r, c)))
                         {
                             matches = false;
                             break;


### PR DESCRIPTION
When I call `EvaluateAllFormulaCells` to evaluate, if the target `MatchPredicate` cell has no value, A `NullReferenceException` will be thrown and the program can't continue, so add the null check code.