### PR TITLE
Optimize OOM issue while loading big Xlsx file 

### DIFF
--- a/main/SS/UserModel/Sheet.cs
+++ b/main/SS/UserModel/Sheet.cs
@@ -913,6 +913,5 @@ namespace NPOI.SS.UserModel
 
 
         void CopyTo(IWorkbook dest, string name, bool copyStyle, bool keepFormulas);
-
     }
 }

--- a/main/SS/UserModel/Sheet.cs
+++ b/main/SS/UserModel/Sheet.cs
@@ -913,5 +913,6 @@ namespace NPOI.SS.UserModel
 
 
         void CopyTo(IWorkbook dest, string name, bool copyStyle, bool keepFormulas);
+
     }
 }

--- a/ooxml/POIXMLDocumentPart.cs
+++ b/ooxml/POIXMLDocumentPart.cs
@@ -38,7 +38,7 @@ using System.Xml;
     {
         private static POILogger logger = POILogFactory.GetLogger(typeof(POIXMLDocumentPart));
         private String coreDocumentRel = PackageRelationshipTypes.CORE_DOCUMENT;
-
+        public bool DocumentRead { get;  set; }
         private PackagePart packagePart;
         private PackageRelationship packageRel;
         private POIXMLDocumentPart parent;

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -4980,6 +4980,7 @@ namespace NPOI.XSSF.UserModel
             }
             CopySheetImages(dest as XSSFWorkbook, newSheet);
         }
+
         private static void CopyRow(XSSFSheet srcSheet, XSSFSheet destSheet, XSSFRow srcRow, XSSFRow destRow, IDictionary<Int32, ICellStyle> styleMap, bool keepFormulas)
         {
             destRow.Height = srcRow.Height;

--- a/ooxml/XSSF/UserModel/XSSFWorkbook.cs
+++ b/ooxml/XSSF/UserModel/XSSFWorkbook.cs
@@ -929,7 +929,7 @@ namespace NPOI.XSSF.UserModel
         private void ValidateSheetName(String sheetName)
         {
             if (ContainsSheet(sheetName, sheets.Count))
-                throw new ArgumentException(string.Format("The workbook already contains a sheet named '{0}'", sheetName));
+                throw new ArgumentException(string.Format("The workbook already contains a sheet named '{0}'",sheetName));
         }
         protected XSSFDialogsheet CreateDialogsheet(String sheetname, CT_Dialogsheet dialogsheet)
         {

--- a/ooxml/XSSF/UserModel/XSSFWorkbook.cs
+++ b/ooxml/XSSF/UserModel/XSSFWorkbook.cs
@@ -1277,7 +1277,7 @@ namespace NPOI.XSSF.UserModel
         public void RemoveName(String name)
         {
             List<XSSFName> names = namedRangesByName[name.ToLower()];
-            if (names.Count == 0)
+            if (names.Count==0)
             {
                 throw new ArgumentException("Named range was not found: " + name);
             }
@@ -1286,7 +1286,7 @@ namespace NPOI.XSSF.UserModel
 
         private bool RemoveMapping(string key, XSSFName item)
         {
-            if (namedRangesByName.ContainsKey(key))
+            if(namedRangesByName.ContainsKey(key))
             {
                 var values = namedRangesByName[key];
                 return values.Remove(item);
@@ -1652,7 +1652,7 @@ namespace NPOI.XSSF.UserModel
 
             // Check it isn't already taken
             if (ContainsSheet(sheetname, sheetIndex))
-                throw new ArgumentException(string.Format("The workbook already contains a sheet named '{0}'", sheetname));
+                throw new ArgumentException(string.Format("The workbook already contains a sheet named '{0}'",sheetname));
 
             // Update references to the name
             XSSFFormulaUtils utils = new XSSFFormulaUtils(this);
@@ -2193,7 +2193,7 @@ namespace NPOI.XSSF.UserModel
             {
                 if (poixmlDocumentPart is XSSFPivotCacheDefinition)
                 {
-                    var pivotCacheDefinition = (XSSFPivotCacheDefinition)poixmlDocumentPart;
+                    var pivotCacheDefinition = (XSSFPivotCacheDefinition)poixmlDocumentPart; 
                     RemoveRelation(pivotCacheDefinition);
                 }
             }

--- a/ooxml/XSSF/UserModel/XSSFWorkbook.cs
+++ b/ooxml/XSSF/UserModel/XSSFWorkbook.cs
@@ -261,7 +261,7 @@ namespace NPOI.XSSF.UserModel
         public XSSFWorkbook(FileInfo file)
             : this(OPCPackage.Open(file))
         {
-     
+
         }
 
         /**
@@ -429,7 +429,7 @@ namespace NPOI.XSSF.UserModel
                 return;
             }
             sh.sheet = ctSheet;
-            sh.OnDocumentRead();
+            //sh.OnDocumentRead();
             sheets.Add(sh);
         }
         /**
@@ -929,7 +929,7 @@ namespace NPOI.XSSF.UserModel
         private void ValidateSheetName(String sheetName)
         {
             if (ContainsSheet(sheetName, sheets.Count))
-                throw new ArgumentException(string.Format("The workbook already contains a sheet named '{0}'",sheetName));
+                throw new ArgumentException(string.Format("The workbook already contains a sheet named '{0}'", sheetName));
         }
         protected XSSFDialogsheet CreateDialogsheet(String sheetname, CT_Dialogsheet dialogsheet)
         {
@@ -1174,6 +1174,11 @@ namespace NPOI.XSSF.UserModel
             {
                 if (name.Equals(sheet.SheetName, StringComparison.InvariantCultureIgnoreCase))
                 {
+                    if (!sheet.DocumentRead)
+                    {
+                        sheet.OnDocumentRead();
+                        sheet.DocumentRead = true;
+                    }
                     return sheet;
                 }
             }
@@ -1272,7 +1277,7 @@ namespace NPOI.XSSF.UserModel
         public void RemoveName(String name)
         {
             List<XSSFName> names = namedRangesByName[name.ToLower()];
-            if (names.Count==0)
+            if (names.Count == 0)
             {
                 throw new ArgumentException("Named range was not found: " + name);
             }
@@ -1281,7 +1286,7 @@ namespace NPOI.XSSF.UserModel
 
         private bool RemoveMapping(string key, XSSFName item)
         {
-            if(namedRangesByName.ContainsKey(key))
+            if (namedRangesByName.ContainsKey(key))
             {
                 var values = namedRangesByName[key];
                 return values.Remove(item);
@@ -1572,7 +1577,7 @@ namespace NPOI.XSSF.UserModel
         {
             if (!namedRangesByName.ContainsKey(builtInCode.ToLower()))
                 return null;
-            
+
             foreach (XSSFName name in namedRangesByName[builtInCode.ToLower()])
             {
                 if (name.SheetIndex == sheetNumber)
@@ -1647,7 +1652,7 @@ namespace NPOI.XSSF.UserModel
 
             // Check it isn't already taken
             if (ContainsSheet(sheetname, sheetIndex))
-                throw new ArgumentException(string.Format("The workbook already contains a sheet named '{0}'",sheetname));
+                throw new ArgumentException(string.Format("The workbook already contains a sheet named '{0}'", sheetname));
 
             // Update references to the name
             XSSFFormulaUtils utils = new XSSFFormulaUtils(this);
@@ -2178,7 +2183,7 @@ namespace NPOI.XSSF.UserModel
             foreach (var xssfPivotTable in pivotTables)
             {
                 var sheet = xssfPivotTable.GetParent();
-                if ( sheet is XSSFSheet )
+                if (sheet is XSSFSheet)
                 {
                     sheet.RemoveRelation(xssfPivotTable);
                 }
@@ -2188,7 +2193,7 @@ namespace NPOI.XSSF.UserModel
             {
                 if (poixmlDocumentPart is XSSFPivotCacheDefinition)
                 {
-                    var pivotCacheDefinition = (XSSFPivotCacheDefinition)poixmlDocumentPart; 
+                    var pivotCacheDefinition = (XSSFPivotCacheDefinition)poixmlDocumentPart;
                     RemoveRelation(pivotCacheDefinition);
                 }
             }

--- a/ooxml/XSSF/UserModel/XSSFWorkbook.cs
+++ b/ooxml/XSSF/UserModel/XSSFWorkbook.cs
@@ -2183,7 +2183,7 @@ namespace NPOI.XSSF.UserModel
             foreach (var xssfPivotTable in pivotTables)
             {
                 var sheet = xssfPivotTable.GetParent();
-                if (sheet is XSSFSheet)
+                if ( sheet is XSSFSheet )
                 {
                     sheet.RemoveRelation(xssfPivotTable);
                 }

--- a/openxml4Net/Util/ZipInputStreamZipEntrySource.cs
+++ b/openxml4Net/Util/ZipInputStreamZipEntrySource.cs
@@ -166,7 +166,7 @@ namespace NPOI.OpenXml4Net.Util
                 return new MemoryStream(GZipDecompress(data));
             }
 
-            public static byte[] GZipCompress(byte[] source)
+            private static byte[] GZipCompress(byte[] source)
             {
                 using (var outStream = new MemoryStream())
                 {
@@ -181,7 +181,7 @@ namespace NPOI.OpenXml4Net.Util
                 }
             }
 
-            public static byte[] GZipDecompress(byte[] compressed)
+            private static byte[] GZipDecompress(byte[] compressed)
             {
                 using (var inStream = new MemoryStream(compressed))
                 {


### PR DESCRIPTION
思路：
1、 在ZipInputStreamZipEntrySource类优化读取，将文件流压缩存在内存中，在需要的时候再将文件流解压还原；
2、 在ooxml/POIXMLDocumentPart.cs新增DocumentRead字段，将之前读取时候即使构建对象（调用OnDocumentRead）延迟改成请求获取sheet的时候构建，毕竟在实际操作中，如果Excel有十几个工作表，并不是所有工作表都会使用到；
3、测试下来，八十多兆Xlsx文件之前经过较长读取后直接内存溢出；调整成上述逻辑后，内存降到六七百兆并能够成功读取；