### PR TITLE
Add minimal support Pivot tables, Fix #419, Fix #262

### DIFF
--- a/OpenXmlFormats/Drawing/Chart/Chart.cs
+++ b/OpenXmlFormats/Drawing/Chart/Chart.cs
@@ -74,6 +74,8 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                     ctObj.lang = CT_TextLanguageID.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "roundedCorners")
                     ctObj.roundedCorners = CT_Boolean.Parse(childNode, namespaceManager);
+                else if (childNode.LocalName == "AlternateContent")
+                    ctObj.alternateContent = Vml.Spreadsheet.CT_AlternateContent.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "style")
                     ctObj.style = CT_Style.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "clrMapOvr")
@@ -117,6 +119,8 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                     this.lang.Write(sw, "lang");
                 if (this.roundedCorners != null)
                     this.roundedCorners.Write(sw, "roundedCorners");
+                if (this.alternateContent != null)
+                    this.alternateContent.Write(sw, "AlternateContent");
                 if (this.style != null)
                     this.style.Write(sw, "style");
                 if (this.clrMapOvr != null)
@@ -194,6 +198,19 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             set
             {
                 this.roundedCornersField = value;
+            }
+        }
+
+        Vml.Spreadsheet.CT_AlternateContent alternateContentField = null;
+        public Vml.Spreadsheet.CT_AlternateContent alternateContent
+        {
+            get
+            {
+                return alternateContentField;
+            }
+            set
+            {
+                this.alternateContentField = value;
             }
         }
 
@@ -428,8 +445,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "r:id", this.id);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
     }
@@ -513,8 +529,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             XmlHelper.WriteAttribute(sw, "horizontalDpi", this.horizontalDpi);
             XmlHelper.WriteAttribute(sw, "verticalDpi", this.verticalDpi);
             XmlHelper.WriteAttribute(sw, "copies", this.copies);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -711,8 +726,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             XmlHelper.WriteAttribute(sw, "b", this.b);
             XmlHelper.WriteAttribute(sw, "header", this.header);
             XmlHelper.WriteAttribute(sw, "footer", this.footer);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -1520,8 +1534,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("<c:{0}", nodeName));
             if(this.val!= ST_LegendPos.r)
                 XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
     }
@@ -2219,8 +2232,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("<c:{0}", nodeName));
             if(this.val!= ST_LayoutTarget.outer)
                 XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -2297,8 +2309,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("<c:{0}", nodeName));
             if(this.val!= ST_LayoutMode.factor)
                 XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
     }
@@ -3228,8 +3239,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -4061,8 +4071,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private ST_Crosses valField;
@@ -4123,8 +4132,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -4165,8 +4173,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private ST_TimeUnit valField;
@@ -4783,8 +4790,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -4828,8 +4834,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -4870,8 +4875,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private ST_LblAlgn valField;
@@ -5716,8 +5720,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -6673,8 +6676,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
     }
@@ -6763,8 +6765,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
 
@@ -6923,8 +6924,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private ST_PictureFormat valField;
@@ -6982,8 +6982,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private double valField;
@@ -7656,8 +7655,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
     }
@@ -7997,8 +7995,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -8067,8 +8064,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val, true);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         public CT_Order()
@@ -8122,8 +8118,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -8533,8 +8528,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private ST_ErrDir valField;
@@ -8590,8 +8584,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private ST_ErrBarType valField;
@@ -8663,8 +8656,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -9356,7 +9348,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
 
         private CT_UnsignedInt ptCountField;
 
-        private List<CT_StrVal> lvlField;
+        private List<CT_Lvl> lvlField;
 
         private List<CT_Extension> extLstField;
 
@@ -9365,14 +9357,14 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             if (node == null)
                 return null;
             CT_MultiLvlStrData ctObj = new CT_MultiLvlStrData();
-            ctObj.lvl = new List<CT_StrVal>();
+            ctObj.lvl = new List<CT_Lvl>();
             ctObj.extLst = new List<CT_Extension>();
             foreach (XmlNode childNode in node.ChildNodes)
             {
                 if (childNode.LocalName == "ptCount")
                     ctObj.ptCount = CT_UnsignedInt.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "lvl")
-                    ctObj.lvl.Add(CT_StrVal.Parse(childNode, namespaceManager));
+                    ctObj.lvl.Add(CT_Lvl.Parse(childNode, namespaceManager));
                 else if (childNode.LocalName == "extLst")
                     ctObj.extLst.Add(CT_Extension.Parse(childNode, namespaceManager));
             }
@@ -9387,9 +9379,9 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(">");
             if (this.ptCount != null)
                 this.ptCount.Write(sw, "ptCount");
-            if (this.lvl != null)
+            if (this.lvl != null && this.lvl.Count > 0)
             {
-                foreach (CT_StrVal x in this.lvl)
+                foreach (CT_Lvl x in this.lvl)
                 {
                     x.Write(sw, "lvl");
                 }
@@ -9422,7 +9414,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         }
 
         [XmlElement(Order = 1)]
-        public List<CT_StrVal> lvl
+        public List<CT_Lvl> lvl
         {
             get
             {
@@ -9709,8 +9701,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -9759,8 +9750,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -9831,8 +9821,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -9882,8 +9871,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -9950,8 +9938,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private sbyte valField;
@@ -10008,8 +9995,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val.ToString());
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -10281,18 +10267,18 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                     x.Write(sw, "dateAx");
                 }
             }
-            if (this.catAx != null)
-            {
-                foreach (CT_CatAx x in this.catAx)
-                {
-                    x.Write(sw, "catAx");
-                }
-            }
             if (this.valAx != null)
             {
                 foreach (CT_ValAx x in this.valAx)
                 {
                     x.Write(sw, "valAx");
+                }
+            }
+            if (this.catAx != null)
+            {
+                foreach (CT_CatAx x in this.catAx)
+                {
+                    x.Write(sw, "catAx");
                 }
             }
             if (this.spPr != null)
@@ -10689,8 +10675,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("<c:{0}", nodeName));
             if(this.val!=30)
                 XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         [XmlAttribute]
@@ -10754,8 +10739,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("<c:{0}", nodeName));
             if(valField!=100)
                 XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
     }
@@ -10790,8 +10774,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
 
@@ -10833,8 +10816,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
 
@@ -10890,8 +10872,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
 
@@ -11252,7 +11233,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
 
         private CT_Boolean autoTitleDeletedField;
 
-        private List<CT_PivotFmt> pivotFmtsField;
+        private CT_PivotFmts pivotFmtsField;
 
         private CT_View3D view3DField;
 
@@ -11282,7 +11263,6 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             if (node == null)
                 return null;
             CT_Chart ctObj = new CT_Chart();
-            ctObj.pivotFmts = new List<CT_PivotFmt>();
             ctObj.extLst = new List<CT_Extension>();
             foreach (XmlNode childNode in node.ChildNodes)
             {
@@ -11290,6 +11270,8 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                     ctObj.title = CT_Title.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "autoTitleDeleted")
                     ctObj.autoTitleDeleted = CT_Boolean.Parse(childNode, namespaceManager);
+                else if (childNode.LocalName == "pivotFmts")
+                    ctObj.pivotFmts = CT_PivotFmts.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "view3D")
                     ctObj.view3D = CT_View3D.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "floor")
@@ -11308,8 +11290,6 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                     ctObj.dispBlanksAs = CT_DispBlanksAs.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "showDLblsOverMax")
                     ctObj.showDLblsOverMax = CT_Boolean.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "pivotFmts")
-                    ctObj.pivotFmts.Add(CT_PivotFmt.Parse(childNode, namespaceManager));
                 else if (childNode.LocalName == "extLst")
                     ctObj.extLst.Add(CT_Extension.Parse(childNode, namespaceManager));
             }
@@ -11326,6 +11306,8 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                 this.title.Write(sw, "title");
             if (this.autoTitleDeleted != null)
                 this.autoTitleDeleted.Write(sw, "autoTitleDeleted");
+            if (this.pivotFmts != null)
+                this.pivotFmts.Write(sw, "pivotFmts");
             if (this.view3D != null)
                 this.view3D.Write(sw, "view3D");
             if (this.floor != null)
@@ -11344,13 +11326,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                 this.dispBlanksAs.Write(sw, "dispBlanksAs");
             if (this.showDLblsOverMax != null)
                 this.showDLblsOverMax.Write(sw, "showDLblsOverMax");
-            if (this.pivotFmts != null)
-            {
-                foreach (CT_PivotFmt x in this.pivotFmts)
-                {
-                    x.Write(sw, "pivotFmts");
-                }
-            }
+            
             if (this.extLst != null)
             {
                 foreach (CT_Extension x in this.extLst)
@@ -11423,7 +11399,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         }
 
         [XmlElement(Order = 2)]
-        public List<CT_PivotFmt> pivotFmts
+        public CT_PivotFmts pivotFmts
         {
             get
             {
@@ -11742,7 +11718,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             sw.Write(string.Format("<c:{0}", nodeName));
             sw.Write(">");
             if (this.name != null)
-                sw.Write(string.Format("<name>{0}</name>", this.name));
+                sw.Write(string.Format("<c:name>{0}</c:name>", this.name));
             if (this.fmtId != null)
                 this.fmtId.Write(sw, "fmtId");
             if (this.extLst != null)
@@ -11819,8 +11795,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private byte valField;
@@ -11877,8 +11852,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
         {
             sw.Write(string.Format("<c:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "val", this.val);
-            sw.Write(">");
-            sw.Write(string.Format("</c:{0}>", nodeName));
+            sw.Write("/>");
         }
 
     }
@@ -11921,8 +11895,31 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
     [XmlRoot(Namespace = "http://schemas.openxmlformats.org/drawingml/2006/chart", IsNullable = true)]
     public class CT_Lvl
     {
-
         private List<CT_StrVal> ptField;
+
+        public static CT_Lvl Parse(XmlNode node, XmlNamespaceManager namespaceManager)
+        {
+            if (node == null)
+                return null;
+            CT_Lvl ctObj = new CT_Lvl();
+            ctObj.pt = new List<CT_StrVal>();
+            foreach (XmlNode childNode in node.ChildNodes)
+            {
+                if (childNode.LocalName == "pt")
+                    ctObj.pt.Add(CT_StrVal.Parse(childNode, namespaceManager));
+            }
+            return ctObj;
+        }
+
+        internal void Write(StreamWriter sw, string nodeName)
+        {
+            sw.Write(string.Format("<c:{0}>", nodeName));
+            foreach (CT_StrVal x in this.pt)
+            {
+                x.Write(sw, "pt");
+            }
+            sw.Write(string.Format("</c:{0}>", nodeName));
+        }
 
         public CT_Lvl()
         {
@@ -12011,8 +12008,36 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
     [XmlRoot(Namespace = "http://schemas.openxmlformats.org/drawingml/2006/chart", IsNullable = true)]
     public class CT_PivotFmts
     {
-
         private List<CT_PivotFmt> pivotFmtField;
+
+        public static CT_PivotFmts Parse(XmlNode node, XmlNamespaceManager namespaceManager)
+        {
+            if (node == null)
+                return null;
+            CT_PivotFmts ctObj = new CT_PivotFmts();
+            ctObj.pivotFmt = new List<CT_PivotFmt>();
+            foreach (XmlNode childNode in node.ChildNodes)
+            {
+                if (childNode.LocalName == "pivotFmt")
+                    ctObj.pivotFmt.Add(CT_PivotFmt.Parse(childNode, namespaceManager));
+            }
+            return ctObj;
+        }
+
+        internal void Write(StreamWriter sw, string nodeName)
+        {
+            if (this.pivotFmt.Count == 0)
+            {
+                return;
+            }
+
+            sw.Write(string.Format("<c:{0}>", nodeName));
+            foreach (CT_PivotFmt x in this.pivotFmt)
+            {
+                x.Write(sw, "pivotFmt");
+            }
+            sw.Write(string.Format("</c:{0}>", nodeName));
+        }
 
         public CT_PivotFmts()
         {

--- a/OpenXmlFormats/Drawing/SpreadsheetDrawing.cs
+++ b/OpenXmlFormats/Drawing/SpreadsheetDrawing.cs
@@ -1807,6 +1807,20 @@ namespace NPOI.OpenXmlFormats.Dml.Spreadsheet
             set { toField = value; }
         }
 
+        private Vml.Spreadsheet.CT_AlternateContent alternateContentField = null;
+
+        public Vml.Spreadsheet.CT_AlternateContent alternateContent
+        {
+            get
+            {
+                return alternateContentField;
+            }
+            set
+            {
+                this.alternateContentField = value;
+            }
+        }
+
         #region Choice - one of CT_Shape, CT_GroupShape, CT_GraphicalObjectFrame, CT_Connector or CT_Picture
 
         [XmlElement]
@@ -1863,6 +1877,10 @@ namespace NPOI.OpenXmlFormats.Dml.Spreadsheet
                 this.graphicalObjectField.Write(sw, "graphicFrame");
             else if (this.pictureField != null)
                 this.picture.Write(sw, "pic");
+            if (this.alternateContent != null)
+            {
+                this.alternateContent.Write(sw, "AlternateContent");
+            }
             if (this.clientData != null)
             {
                 this.clientData.Write(sw, "clientData");
@@ -1905,6 +1923,10 @@ namespace NPOI.OpenXmlFormats.Dml.Spreadsheet
                 else if (childNode.LocalName == "graphicFrame")
                 {
                     twoCellAnchor.graphicFrame = CT_GraphicalObjectFrame.Parse(childNode, namespaceManager);
+                }
+                else if (childNode.LocalName == "AlternateContent")
+                {
+                    twoCellAnchor.alternateContent = Vml.Spreadsheet.CT_AlternateContent.Parse(childNode, namespaceManager);
                 }
                 else if (childNode.LocalName == "clientData")
                 {

--- a/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotCacheDefinition.cs
+++ b/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotCacheDefinition.cs
@@ -213,14 +213,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         public CT_PivotCacheDefinition()
         {
             this.extLstField = new CT_ExtensionList();
-            this.mapsField = new CT_MeasureDimensionMaps();
-            this.measureGroupsField = new CT_MeasureGroups();
-            this.dimensionsField = new CT_Dimensions();
-            this.calculatedMembersField = new CT_CalculatedMembers();
-            this.calculatedItemsField = new CT_CalculatedItems();
-            this.tupleCacheField = new CT_TupleCache();
-            this.kpisField = new CT_PCDKPIs();
-            this.cacheHierarchiesField = new CT_CacheHierarchies();
+            //this.mapsField = new CT_MeasureDimensionMaps();
+            //this.measureGroupsField = new CT_MeasureGroups();
+            //this.dimensionsField = new CT_Dimensions();
+            //this.calculatedMembersField = new CT_CalculatedMembers();
+            //this.calculatedItemsField = new CT_CalculatedItems();
+            //this.tupleCacheField = new CT_TupleCache();
+            //this.kpisField = new CT_PCDKPIs();
+            //this.cacheHierarchiesField = new CT_CacheHierarchies();
             this.cacheFieldsField = new CT_CacheFields();
             this.cacheSourceField = new CT_CacheSource();
             this.invalidField = false;
@@ -264,7 +264,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
-        [XmlElement(Order = 2)]
+        [XmlElement(Order = 2, IsNullable = true)]
         public CT_CacheHierarchies cacheHierarchies
         {
             get
@@ -277,7 +277,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
-        [XmlElement(Order = 3)]
+        [XmlElement(Order = 3, IsNullable = true)]
         public CT_PCDKPIs kpis
         {
             get
@@ -290,7 +290,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
-        [XmlElement(Order = 4)]
+        [XmlElement(Order = 4, IsNullable = true)]
         public CT_TupleCache tupleCache
         {
             get
@@ -303,7 +303,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
-        [XmlElement(Order = 5)]
+        [XmlElement(Order = 5, IsNullable = true)]
         public CT_CalculatedItems calculatedItems
         {
             get
@@ -316,7 +316,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
-        [XmlElement(Order = 6)]
+        [XmlElement(Order = 6, IsNullable = true)]
         public CT_CalculatedMembers calculatedMembers
         {
             get
@@ -329,7 +329,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
-        [XmlElement(Order = 7)]
+        [XmlElement(Order = 7, IsNullable = true)]
         public CT_Dimensions dimensions
         {
             get
@@ -342,7 +342,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
-        [XmlElement(Order = 8)]
+        [XmlElement(Order = 8, IsNullable = true)]
         public CT_MeasureGroups measureGroups
         {
             get
@@ -355,7 +355,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
-        [XmlElement(Order = 9)]
+        [XmlElement(Order = 9, IsNullable = true)]
         public CT_MeasureDimensionMaps maps
         {
             get
@@ -736,15 +736,25 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.page != null)
+
+            if (this.page == null || this.page.Count == 0)
             {
-                foreach (CT_PCDSCPage x in this.page)
-                {
-                    x.Write(sw, "page");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+
+                if (this.page != null && this.page.Count > 0)
+                {
+                    foreach (CT_PCDSCPage x in this.page)
+                    {
+                        x.Write(sw, "page");
+                    }
+                }
+
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_PCDSCPage> pageField;
@@ -827,15 +837,25 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.pageItem != null)
+
+            if (this.pageItem == null || this.pageItem.Count == 0)
             {
-                foreach (CT_PageItem x in this.pageItem)
-                {
-                    x.Write(sw, "pageItem");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+
+                if (this.pageItem != null && this.pageItem.Count > 0)
+                {
+                    foreach (CT_PageItem x in this.pageItem)
+                    {
+                        x.Write(sw, "pageItem");
+                    }
+                }
+
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_PageItem> pageItemField;
@@ -911,8 +931,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "name", this.name);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private string nameField;
@@ -960,15 +979,25 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.rangeSet != null)
+
+            if (this.rangeSet == null || this.rangeSet.Count == 0)
             {
-                foreach (CT_RangeSet x in this.rangeSet)
-                {
-                    x.Write(sw, "rangeSet");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+
+                if (this.rangeSet != null && this.rangeSet.Count > 0)
+                {
+                    foreach (CT_RangeSet x in this.rangeSet)
+                    {
+                        x.Write(sw, "rangeSet");
+                    }
+                }
+
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_RangeSet> rangeSetField;
@@ -1062,8 +1091,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "name", this.name);
             XmlHelper.WriteAttribute(sw, "sheet", this.sheet);
             XmlHelper.WriteAttribute(sw, "r:id", this.id);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private uint i1Field;
@@ -1276,12 +1304,20 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "autoPage", this.autoPage);
-            sw.Write(">");
-            if (this.pages != null)
-                this.pages.Write(sw, "pages");
-            if (this.rangeSets != null)
-                this.rangeSets.Write(sw, "rangeSets");
-            sw.Write(string.Format("</{0}>", nodeName));
+
+            if (this.pages == null && this.rangeSets == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.pages != null)
+                    this.pages.Write(sw, "pages");
+                if (this.rangeSets != null)
+                    this.rangeSets.Write(sw, "rangeSets");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_Pages pagesField;
@@ -1366,8 +1402,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "name", this.name);
             XmlHelper.WriteAttribute(sw, "sheet", this.sheet);
             XmlHelper.WriteAttribute(sw, "r:id", this.id);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private string refField;
@@ -1486,17 +1521,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "type", this.type.ToString());
             XmlHelper.WriteAttribute(sw, "connectionId", this.connectionId);
-            sw.Write(">");
 
-            if (this.worksheetSource != null)
-                this.worksheetSource.Write(sw, "worksheetSource");
-            if (this.consolidation != null)
-                this.consolidation.Write(sw, "consolidation");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+            if (this.worksheetSource == null && this.consolidation == null && this.extLst == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.worksheetSource != null)
+                    this.worksheetSource.Write(sw, "worksheetSource");
+                if (this.consolidation != null)
+                    this.consolidation.Write(sw, "consolidation");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
-
 
         private object itemField;
 
@@ -1628,15 +1669,26 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.cacheField != null)
+
+            if (this.cacheField == null || this.cacheField.Count == 0)
             {
-                foreach (CT_CacheField x in this.cacheField)
-                {
-                    x.Write(sw, "cacheField");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+
+                if (this.cacheField != null && this.cacheField.Count > 0)
+                {
+
+                    foreach (CT_CacheField x in this.cacheField)
+                    {
+                        x.Write(sw, "cacheField");
+                    }
+                }
+
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_CacheField> cacheFieldField;
@@ -1785,39 +1837,53 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "containsSemiMixedTypes", this.containsSemiMixedTypes);
-            XmlHelper.WriteAttribute(sw, "containsNonDate", this.containsNonDate);
-            XmlHelper.WriteAttribute(sw, "containsDate", this.containsDate);
-            XmlHelper.WriteAttribute(sw, "containsString", this.containsString);
-            XmlHelper.WriteAttribute(sw, "containsBlank", this.containsBlank);
-            XmlHelper.WriteAttribute(sw, "containsMixedTypes", this.containsMixedTypes);
-            XmlHelper.WriteAttribute(sw, "containsNumber", this.containsNumber);
-            XmlHelper.WriteAttribute(sw, "containsInteger", this.containsInteger);
+            if (!this.containsSemiMixedTypes)
+                XmlHelper.WriteAttribute(sw, "containsSemiMixedTypes", this.containsSemiMixedTypes);
+            if (!this.containsNonDate)
+                XmlHelper.WriteAttribute(sw, "containsNonDate", this.containsNonDate);
+            XmlHelper.WriteAttribute(sw, "containsDate", this.containsDate, false);
+            if (!this.containsString)
+                XmlHelper.WriteAttribute(sw, "containsString", this.containsString);
+            XmlHelper.WriteAttribute(sw, "containsBlank", this.containsBlank, false);
+            XmlHelper.WriteAttribute(sw, "containsMixedTypes", this.containsMixedTypes, false);
+            XmlHelper.WriteAttribute(sw, "containsNumber", this.containsNumber, false);
+            XmlHelper.WriteAttribute(sw, "containsInteger", this.containsInteger, false);
             XmlHelper.WriteAttribute(sw, "minValue", this.minValue);
             XmlHelper.WriteAttribute(sw, "maxValue", this.maxValue);
             XmlHelper.WriteAttribute(sw, "minDate", this.minDate);
             XmlHelper.WriteAttribute(sw, "maxDate", this.maxDate);
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            XmlHelper.WriteAttribute(sw, "longText", this.longText);
-            sw.Write(">");
+            XmlHelper.WriteAttribute(sw, "longText", this.longText, false);
 
-            foreach (object o in this.Items)
+            if (this.Items == null || this.Items.Count == 0)
             {
-                if (o is CT_Number)
-                    ((CT_Number)o).Write(sw, "n");
-                else if (o is CT_Boolean)
-                    ((CT_Boolean)o).Write(sw, "b");
-                else if (o is CT_DateTime)
-                    ((CT_DateTime)o).Write(sw, "d");
-                else if (o is CT_Error)
-                    ((CT_Error)o).Write(sw, "e");
-                else if (o is CT_Missing)
-                    ((CT_Missing)o).Write(sw, "m");
-                else if (o is CT_String)
-                    ((CT_String)o).Write(sw, "s");
+                sw.Write("/>");
             }
+            else
+            {
+                sw.Write(">");
 
-            sw.Write(string.Format("</{0}>", nodeName));
+                if (this.Items != null && this.Items.Count > 0)
+                {
+                    foreach (object o in this.Items)
+                    {
+                        if (o is CT_Number)
+                            ((CT_Number)o).Write(sw, "n");
+                        else if (o is CT_Boolean)
+                            ((CT_Boolean)o).Write(sw, "b");
+                        else if (o is CT_DateTime)
+                            ((CT_DateTime)o).Write(sw, "d");
+                        else if (o is CT_Error)
+                            ((CT_Error)o).Write(sw, "e");
+                        else if (o is CT_Missing)
+                            ((CT_Missing)o).Write(sw, "m");
+                        else if (o is CT_String)
+                            ((CT_String)o).Write(sw, "s");
+                    }
+                }
+
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<object> itemsField;
@@ -2206,31 +2272,44 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "name", this.name);
             XmlHelper.WriteAttribute(sw, "caption", this.caption);
             XmlHelper.WriteAttribute(sw, "propertyName", this.propertyName);
-            XmlHelper.WriteAttribute(sw, "serverField", this.serverField);
-            XmlHelper.WriteAttribute(sw, "uniqueList", this.uniqueList);
-            XmlHelper.WriteAttribute(sw, "numFmtId", this.numFmtId);
+            XmlHelper.WriteAttribute(sw, "serverField", this.serverField, false);
+            if (!this.uniqueList)
+                XmlHelper.WriteAttribute(sw, "uniqueList", this.uniqueList);
+            XmlHelper.WriteAttribute(sw, "numFmtId", this.numFmtId, true);
             XmlHelper.WriteAttribute(sw, "formula", this.formula);
             XmlHelper.WriteAttribute(sw, "sqlType", this.sqlType);
             XmlHelper.WriteAttribute(sw, "hierarchy", this.hierarchy);
             XmlHelper.WriteAttribute(sw, "level", this.level);
-            XmlHelper.WriteAttribute(sw, "databaseField", this.databaseField);
+            if (!this.databaseField)
+                XmlHelper.WriteAttribute(sw, "databaseField", this.databaseField);
             XmlHelper.WriteAttribute(sw, "mappingCount", this.mappingCount);
-            XmlHelper.WriteAttribute(sw, "memberPropertyField", this.memberPropertyField);
-            sw.Write(">");
-            if (this.sharedItems != null)
-                this.sharedItems.Write(sw, "sharedItems");
-            if (this.fieldGroup != null)
-                this.fieldGroup.Write(sw, "fieldGroup");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            if (this.mpMap != null)
+            XmlHelper.WriteAttribute(sw, "memberPropertyField", this.memberPropertyField, false);
+
+            if (this.sharedItems == null
+                && this.fieldGroup == null
+                && this.extLst == null
+                && (this.mpMap == null || this.mpMap.Count == 0))
             {
-                foreach (CT_X x in this.mpMap)
-                {
-                    x.Write(sw, "mpMap");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.sharedItems != null)
+                    this.sharedItems.Write(sw, "sharedItems");
+                if (this.fieldGroup != null)
+                    this.fieldGroup.Write(sw, "fieldGroup");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                if (this.mpMap != null && this.mpMap.Count > 0)
+                {
+                    foreach (CT_X x in this.mpMap)
+                    {
+                        x.Write(sw, "mpMap");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_SharedItems sharedItemsField;
@@ -2273,10 +2352,10 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         public CT_CacheField()
         {
-            this.extLstField = new CT_ExtensionList();
+            //this.extLstField = new CT_ExtensionList();
             this.mpMapField = new List<CT_X>();
-            this.fieldGroupField = new CT_FieldGroup();
-            this.sharedItemsField = new CT_SharedItems();
+            //this.fieldGroupField = new CT_FieldGroup();
+            //this.sharedItemsField = new CT_SharedItems();
             this.serverFieldField = false;
             this.uniqueListField = true;
             this.sqlTypeField = 0;
@@ -2299,7 +2378,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
-        [XmlElement(Order = 1)]
+        [XmlElement(Order = 1, IsNullable = true)]
         public CT_FieldGroup fieldGroup
         {
             get
@@ -2325,7 +2404,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
-        [XmlElement(Order = 3)]
+        [XmlElement(Order = 3, IsNullable = true)]
         public CT_ExtensionList extLst
         {
             get
@@ -2576,15 +2655,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.cacheHierarchy != null)
+
+            if (this.cacheHierarchy == null || this.cacheHierarchy.Count == 0)
             {
-                foreach (CT_CacheHierarchy x in this.cacheHierarchy)
-                {
-                    x.Write(sw, "cacheHierarchy");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.cacheHierarchy != null && this.cacheHierarchy.Count > 0)
+                {
+                    foreach (CT_CacheHierarchy x in this.cacheHierarchy)
+                    {
+                        x.Write(sw, "cacheHierarchy");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_CacheHierarchy> cacheHierarchyField;
@@ -2673,20 +2760,28 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "v", this.v);
-            XmlHelper.WriteAttribute(sw, "u", this.u);
-            XmlHelper.WriteAttribute(sw, "f", this.f);
-            XmlHelper.WriteAttribute(sw, "c", this.c);
-            XmlHelper.WriteAttribute(sw, "cp", this.cp);
-            sw.Write(">");
-            if (this.x != null)
+            XmlHelper.WriteAttribute(sw, "v", this.v, true);
+            XmlHelper.WriteAttribute(sw, "u", this.u, false);
+            XmlHelper.WriteAttribute(sw, "f", this.f, false);
+            XmlHelper.WriteAttribute(sw, "c", this.c, false);
+            XmlHelper.WriteAttribute(sw, "cp", this.cp, false);
+
+            if (this.x == null || this.x.Count == 0)
             {
-                foreach (CT_X x in this.x)
-                {
-                    x.Write(sw, "x");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.x != null && this.x.Count > 0)
+                {
+                    foreach (CT_X x in this.x)
+                    {
+                        x.Write(sw, "x");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_X> xField;
@@ -2874,11 +2969,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "v", this.v);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            XmlHelper.WriteAttribute(sw, "v", this.v, true);
+            sw.Write("/>");
         }
-
     }
 
     
@@ -2917,19 +3010,27 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "v", this.v);
-            XmlHelper.WriteAttribute(sw, "u", this.u);
-            XmlHelper.WriteAttribute(sw, "f", this.f);
-            XmlHelper.WriteAttribute(sw, "c", this.c);
-            XmlHelper.WriteAttribute(sw, "cp", this.cp);
-            sw.Write(">");
-            if (this.x != null)
+            XmlHelper.WriteAttribute(sw, "u", this.u, false);
+            XmlHelper.WriteAttribute(sw, "f", this.f, false);
+            XmlHelper.WriteAttribute(sw, "c", this.c, false);
+            XmlHelper.WriteAttribute(sw, "cp", this.cp, false);
+
+            if (this.x == null || this.x.Count == 0)
             {
-                foreach (CT_X x in this.x)
-                {
-                    x.Write(sw, "x");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.x != null && this.x.Count > 0)
+                {
+                    foreach (CT_X x in this.x)
+                    {
+                        x.Write(sw, "x");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_X> xField;
@@ -3406,31 +3507,38 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "v", this.v);
-            XmlHelper.WriteAttribute(sw, "u", this.u);
-            XmlHelper.WriteAttribute(sw, "f", this.f);
-            XmlHelper.WriteAttribute(sw, "c", this.c);
-            XmlHelper.WriteAttribute(sw, "cp", this.cp);
-            XmlHelper.WriteAttribute(sw, "in", this.@in);
+            XmlHelper.WriteAttribute(sw, "v", this.v, true);
+            XmlHelper.WriteAttribute(sw, "u", this.u, false);
+            XmlHelper.WriteAttribute(sw, "f", this.f, false);
+            XmlHelper.WriteAttribute(sw, "c", this.c, false);
+            XmlHelper.WriteAttribute(sw, "cp", this.cp, false);
+            XmlHelper.WriteAttribute(sw, "in", this.@in, false);
             XmlHelper.WriteAttribute(sw, "bc", this.bc);
             XmlHelper.WriteAttribute(sw, "fc", this.fc);
-            XmlHelper.WriteAttribute(sw, "i", this.i);
-            XmlHelper.WriteAttribute(sw, "un", this.un);
-            XmlHelper.WriteAttribute(sw, "st", this.st);
-            XmlHelper.WriteAttribute(sw, "b", this.b);
-            sw.Write(">");
-            if (this.tpls != null)
-                this.tpls.Write(sw, "tpls");
-            if (this.x != null)
-            {
-                foreach (CT_X x in this.x)
-                {
-                    x.Write(sw, "x");
-                }
-            }
-            sw.Write(string.Format("</{0}>", nodeName));
-        }
+            XmlHelper.WriteAttribute(sw, "i", this.i, false);
+            XmlHelper.WriteAttribute(sw, "un", this.un, false);
+            XmlHelper.WriteAttribute(sw, "st", this.st, false);
+            XmlHelper.WriteAttribute(sw, "b", this.b, false);
 
+            if (this.tpls == null && (this.x == null || this.x.Count == 0))
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.tpls != null)
+                    this.tpls.Write(sw, "tpls");
+                if (this.x != null && this.x.Count > 0)
+                {
+                    foreach (CT_X x in this.x)
+                    {
+                        x.Write(sw, "x");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
+        }
     }
 
     
@@ -3513,15 +3621,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "c", this.c);
-            sw.Write(">");
-            if (this.tpl != null)
+
+            if (this.tpl == null || this.tpl.Count == 0)
             {
-                foreach (CT_Tuple x in this.tpl)
-                {
-                    x.Write(sw, "tpl");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.tpl != null && this.tpl.Count > 0)
+                {
+                    foreach (CT_Tuple x in this.tpl)
+                    {
+                        x.Write(sw, "tpl");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
     }
@@ -3631,8 +3747,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "fld", this.fld);
             XmlHelper.WriteAttribute(sw, "hier", this.hier);
             XmlHelper.WriteAttribute(sw, "item", this.item);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
     }
@@ -3955,33 +4070,41 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "u", this.u);
-            XmlHelper.WriteAttribute(sw, "f", this.f);
-            XmlHelper.WriteAttribute(sw, "c", this.c);
-            XmlHelper.WriteAttribute(sw, "cp", this.cp);
-            XmlHelper.WriteAttribute(sw, "in", this.@in);
+            XmlHelper.WriteAttribute(sw, "u", this.u, false);
+            XmlHelper.WriteAttribute(sw, "f", this.f, false);
+            XmlHelper.WriteAttribute(sw, "c", this.c, false);
+            XmlHelper.WriteAttribute(sw, "cp", this.cp, false);
+            XmlHelper.WriteAttribute(sw, "in", this.@in, false);
             XmlHelper.WriteAttribute(sw, "bc", this.bc);
             XmlHelper.WriteAttribute(sw, "fc", this.fc);
-            XmlHelper.WriteAttribute(sw, "i", this.i);
-            XmlHelper.WriteAttribute(sw, "un", this.un);
-            XmlHelper.WriteAttribute(sw, "st", this.st);
-            XmlHelper.WriteAttribute(sw, "b", this.b);
-            sw.Write(">");
-            if (this.tpls != null)
+            XmlHelper.WriteAttribute(sw, "i", this.i, false);
+            XmlHelper.WriteAttribute(sw, "un", this.un, false);
+            XmlHelper.WriteAttribute(sw, "st", this.st, false);
+            XmlHelper.WriteAttribute(sw, "b", this.b, false);
+
+            if ((this.tpls == null || this.tpls.Count == 0) && (this.x == null || this.x.Count == 0))
             {
-                foreach (CT_Tuples x in this.tpls)
-                {
-                    x.Write(sw, "tpls");
-                }
+                sw.Write("/>");
             }
-            if (this.x != null)
+            else
             {
-                foreach (CT_X x in this.x)
+                sw.Write(">");
+                if (this.tpls != null && this.tpls.Count > 0)
                 {
-                    x.Write(sw, "x");
+                    foreach (CT_Tuples x in this.tpls)
+                    {
+                        x.Write(sw, "tpls");
+                    }
                 }
+                if (this.x != null && this.x.Count > 0)
+                {
+                    foreach (CT_X x in this.x)
+                    {
+                        x.Write(sw, "x");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
             }
-            sw.Write(string.Format("</{0}>", nodeName));
         }
 
     }
@@ -4316,46 +4439,48 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             return ctObj;
         }
 
-
-
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "v", this.v);
-            XmlHelper.WriteAttribute(sw, "u", this.u);
-            XmlHelper.WriteAttribute(sw, "f", this.f);
-            XmlHelper.WriteAttribute(sw, "c", this.c);
-            XmlHelper.WriteAttribute(sw, "cp", this.cp);
-            XmlHelper.WriteAttribute(sw, "in", this.@in);
+            XmlHelper.WriteAttribute(sw, "u", this.u, false);
+            XmlHelper.WriteAttribute(sw, "f", this.f, false);
+            XmlHelper.WriteAttribute(sw, "c", this.c, false);
+            XmlHelper.WriteAttribute(sw, "cp", this.cp, false);
+            XmlHelper.WriteAttribute(sw, "in", this.@in, false);
             XmlHelper.WriteAttribute(sw, "bc", this.bc);
             XmlHelper.WriteAttribute(sw, "fc", this.fc);
-            XmlHelper.WriteAttribute(sw, "i", this.i);
-            XmlHelper.WriteAttribute(sw, "un", this.un);
-            XmlHelper.WriteAttribute(sw, "st", this.st);
-            XmlHelper.WriteAttribute(sw, "b", this.b);
-            sw.Write(">");
-            if (this.tpls != null)
-            {
-                foreach (CT_Tuples x in this.tpls)
-                {
-                    x.Write(sw, "tpls");
-                }
-            }
-            if (this.x != null)
-            {
-                foreach (CT_X x in this.x)
-                {
-                    x.Write(sw, "x");
-                }
-            }
-            sw.Write(string.Format("</{0}>", nodeName));
-        }
+            XmlHelper.WriteAttribute(sw, "i", this.i, false);
+            XmlHelper.WriteAttribute(sw, "un", this.un, false);
+            XmlHelper.WriteAttribute(sw, "st", this.st, false);
+            XmlHelper.WriteAttribute(sw, "b", this.b, false);
 
+            if ((this.tpls == null || this.tpls.Count == 0) && (this.x == null || this.x.Count == 0))
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.tpls != null && this.tpls.Count > 0)
+                {
+                    foreach (CT_Tuples x in this.tpls)
+                    {
+                        x.Write(sw, "tpls");
+                    }
+                }
+                if (this.x != null && this.x.Count > 0)
+                {
+                    foreach (CT_X x in this.x)
+                    {
+                        x.Write(sw, "x");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
+        }
     }
 
-    
-    
-    
     [XmlType(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main")]
     [XmlRoot(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main", IsNullable = true)]
     public partial class CT_String
@@ -4688,33 +4813,41 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "v", this.v);
-            XmlHelper.WriteAttribute(sw, "u", this.u);
-            XmlHelper.WriteAttribute(sw, "f", this.f);
-            XmlHelper.WriteAttribute(sw, "c", this.c);
-            XmlHelper.WriteAttribute(sw, "cp", this.cp);
-            XmlHelper.WriteAttribute(sw, "in", this.@in);
+            XmlHelper.WriteAttribute(sw, "u", this.u, false);
+            XmlHelper.WriteAttribute(sw, "f", this.f, false);
+            XmlHelper.WriteAttribute(sw, "c", this.c, false);
+            XmlHelper.WriteAttribute(sw, "cp", this.cp, false);
+            XmlHelper.WriteAttribute(sw, "in", this.@in, false);
             XmlHelper.WriteAttribute(sw, "bc", this.bc);
             XmlHelper.WriteAttribute(sw, "fc", this.fc);
-            XmlHelper.WriteAttribute(sw, "i", this.i);
-            XmlHelper.WriteAttribute(sw, "un", this.un);
-            XmlHelper.WriteAttribute(sw, "st", this.st);
-            XmlHelper.WriteAttribute(sw, "b", this.b);
-            sw.Write(">");
-            if (this.tpls != null)
+            XmlHelper.WriteAttribute(sw, "i", this.i, false);
+            XmlHelper.WriteAttribute(sw, "un", this.un, false);
+            XmlHelper.WriteAttribute(sw, "st", this.st, false);
+            XmlHelper.WriteAttribute(sw, "b", this.b, false);
+
+            if ((this.tpls == null || this.tpls.Count == 0) && (this.x == null || this.x.Count == 0))
             {
-                foreach (CT_Tuples x in this.tpls)
-                {
-                    x.Write(sw, "tpls");
-                }
+                sw.Write("/>");
             }
-            if (this.x != null)
+            else
             {
-                foreach (CT_X x in this.x)
+                sw.Write(">");
+                if (this.tpls != null && this.tpls.Count > 0)
                 {
-                    x.Write(sw, "x");
+                    foreach (CT_Tuples x in this.tpls)
+                    {
+                        x.Write(sw, "tpls");
+                    }
                 }
+                if (this.x != null && this.x.Count > 0)
+                {
+                    foreach (CT_X x in this.x)
+                    {
+                        x.Write(sw, "x");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
             }
-            sw.Write(string.Format("</{0}>", nodeName));
         }
 
     }
@@ -4754,14 +4887,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "par", this.par);
             XmlHelper.WriteAttribute(sw, "base", this.@base);
-            sw.Write(">");
-            if (this.rangePr != null)
-                this.rangePr.Write(sw, "rangePr");
-            if (this.discretePr != null)
-                this.discretePr.Write(sw, "discretePr");
-            if (this.groupItems != null)
-                this.groupItems.Write(sw, "groupItems");
-            sw.Write(string.Format("</{0}>", nodeName));
+
+            if (this.rangePr == null && this.discretePr == null && this.groupItems == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.rangePr != null)
+                    this.rangePr.Write(sw, "rangePr");
+                if (this.discretePr != null)
+                    this.discretePr.Write(sw, "discretePr");
+                if (this.groupItems != null)
+                    this.groupItems.Write(sw, "groupItems");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_RangePr rangePrField;
@@ -4921,8 +5062,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "startDate", this.startDate);
             XmlHelper.WriteAttribute(sw, "endDate", this.endDate);
             XmlHelper.WriteAttribute(sw, "groupInterval", this.groupInterval);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private bool autoStartField;
@@ -5179,15 +5319,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.x != null)
+
+            if (this.x == null || this.x.Count == 0)
             {
-                foreach (CT_Index x in this.x)
-                {
-                    x.Write(sw, "x");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.x != null && this.x.Count > 0)
+                {
+                    foreach (CT_Index x in this.x)
+                    {
+                        x.Write(sw, "x");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_Index> xField;
@@ -5292,23 +5440,30 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            sw.Write(">");
-            foreach (object o in this.Items)
+            if (this.Items == null || this.Items.Count == 0)
             {
-                if (o is CT_Error)
-                    ((CT_Error)o).Write(sw, "e");
-                else if (o is CT_Boolean)
-                    ((CT_Boolean)o).Write(sw, "b");
-                else if (o is CT_DateTime)
-                    ((CT_DateTime)o).Write(sw, "d");
-                else if (o is CT_Number)
-                    ((CT_Number)o).Write(sw, "n");
-                else if (o is CT_Missing)
-                    ((CT_Missing)o).Write(sw, "m");
-                else if (o is CT_String)
-                    ((CT_String)o).Write(sw, "s");
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                foreach (object o in this.Items)
+                {
+                    if (o is CT_Error)
+                        ((CT_Error)o).Write(sw, "e");
+                    else if (o is CT_Boolean)
+                        ((CT_Boolean)o).Write(sw, "b");
+                    else if (o is CT_DateTime)
+                        ((CT_DateTime)o).Write(sw, "d");
+                    else if (o is CT_Number)
+                        ((CT_Number)o).Write(sw, "n");
+                    else if (o is CT_Missing)
+                        ((CT_Missing)o).Write(sw, "m");
+                    else if (o is CT_String)
+                        ((CT_String)o).Write(sw, "s");
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<object> itemsField;
@@ -5396,15 +5551,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.fieldUsage != null)
+
+            if (this.fieldUsage == null || this.fieldUsage.Count == 0)
             {
-                foreach (CT_FieldUsage x in this.fieldUsage)
-                {
-                    x.Write(sw, "fieldUsage");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.fieldUsage != null && this.fieldUsage.Count > 0)
+                {
+                    foreach (CT_FieldUsage x in this.fieldUsage)
+                    {
+                        x.Write(sw, "fieldUsage");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_FieldUsage> fieldUsageField;
@@ -5480,9 +5643,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "x", this.x);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            XmlHelper.WriteAttribute(sw, "x", this.x, true);
+            sw.Write("/>");
         }
 
         private int xField;
@@ -5530,15 +5692,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.groupLevel != null)
+
+            if (this.groupLevel == null || this.groupLevel.Count == 0)
             {
-                foreach (CT_GroupLevel x in this.groupLevel)
-                {
-                    x.Write(sw, "groupLevel");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.groupLevel != null && this.groupLevel.Count > 0)
+                {
+                    foreach (CT_GroupLevel x in this.groupLevel)
+                    {
+                        x.Write(sw, "groupLevel");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_GroupLevel> groupLevelField;
@@ -5629,12 +5799,20 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "caption", this.caption);
             XmlHelper.WriteAttribute(sw, "user", this.user);
             XmlHelper.WriteAttribute(sw, "customRollUp", this.customRollUp);
-            sw.Write(">");
-            if (this.groups != null)
-                this.groups.Write(sw, "groups");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+
+            if (this.groups == null && this.extLst == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.groups != null)
+                    this.groups.Write(sw, "groups");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_Groups groupsField;
@@ -5767,15 +5945,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.group != null)
+
+            if (this.group == null || this.group.Count == 0)
             {
-                foreach (CT_LevelGroup x in this.group)
-                {
-                    x.Write(sw, "group");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.group != null && this.group.Count > 0)
+                {
+                    foreach (CT_LevelGroup x in this.group)
+                    {
+                        x.Write(sw, "group");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_LevelGroup> groupField;
@@ -5865,10 +6051,18 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "caption", this.caption);
             XmlHelper.WriteAttribute(sw, "uniqueParent", this.uniqueParent);
             XmlHelper.WriteAttribute(sw, "id", this.id);
-            sw.Write(">");
-            if (this.groupMembers != null)
-                this.groupMembers.Write(sw, "groupMembers");
-            sw.Write(string.Format("</{0}>", nodeName));
+
+            if (this.groupMembers == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.groupMembers != null)
+                    this.groupMembers.Write(sw, "groupMembers");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_GroupMembers groupMembersField;
@@ -6011,15 +6205,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.groupMember != null)
+
+            if (this.groupMember == null || this.groupMember.Count == 0)
             {
-                foreach (CT_GroupMember x in this.groupMember)
-                {
-                    x.Write(sw, "groupMember");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.groupMember != null && this.groupMember.Count > 0)
+                {
+                    foreach (CT_GroupMember x in this.groupMember)
+                    {
+                        x.Write(sw, "groupMember");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_GroupMember> groupMemberField;
@@ -6098,8 +6300,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "uniqueName", this.uniqueName);
             XmlHelper.WriteAttribute(sw, "group", this.group);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private string uniqueNameField;
@@ -6205,7 +6406,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "uniqueName", this.uniqueName);
+            XmlHelper.WriteAttribute(sw, "uniqueName", this.uniqueName, true);
             XmlHelper.WriteAttribute(sw, "caption", this.caption);
             XmlHelper.WriteAttribute(sw, "measure", this.measure);
             XmlHelper.WriteAttribute(sw, "set", this.set);
@@ -6221,20 +6422,28 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "displayFolder", this.displayFolder);
             XmlHelper.WriteAttribute(sw, "measureGroup", this.measureGroup);
             XmlHelper.WriteAttribute(sw, "measures", this.measures);
-            XmlHelper.WriteAttribute(sw, "count", this.count);
+            XmlHelper.WriteAttribute(sw, "count", this.count, true);
             XmlHelper.WriteAttribute(sw, "oneField", this.oneField);
             XmlHelper.WriteAttribute(sw, "memberValueDatatype", this.memberValueDatatype);
             XmlHelper.WriteAttribute(sw, "unbalanced", this.unbalanced);
             XmlHelper.WriteAttribute(sw, "unbalancedGroup", this.unbalancedGroup);
             XmlHelper.WriteAttribute(sw, "hidden", this.hidden);
-            sw.Write(">");
-            if (this.fieldsUsage != null)
-                this.fieldsUsage.Write(sw, "fieldsUsage");
-            if (this.groupLevels != null)
-                this.groupLevels.Write(sw, "groupLevels");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+
+            if (this.fieldsUsage == null && this.groupLevels == null && this.extLst == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.fieldsUsage != null)
+                    this.fieldsUsage.Write(sw, "fieldsUsage");
+                if (this.groupLevels != null)
+                    this.groupLevels.Write(sw, "groupLevels");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_FieldsUsage fieldsUsageField;
@@ -6297,9 +6506,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         public CT_CacheHierarchy()
         {
-            this.extLstField = new CT_ExtensionList();
-            this.groupLevelsField = new CT_GroupLevels();
-            this.fieldsUsageField = new CT_FieldsUsage();
+            //this.extLstField = new CT_ExtensionList();
+            //this.groupLevelsField = new CT_GroupLevels();
+            //this.fieldsUsageField = new CT_FieldsUsage();
             this.measureField = false;
             this.setField = false;
             this.iconSetField = 0;
@@ -6727,15 +6936,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.kpi != null)
+            if (this.kpi == null || this.kpi.Count == 0)
             {
-                foreach (CT_PCDKPI x in this.kpi)
-                {
-                    x.Write(sw, "kpi");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.kpi != null && this.kpi.Count > 0)
+                {
+                    foreach (CT_PCDKPI x in this.kpi)
+                    {
+                        x.Write(sw, "kpi");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_PCDKPI> kpiField;
@@ -6831,8 +7047,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "trend", this.trend);
             XmlHelper.WriteAttribute(sw, "weight", this.weight);
             XmlHelper.WriteAttribute(sw, "time", this.time);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private string uniqueNameField;
@@ -7034,18 +7249,29 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            sw.Write(">");
-            if (this.entries != null)
-                this.entries.Write(sw, "entries");
-            if (this.sets != null)
-                this.sets.Write(sw, "sets");
-            if (this.queryCache != null)
-                this.queryCache.Write(sw, "queryCache");
-            if (this.serverFormats != null)
-                this.serverFormats.Write(sw, "serverFormats");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+            if (this.entries == null
+                && this.sets == null
+                && this.queryCache == null
+                && this.serverFormats == null
+                && this.extLst == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.entries != null)
+                    this.entries.Write(sw, "entries");
+                if (this.sets != null)
+                    this.sets.Write(sw, "sets");
+                if (this.queryCache != null)
+                    this.queryCache.Write(sw, "queryCache");
+                if (this.serverFormats != null)
+                    this.serverFormats.Write(sw, "serverFormats");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_PCDSDTCEntries entriesField;
@@ -7174,19 +7400,26 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            sw.Write(">");
-            foreach (object o in this.Items)
+            if (this.Items == null || this.Items.Count == 0)
             {
-                if (o is CT_Missing)
-                    ((CT_Missing)o).Write(sw, "m");
-                else if (o is CT_Number)
-                    ((CT_Number)o).Write(sw, "n");
-                else if (o is CT_Error)
-                    ((CT_Error)o).Write(sw, "e");
-                else if (o is CT_String)
-                    ((CT_String)o).Write(sw, "s");
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                foreach (object o in this.Items)
+                {
+                    if (o is CT_Missing)
+                        ((CT_Missing)o).Write(sw, "m");
+                    else if (o is CT_Number)
+                        ((CT_Number)o).Write(sw, "n");
+                    else if (o is CT_Error)
+                        ((CT_Error)o).Write(sw, "e");
+                    else if (o is CT_String)
+                        ((CT_String)o).Write(sw, "s");
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<object> itemsField;
@@ -7272,15 +7505,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.set != null)
+
+            if (this.set == null || this.set.Count == 0)
             {
-                foreach (CT_Set x in this.set)
-                {
-                    x.Write(sw, "set");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.set != null && this.set.Count > 0)
+                {
+                    foreach (CT_Set x in this.set)
+                    {
+                        x.Write(sw, "set");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_Set> setField;
@@ -7376,17 +7617,25 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "setDefinition", this.setDefinition);
             XmlHelper.WriteAttribute(sw, "sortType", this.sortType.ToString());
             XmlHelper.WriteAttribute(sw, "queryFailed", this.queryFailed);
-            sw.Write(">");
-            if (this.sortByTuple != null)
-                this.sortByTuple.Write(sw, "sortByTuple");
-            if (this.tpls != null)
+
+            if (this.sortByTuple == null && (this.tpls == null || this.tpls.Count == 0))
             {
-                foreach (CT_Tuples x in this.tpls)
-                {
-                    x.Write(sw, "tpls");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.sortByTuple != null)
+                    this.sortByTuple.Write(sw, "sortByTuple");
+                if (this.tpls != null && this.tpls.Count > 0)
+                {
+                    foreach (CT_Tuples x in this.tpls)
+                    {
+                        x.Write(sw, "tpls");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_Tuples> tplsField;
@@ -7578,15 +7827,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.query != null)
+            if (this.query == null || this.query.Count == 0)
             {
-                foreach (CT_Query x in this.query)
-                {
-                    x.Write(sw, "query");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.query != null && this.query.Count > 0)
+                {
+                    foreach (CT_Query x in this.query)
+                    {
+                        x.Write(sw, "query");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_Query> queryField;
@@ -7667,10 +7923,17 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "mdx", this.mdx);
-            sw.Write(">");
-            if (this.tpls != null)
-                this.tpls.Write(sw, "tpls");
-            sw.Write(string.Format("</{0}>", nodeName));
+            if (this.tpls == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.tpls != null)
+                    this.tpls.Write(sw, "tpls");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_Tuples tplsField;
@@ -7738,15 +8001,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.serverFormat != null)
+
+            if (this.serverFormat == null || this.serverFormat.Count == 0)
             {
-                foreach (CT_ServerFormat x in this.serverFormat)
-                {
-                    x.Write(sw, "serverFormat");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.serverFormat != null && this.serverFormat.Count > 0)
+                {
+                    foreach (CT_ServerFormat x in this.serverFormat)
+                    {
+                        x.Write(sw, "serverFormat");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_ServerFormat> serverFormatField;
@@ -7824,8 +8095,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "culture", this.culture);
             XmlHelper.WriteAttribute(sw, "format", this.format);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private string cultureField;
@@ -7888,15 +8158,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.calculatedItem != null)
+            if (this.calculatedItem == null || this.calculatedItem.Count == 0)
             {
-                foreach (CT_CalculatedItem x in this.calculatedItem)
-                {
-                    x.Write(sw, "calculatedItem");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.calculatedItem != null && this.calculatedItem.Count > 0)
+                {
+                    foreach (CT_CalculatedItem x in this.calculatedItem)
+                    {
+                        x.Write(sw, "calculatedItem");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_CalculatedItem> calculatedItemField;
@@ -7982,12 +8259,19 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "field", this.field);
             XmlHelper.WriteAttribute(sw, "formula", this.formula);
-            sw.Write(">");
-            if (this.pivotArea != null)
-                this.pivotArea.Write(sw, "pivotArea");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+            if (this.pivotArea == null && this.extLst == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.pivotArea != null)
+                    this.pivotArea.Write(sw, "pivotArea");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_PivotArea pivotAreaField;
@@ -8101,15 +8385,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.calculatedMember != null)
+
+            if (this.calculatedMember == null || this.calculatedMember.Count == 0)
             {
-                foreach (CT_CalculatedMember x in this.calculatedMember)
-                {
-                    x.Write(sw, "calculatedMember");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.calculatedMember != null && this.calculatedMember.Count > 0)
+                {
+                    foreach (CT_CalculatedMember x in this.calculatedMember)
+                    {
+                        x.Write(sw, "calculatedMember");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_CalculatedMember> calculatedMemberField;
@@ -8204,10 +8496,18 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "parent", this.parent);
             XmlHelper.WriteAttribute(sw, "solveOrder", this.solveOrder);
             XmlHelper.WriteAttribute(sw, "set", this.set);
-            sw.Write(">");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+            
+            if (this.extLst == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_ExtensionList extLstField;
@@ -8369,15 +8669,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.dimension != null)
+            if (this.dimension == null || this.dimension.Count == 0)
             {
-                foreach (CT_PivotDimension x in this.dimension)
-                {
-                    x.Write(sw, "dimension");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.dimension != null && this.dimension.Count > 0)
+                {
+                    foreach (CT_PivotDimension x in this.dimension)
+                    {
+                        x.Write(sw, "dimension");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_PivotDimension> dimensionField;
@@ -8460,8 +8767,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "name", this.name);
             XmlHelper.WriteAttribute(sw, "uniqueName", this.uniqueName);
             XmlHelper.WriteAttribute(sw, "caption", this.caption);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private bool measureField;
@@ -8560,15 +8866,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.measureGroup != null)
+            if (this.measureGroup == null || this.measureGroup.Count == 0)
             {
-                foreach (CT_MeasureGroup x in this.measureGroup)
-                {
-                    x.Write(sw, "measureGroup");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.measureGroup != null && this.measureGroup.Count > 0)
+                {
+                    foreach (CT_MeasureGroup x in this.measureGroup)
+                    {
+                        x.Write(sw, "measureGroup");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_MeasureGroup> measureGroupField;
@@ -8646,8 +8959,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "name", this.name);
             XmlHelper.WriteAttribute(sw, "caption", this.caption);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private string nameField;
@@ -8710,15 +9022,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.map != null)
+
+            if (this.map == null || this.map.Count == 0)
             {
-                foreach (CT_MeasureDimensionMap x in this.map)
-                {
-                    x.Write(sw, "map");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.map != null && this.map.Count > 0)
+                {
+                    foreach (CT_MeasureDimensionMap x in this.map)
+                    {
+                        x.Write(sw, "map");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_MeasureDimensionMap> mapField;

--- a/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotCacheRecords.cs
+++ b/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotCacheRecords.cs
@@ -19,44 +19,20 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             CT_PivotCacheRecords ctObj = new CT_PivotCacheRecords();
             if (node.Attributes["count"] != null)
                 ctObj.count = XmlHelper.ReadUInt(node.Attributes["count"]);
-            ctObj.r = new List<Object>();
+            ctObj.r = new List<CT_PivotCacheRecord>();
             foreach (XmlNode childNode in node.ChildNodes)
             {
                 if (childNode.LocalName == "extLst")
+                {
                     ctObj.extLst = CT_ExtensionList.Parse(childNode, namespaceManager);
-                else if (childNode.LocalName == "n")
-                {
-                    ctObj.r.Add(CT_Number.Parse(childNode, namespaceManager));
                 }
-                else if (childNode.LocalName == "b")
+                else if (childNode.LocalName == "r")
                 {
-                    ctObj.r.Add(CT_Boolean.Parse(childNode, namespaceManager));
-                }
-                else if (childNode.LocalName == "d")
-                {
-                    ctObj.r.Add(CT_DateTime.Parse(childNode, namespaceManager));
-                }
-                else if (childNode.LocalName == "e")
-                {
-                    ctObj.r.Add(CT_Error.Parse(childNode, namespaceManager));
-                }
-                else if (childNode.LocalName == "m")
-                {
-                    ctObj.r.Add(CT_Missing.Parse(childNode, namespaceManager));
-                }
-                else if (childNode.LocalName == "s")
-                {
-                    ctObj.r.Add(CT_String.Parse(childNode, namespaceManager));
-                }
-                else if (childNode.LocalName == "x")
-                {
-                    ctObj.r.Add(CT_Index.Parse(childNode, namespaceManager));
+                    ctObj.rField.Add(CT_PivotCacheRecord.Parse(childNode, namespaceManager));
                 }
             }
             return ctObj;
         }
-
-
 
         internal void Write(StreamWriter sw)
         {
@@ -68,24 +44,11 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(">");
             if (this.extLst != null)
                 this.extLst.Write(sw, "extLst");
-            foreach (object o in this.r)
+            foreach (CT_PivotCacheRecord o in this.r)
             {
-                if (o is CT_Number)
-                    ((CT_Number)o).Write(sw, "n");
-                else if (o is CT_Boolean)
-                    ((CT_Boolean)o).Write(sw, "b");
-                else if (o is CT_DateTime)
-                    ((CT_DateTime)o).Write(sw, "d");
-                else if (o is CT_Error)
-                    ((CT_Error)o).Write(sw, "e");
-                else if (o is CT_Missing)
-                    ((CT_Missing)o).Write(sw, "m");
-                else if (o is CT_String)
-                    ((CT_String)o).Write(sw, "s");
-                else if (o is CT_Index)
-                    ((CT_Index)o).Write(sw, "x");
+                o.Write(sw);
             }
-            sw.Write(string.Format("</pivotCacheRecords>"));
+            sw.Write("</pivotCacheRecords>");
         }
 
         public void Save(Stream stream)
@@ -96,7 +59,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 this.Write(sw);
             }
         }
-        private List<object> rField;
+
+        private List<CT_PivotCacheRecord> rField;
 
         private CT_ExtensionList extLstField;
 
@@ -104,21 +68,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         private bool countFieldSpecified;
 
-        public CT_PivotCacheRecords()
-        {
-            this.extLstField = new CT_ExtensionList();
-            this.rField = new List<object>();
-        }
-
         [System.Xml.Serialization.XmlArrayAttribute(Order = 0)]
-        [System.Xml.Serialization.XmlArrayItemAttribute("b", typeof(CT_Boolean), IsNullable = false)]
-        [System.Xml.Serialization.XmlArrayItemAttribute("d", typeof(CT_DateTime), IsNullable = false)]
-        [System.Xml.Serialization.XmlArrayItemAttribute("e", typeof(CT_Error), IsNullable = false)]
-        [System.Xml.Serialization.XmlArrayItemAttribute("m", typeof(CT_Missing), IsNullable = false)]
-        [System.Xml.Serialization.XmlArrayItemAttribute("n", typeof(CT_Number), IsNullable = false)]
-        [System.Xml.Serialization.XmlArrayItemAttribute("s", typeof(CT_String), IsNullable = false)]
-        [System.Xml.Serialization.XmlArrayItemAttribute("x", typeof(CT_Index), IsNullable = false)]
-        public List<object> r
+        public List<CT_PivotCacheRecord> r
         {
             get
             {
@@ -169,5 +120,98 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
     }
-    
+
+    [XmlType(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main")]
+    [XmlRoot(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main", IsNullable = true)]
+    public partial class CT_PivotCacheRecord
+    {
+        private List<object> items;
+
+        public static CT_PivotCacheRecord Parse(XmlNode node, XmlNamespaceManager namespaceManager)
+        {
+            CT_PivotCacheRecord ctObj = new CT_PivotCacheRecord();
+            ctObj.fields = new List<object>();
+
+            foreach (XmlNode childNode in node.ChildNodes)
+            {
+                if (childNode.LocalName == "n")
+                {
+                    ctObj.fields.Add(CT_Number.Parse(childNode, namespaceManager));
+                }
+                else if (childNode.LocalName == "b")
+                {
+                    ctObj.fields.Add(CT_Boolean.Parse(childNode, namespaceManager));
+                }
+                else if (childNode.LocalName == "d")
+                {
+                    ctObj.fields.Add(CT_DateTime.Parse(childNode, namespaceManager));
+                }
+                else if (childNode.LocalName == "e")
+                {
+                    ctObj.fields.Add(CT_Error.Parse(childNode, namespaceManager));
+                }
+                else if (childNode.LocalName == "m")
+                {
+                    ctObj.fields.Add(CT_Missing.Parse(childNode, namespaceManager));
+                }
+                else if (childNode.LocalName == "s")
+                {
+                    ctObj.fields.Add(CT_String.Parse(childNode, namespaceManager));
+                }
+                else if (childNode.LocalName == "x")
+                {
+                    ctObj.fields.Add(CT_Index.Parse(childNode, namespaceManager));
+                }
+            }
+
+            return ctObj;
+        }
+
+        [System.Xml.Serialization.XmlArrayItemAttribute("b", typeof(CT_Boolean), IsNullable = false)]
+        [System.Xml.Serialization.XmlArrayItemAttribute("d", typeof(CT_DateTime), IsNullable = false)]
+        [System.Xml.Serialization.XmlArrayItemAttribute("e", typeof(CT_Error), IsNullable = false)]
+        [System.Xml.Serialization.XmlArrayItemAttribute("m", typeof(CT_Missing), IsNullable = false)]
+        [System.Xml.Serialization.XmlArrayItemAttribute("n", typeof(CT_Number), IsNullable = false)]
+        [System.Xml.Serialization.XmlArrayItemAttribute("s", typeof(CT_String), IsNullable = false)]
+        [System.Xml.Serialization.XmlArrayItemAttribute("x", typeof(CT_Index), IsNullable = false)]
+        public List<object> fields
+        {
+            get
+            {
+                return this.items;
+            }
+            set
+            {
+                this.items = value;
+            }
+        }
+
+        internal void Write(StreamWriter sw)
+        {
+            if (this.fields != null && fields.Count > 0)
+            {
+                sw.Write("<r>");
+
+                foreach (object o in this.fields)
+                {
+                    if (o is CT_Number)
+                        ((CT_Number)o).Write(sw, "n");
+                    else if (o is CT_Boolean)
+                        ((CT_Boolean)o).Write(sw, "b");
+                    else if (o is CT_DateTime)
+                        ((CT_DateTime)o).Write(sw, "d");
+                    else if (o is CT_Error)
+                        ((CT_Error)o).Write(sw, "e");
+                    else if (o is CT_Missing)
+                        ((CT_Missing)o).Write(sw, "m");
+                    else if (o is CT_String)
+                        ((CT_String)o).Write(sw, "s");
+                    else if (o is CT_Index)
+                        ((CT_Index)o).Write(sw, "x");
+                }
+
+                sw.Write("</r>");
+            }
+        }
+    }
 }

--- a/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotCacheRecords.cs
+++ b/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotCacheRecords.cs
@@ -44,9 +44,12 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(">");
             if (this.extLst != null)
                 this.extLst.Write(sw, "extLst");
-            foreach (CT_PivotCacheRecord o in this.r)
+            if (this.r != null && this.r.Count > 0)
             {
-                o.Write(sw);
+                foreach (CT_PivotCacheRecord o in this.r)
+                {
+                    o.Write(sw);
+                }
             }
             sw.Write("</pivotCacheRecords>");
         }

--- a/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotTableDefinition.cs
+++ b/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotTableDefinition.cs
@@ -296,7 +296,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 this.colHierarchiesUsage.Write(sw, "colHierarchiesUsage");
             if (this.extLst != null)
                 this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</pivotTableDefinition>"));
+            sw.Write("</pivotTableDefinition>");
         }
         public void Save(Stream stream)
         {
@@ -1892,14 +1892,13 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "ref", this.@ref);
-            XmlHelper.WriteAttribute(sw, "firstHeaderRow", this.firstHeaderRow);
-            XmlHelper.WriteAttribute(sw, "firstDataRow", this.firstDataRow);
-            XmlHelper.WriteAttribute(sw, "firstDataCol", this.firstDataCol);
+            XmlHelper.WriteAttribute(sw, "ref", this.@ref, true);
+            XmlHelper.WriteAttribute(sw, "firstHeaderRow", this.firstHeaderRow, true);
+            XmlHelper.WriteAttribute(sw, "firstDataRow", this.firstDataRow, true);
+            XmlHelper.WriteAttribute(sw, "firstDataCol", this.firstDataCol, true);
             XmlHelper.WriteAttribute(sw, "rowPageCount", this.rowPageCount);
             XmlHelper.WriteAttribute(sw, "colPageCount", this.colPageCount);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private string refField;
@@ -2030,15 +2029,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.pivotField != null)
+            if (this.pivotField == null || this.pivotField.Count == 0)
             {
-                foreach (CT_PivotField x in this.pivotField)
-                {
-                    x.Write(sw, "pivotField");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.pivotField != null && this.pivotField.Count > 0)
+                {
+                    foreach (CT_PivotField x in this.pivotField)
+                    {
+                        x.Write(sw, "pivotField");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_PivotField> pivotFieldField;
@@ -2243,61 +2249,70 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "name", this.name);
-            XmlHelper.WriteAttribute(sw, "axis", this.axis.ToString());
-            XmlHelper.WriteAttribute(sw, "dataField", this.dataField);
+            if (this.axis != null)
+                XmlHelper.WriteAttribute(sw, "axis", this.axis.ToString());
+            XmlHelper.WriteAttribute(sw, "dataField", this.dataField, true);
             XmlHelper.WriteAttribute(sw, "subtotalCaption", this.subtotalCaption);
-            XmlHelper.WriteAttribute(sw, "showDropDowns", this.showDropDowns);
-            XmlHelper.WriteAttribute(sw, "hiddenLevel", this.hiddenLevel);
-            XmlHelper.WriteAttribute(sw, "uniqueMemberProperty", this.uniqueMemberProperty);
-            XmlHelper.WriteAttribute(sw, "compact", this.compact);
-            XmlHelper.WriteAttribute(sw, "allDrilled", this.allDrilled);
-            XmlHelper.WriteAttribute(sw, "numFmtId", this.numFmtId);
-            XmlHelper.WriteAttribute(sw, "outline", this.outline);
+            XmlHelper.WriteAttribute(sw, "showDropDowns", this.showDropDowns, false, true);
+            XmlHelper.WriteAttribute(sw, "hiddenLevel", this.hiddenLevel, false);
+            XmlHelper.WriteAttribute(sw, "uniqueMemberProperty", this.uniqueMemberProperty, false);
+            XmlHelper.WriteAttribute(sw, "compact", this.compact, false, true);
+            XmlHelper.WriteAttribute(sw, "allDrilled", this.allDrilled, false);
+            XmlHelper.WriteAttribute(sw, "numFmtId", this.numFmtId, false);
+            XmlHelper.WriteAttribute(sw, "outline", this.outline, false, true);
             XmlHelper.WriteAttribute(sw, "subtotalTop", this.subtotalTop);
-            XmlHelper.WriteAttribute(sw, "dragToRow", this.dragToRow);
-            XmlHelper.WriteAttribute(sw, "dragToCol", this.dragToCol);
-            XmlHelper.WriteAttribute(sw, "multipleItemSelectionAllowed", this.multipleItemSelectionAllowed);
-            XmlHelper.WriteAttribute(sw, "dragToPage", this.dragToPage);
-            XmlHelper.WriteAttribute(sw, "dragToData", this.dragToData);
-            XmlHelper.WriteAttribute(sw, "dragOff", this.dragOff);
+            XmlHelper.WriteAttribute(sw, "dragToRow", this.dragToRow, false, true);
+            XmlHelper.WriteAttribute(sw, "dragToCol", this.dragToCol, false, true);
+            XmlHelper.WriteAttribute(sw, "multipleItemSelectionAllowed", this.multipleItemSelectionAllowed, false);
+            XmlHelper.WriteAttribute(sw, "dragToPage", this.dragToPage, false, true);
+            XmlHelper.WriteAttribute(sw, "dragToData", this.dragToData, false, true);
+            XmlHelper.WriteAttribute(sw, "dragOff", this.dragOff, false, true);
             XmlHelper.WriteAttribute(sw, "showAll", this.showAll);
-            XmlHelper.WriteAttribute(sw, "insertBlankRow", this.insertBlankRow);
-            XmlHelper.WriteAttribute(sw, "serverField", this.serverField);
-            XmlHelper.WriteAttribute(sw, "insertPageBreak", this.insertPageBreak);
-            XmlHelper.WriteAttribute(sw, "autoShow", this.autoShow);
-            XmlHelper.WriteAttribute(sw, "topAutoShow", this.topAutoShow);
-            XmlHelper.WriteAttribute(sw, "hideNewItems", this.hideNewItems);
-            XmlHelper.WriteAttribute(sw, "measureFilter", this.measureFilter);
-            XmlHelper.WriteAttribute(sw, "includeNewItemsInFilter", this.includeNewItemsInFilter);
-            XmlHelper.WriteAttribute(sw, "itemPageCount", this.itemPageCount);
-            XmlHelper.WriteAttribute(sw, "sortType", this.sortType.ToString());
-            XmlHelper.WriteAttribute(sw, "dataSourceSort", this.dataSourceSort);
-            XmlHelper.WriteAttribute(sw, "nonAutoSortDefault", this.nonAutoSortDefault);
-            XmlHelper.WriteAttribute(sw, "rankBy", this.rankBy);
+            XmlHelper.WriteAttribute(sw, "insertBlankRow", this.insertBlankRow, false);
+            XmlHelper.WriteAttribute(sw, "serverField", this.serverField, false);
+            XmlHelper.WriteAttribute(sw, "insertPageBreak", this.insertPageBreak, false);
+            XmlHelper.WriteAttribute(sw, "autoShow", this.autoShow, false);
+            XmlHelper.WriteAttribute(sw, "topAutoShow", this.topAutoShow, false, true);
+            XmlHelper.WriteAttribute(sw, "hideNewItems", this.hideNewItems, false);
+            XmlHelper.WriteAttribute(sw, "measureFilter", this.measureFilter, false);
+            XmlHelper.WriteAttribute(sw, "includeNewItemsInFilter", this.includeNewItemsInFilter, false);
+            XmlHelper.WriteAttribute(sw, "itemPageCount", this.itemPageCount, false);
+            if (this.sortType != ST_FieldSortType.manual)
+                XmlHelper.WriteAttribute(sw, "sortType", this.sortType.ToString());
+            XmlHelper.WriteAttribute(sw, "dataSourceSort", this.dataSourceSort, false);
+            XmlHelper.WriteAttribute(sw, "nonAutoSortDefault", this.nonAutoSortDefault, false);
+            XmlHelper.WriteAttribute(sw, "rankBy", this.rankBy, false);
             XmlHelper.WriteAttribute(sw, "defaultSubtotal", this.defaultSubtotal);
-            XmlHelper.WriteAttribute(sw, "sumSubtotal", this.sumSubtotal);
-            XmlHelper.WriteAttribute(sw, "countASubtotal", this.countASubtotal);
-            XmlHelper.WriteAttribute(sw, "avgSubtotal", this.avgSubtotal);
-            XmlHelper.WriteAttribute(sw, "maxSubtotal", this.maxSubtotal);
-            XmlHelper.WriteAttribute(sw, "minSubtotal", this.minSubtotal);
-            XmlHelper.WriteAttribute(sw, "productSubtotal", this.productSubtotal);
-            XmlHelper.WriteAttribute(sw, "countSubtotal", this.countSubtotal);
-            XmlHelper.WriteAttribute(sw, "stdDevSubtotal", this.stdDevSubtotal);
-            XmlHelper.WriteAttribute(sw, "stdDevPSubtotal", this.stdDevPSubtotal);
-            XmlHelper.WriteAttribute(sw, "varSubtotal", this.varSubtotal);
-            XmlHelper.WriteAttribute(sw, "varPSubtotal", this.varPSubtotal);
-            XmlHelper.WriteAttribute(sw, "showPropCell", this.showPropCell);
-            XmlHelper.WriteAttribute(sw, "showPropTip", this.showPropTip);
-            XmlHelper.WriteAttribute(sw, "showPropAsCaption", this.showPropAsCaption);
-            XmlHelper.WriteAttribute(sw, "defaultAttributeDrillState", this.defaultAttributeDrillState);
-            sw.Write(">");
-            if (this.items != null)
-                this.items.Write(sw, "items");
-            if (this.autoSortScope != null)
-                this.autoSortScope.Write(sw, "autoSortScope");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+            XmlHelper.WriteAttribute(sw, "sumSubtotal", this.sumSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "countASubtotal", this.countASubtotal, false);
+            XmlHelper.WriteAttribute(sw, "avgSubtotal", this.avgSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "maxSubtotal", this.maxSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "minSubtotal", this.minSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "productSubtotal", this.productSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "countSubtotal", this.countSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "stdDevSubtotal", this.stdDevSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "stdDevPSubtotal", this.stdDevPSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "varSubtotal", this.varSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "varPSubtotal", this.varPSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "showPropCell", this.showPropCell, false);
+            XmlHelper.WriteAttribute(sw, "showPropTip", this.showPropTip, false);
+            XmlHelper.WriteAttribute(sw, "showPropAsCaption", this.showPropAsCaption, false);
+            XmlHelper.WriteAttribute(sw, "defaultAttributeDrillState", this.defaultAttributeDrillState, false);
+            if (this.items == null && this.autoSortScope == null && this.extLst == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.items != null)
+                    this.items.Write(sw, "items");
+                if (this.autoSortScope != null)
+                    this.autoSortScope.Write(sw, "autoSortScope");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_Items itemsField;
@@ -2308,7 +2323,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         private string nameField;
 
-        private ST_Axis axisField;
+        private ST_Axis? axisField;
 
         private bool axisFieldSpecified;
 
@@ -2412,9 +2427,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         public CT_PivotField()
         {
-            this.extLstField = new CT_ExtensionList();
-            this.autoSortScopeField = new CT_AutoSortScope();
-            this.itemsField = new CT_Items();
+            //this.extLstField = new CT_ExtensionList();
+            //this.autoSortScopeField = new CT_AutoSortScope();
+            //this.itemsField = new CT_Items();
             this.dataFieldField = false;
             this.showDropDownsField = true;
             this.hiddenLevelField = false;
@@ -2511,7 +2526,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
 
         [System.Xml.Serialization.XmlAttributeAttribute()]
-        public ST_Axis axis
+        public ST_Axis? axis
         {
             get
             {
@@ -3250,15 +3265,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.item != null)
+            if (this.item == null || this.item.Count == 0)
             {
-                foreach (CT_Item x in this.item)
-                {
-                    x.Write(sw, "item");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.item != null && this.item.Count > 0)
+                {
+                    foreach (CT_Item x in this.item)
+                    {
+                        x.Write(sw, "item");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_Item> itemField;
@@ -3369,19 +3391,19 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "n", this.n);
-            XmlHelper.WriteAttribute(sw, "t", this.t.ToString());
-            XmlHelper.WriteAttribute(sw, "h", this.h);
-            XmlHelper.WriteAttribute(sw, "s", this.s);
-            XmlHelper.WriteAttribute(sw, "sd", this.sd);
-            XmlHelper.WriteAttribute(sw, "f", this.f);
-            XmlHelper.WriteAttribute(sw, "m", this.m);
-            XmlHelper.WriteAttribute(sw, "c", this.c);
-            XmlHelper.WriteAttribute(sw, "x", this.x);
-            XmlHelper.WriteAttribute(sw, "d", this.d);
-            XmlHelper.WriteAttribute(sw, "e", this.e);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            XmlHelper.WriteAttribute(sw, "n", this.n, false);
+            if (this.t != ST_ItemType.data)
+                XmlHelper.WriteAttribute(sw, "t", this.t.ToString());
+            XmlHelper.WriteAttribute(sw, "h", this.h, false);
+            XmlHelper.WriteAttribute(sw, "s", this.s, false);
+            XmlHelper.WriteAttribute(sw, "sd", this.sd, false, true);
+            XmlHelper.WriteAttribute(sw, "f", this.f, false);
+            XmlHelper.WriteAttribute(sw, "m", this.m, false);
+            XmlHelper.WriteAttribute(sw, "c", this.c, false);
+            XmlHelper.WriteAttribute(sw, "x", this.x, true);
+            XmlHelper.WriteAttribute(sw, "d", this.d, false);
+            XmlHelper.WriteAttribute(sw, "e", this.e, false, true);
+            sw.Write("/>");
         }
 
         private string nField;
@@ -3665,10 +3687,17 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            sw.Write(">");
-            if (this.pivotArea != null)
-                this.pivotArea.Write(sw, "pivotArea");
-            sw.Write(string.Format("</{0}>", nodeName));
+            if (this.pivotArea == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.pivotArea != null)
+                    this.pivotArea.Write(sw, "pivotArea");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_PivotArea pivotAreaField;
@@ -3738,15 +3767,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.field != null)
+            if (this.field == null || this.field.Count == 0)
             {
-                foreach (CT_Field x in this.field)
-                {
-                    x.Write(sw, "field");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.field != null && this.field.Count > 0)
+                {
+                    foreach (CT_Field x in this.field)
+                    {
+                        x.Write(sw, "field");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_Field> fieldField;
@@ -3831,9 +3867,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "x", this.x);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            XmlHelper.WriteAttribute(sw, "x", this.x, true);
+            sw.Write("/>");
         }
 
         private int xField;
@@ -3881,15 +3916,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.i != null)
+            if (this.i == null || this.i.Count == 0)
             {
-                foreach (CT_I x in this.i)
-                {
-                    x.Write(sw, "i");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.i != null && this.i.Count > 0)
+                {
+                    foreach (CT_I x in this.i)
+                    {
+                        x.Write(sw, "i");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_I> iField;
@@ -3975,18 +4017,27 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "t", this.t.ToString());
+            if (this.t != ST_ItemType.data)
+                XmlHelper.WriteAttribute(sw, "t", this.t.ToString());
             XmlHelper.WriteAttribute(sw, "r", this.r);
             XmlHelper.WriteAttribute(sw, "i", this.i);
-            sw.Write(">");
-            if (this.x != null)
+
+            if (this.x == null || this.x.Count == 0)
             {
-                foreach (CT_X x in this.x)
-                {
-                    x.Write(sw, "x");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.x != null && this.x.Count > 0)
+                {
+                    foreach (CT_X x in this.x)
+                    {
+                        x.Write(sw, "x");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_X> xField;
@@ -4090,15 +4141,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.field != null)
+
+            if (this.field == null || this.field.Count == 0)
             {
-                foreach (CT_Field x in this.field)
-                {
-                    x.Write(sw, "field");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.field != null && this.field.Count > 0)
+                {
+                    foreach (CT_Field x in this.field)
+                    {
+                        x.Write(sw, "field");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_Field> fieldField;
@@ -4184,15 +4243,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.i != null)
+
+            if (this.i == null || this.i.Count == 0)
             {
-                foreach (CT_I x in this.i)
-                {
-                    x.Write(sw, "i");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.i != null && this.i.Count > 0)
+                {
+                    foreach (CT_I x in this.i)
+                    {
+                        x.Write(sw, "i");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_I> iField;
@@ -4275,15 +4342,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.pageField != null)
+
+            if (this.pageField == null || this.pageField.Count == 0)
             {
-                foreach (CT_PageField x in this.pageField)
-                {
-                    x.Write(sw, "pageField");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.pageField != null && this.pageField.Count > 0)
+                {
+                    foreach (CT_PageField x in this.pageField)
+                    {
+                        x.Write(sw, "pageField");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_PageField> pageFieldField;
@@ -4386,15 +4461,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "fld", this.fld);
-            XmlHelper.WriteAttribute(sw, "item", this.item);
-            XmlHelper.WriteAttribute(sw, "hier", this.hier);
-            XmlHelper.WriteAttribute(sw, "name", this.name);
-            XmlHelper.WriteAttribute(sw, "cap", this.cap);
-            sw.Write(">");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+            XmlHelper.WriteAttribute(sw, "fld", this.fld, true);
+            XmlHelper.WriteAttribute(sw, "item", this.item, false);
+            XmlHelper.WriteAttribute(sw, "hier", this.hier, false);
+            XmlHelper.WriteAttribute(sw, "name", this.name, false);
+            XmlHelper.WriteAttribute(sw, "cap", this.cap, false);
+
+            if (this.extLst == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_ExtensionList extLstField;
@@ -4552,15 +4635,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.dataField != null)
+
+            if (this.dataField == null || this.dataField.Count == 0)
             {
-                foreach (CT_DataField x in this.dataField)
-                {
-                    x.Write(sw, "dataField");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.dataField != null && this.dataField.Count > 0)
+                {
+                    foreach (CT_DataField x in this.dataField)
+                    {
+                        x.Write(sw, "dataField");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_DataField> dataFieldField;
@@ -4667,16 +4758,24 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "name", this.name);
-            XmlHelper.WriteAttribute(sw, "fld", this.fld);
-            XmlHelper.WriteAttribute(sw, "subtotal", this.subtotal.ToString());
-            XmlHelper.WriteAttribute(sw, "showDataAs", this.showDataAs.ToString());
-            XmlHelper.WriteAttribute(sw, "baseField", this.baseField);
-            XmlHelper.WriteAttribute(sw, "baseItem", this.baseItem);
-            XmlHelper.WriteAttribute(sw, "numFmtId", this.numFmtId);
-            sw.Write(">");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+            XmlHelper.WriteAttribute(sw, "fld", this.fld, true);
+            XmlHelper.WriteAttribute(sw, "subtotal", this.subtotal.ToString(), false);
+            XmlHelper.WriteAttribute(sw, "showDataAs", this.showDataAs.ToString(), false);
+            XmlHelper.WriteAttribute(sw, "baseField", this.baseField, true);
+            XmlHelper.WriteAttribute(sw, "baseItem", this.baseItem, true);
+            XmlHelper.WriteAttribute(sw, "numFmtId", this.numFmtId, false);
+
+            if (this.extLst == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_ExtensionList extLstField;
@@ -4699,7 +4798,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         public CT_DataField()
         {
-            this.extLstField = new CT_ExtensionList();
+            //this.extLstField = new CT_ExtensionList();
             this.subtotalField = ST_DataConsolidateFunction.sum;
             this.showDataAsField = ST_ShowDataAs.normal;
             this.baseFieldField = -1;
@@ -4892,15 +4991,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.format != null)
+            if (this.format == null || this.format.Count == 0)
             {
-                foreach (CT_Format x in this.format)
-                {
-                    x.Write(sw, "format");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.format != null && this.format.Count > 0)
+                {
+                    foreach (CT_Format x in this.format)
+                    {
+                        x.Write(sw, "format");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_Format> formatField;
@@ -4974,12 +5080,19 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "action", this.action.ToString());
             XmlHelper.WriteAttribute(sw, "dxfId", this.dxfId);
-            sw.Write(">");
-            if (this.pivotArea != null)
-                this.pivotArea.Write(sw, "pivotArea");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+            if (this.pivotArea == null && this.extLst == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.pivotArea != null)
+                    this.pivotArea.Write(sw, "pivotArea");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_PivotArea pivotAreaField;
@@ -5115,15 +5228,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.conditionalFormat != null)
+
+            if (this.conditionalFormat == null || this.conditionalFormat.Count == 0)
             {
-                foreach (CT_ConditionalFormat x in this.conditionalFormat)
-                {
-                    x.Write(sw, "conditionalFormat");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.conditionalFormat != null && this.conditionalFormat.Count > 0)
+                {
+                    foreach (CT_ConditionalFormat x in this.conditionalFormat)
+                    {
+                        x.Write(sw, "conditionalFormat");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_ConditionalFormat> conditionalFormatField;
@@ -5200,12 +5321,20 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "scope", this.scope.ToString());
             XmlHelper.WriteAttribute(sw, "type", this.type.ToString());
             XmlHelper.WriteAttribute(sw, "priority", this.priority);
-            sw.Write(">");
-            if (this.pivotAreas != null)
-                this.pivotAreas.Write(sw, "pivotAreas");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+
+            if (this.pivotAreas == null && this.extLst == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.pivotAreas != null)
+                    this.pivotAreas.Write(sw, "pivotAreas");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_PivotAreas pivotAreasField;
@@ -5220,7 +5349,6 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         public CT_ConditionalFormat()
         {
-            this.extLstField = new CT_ExtensionList();
             this.pivotAreasField = new CT_PivotAreas();
             this.scopeField = ST_Scope.selection;
             this.typeField = ST_Type.none;
@@ -5323,15 +5451,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.pivotArea != null)
+
+            if (this.pivotArea == null || this.pivotArea.Count == 0)
             {
-                foreach (CT_PivotArea x in this.pivotArea)
-                {
-                    x.Write(sw, "pivotArea");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.pivotArea != null && this.pivotArea.Count > 0)
+                {
+                    foreach (CT_PivotArea x in this.pivotArea)
+                    {
+                        x.Write(sw, "pivotArea");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_PivotArea> pivotAreaField;
@@ -5451,15 +5587,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.chartFormat != null)
+
+            if (this.chartFormat == null || this.chartFormat.Count == 0)
             {
-                foreach (CT_ChartFormat x in this.chartFormat)
-                {
-                    x.Write(sw, "chartFormat");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.chartFormat != null && this.chartFormat.Count > 0)
+                {
+                    foreach (CT_ChartFormat x in this.chartFormat)
+                    {
+                        x.Write(sw, "chartFormat");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_ChartFormat> chartFormatField;
@@ -5531,13 +5675,21 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "chart", this.chart);
-            XmlHelper.WriteAttribute(sw, "format", this.format);
+            XmlHelper.WriteAttribute(sw, "chart", this.chart, true);
+            XmlHelper.WriteAttribute(sw, "format", this.format, true);
             XmlHelper.WriteAttribute(sw, "series", this.series);
-            sw.Write(">");
-            if (this.pivotArea != null)
-                this.pivotArea.Write(sw, "pivotArea");
-            sw.Write(string.Format("</{0}>", nodeName));
+
+            if (this.pivotArea == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.pivotArea != null)
+                    this.pivotArea.Write(sw, "pivotArea");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_PivotArea pivotAreaField;
@@ -5637,15 +5789,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.pivotHierarchy != null)
+            if (this.pivotHierarchy == null || this.pivotHierarchy.Count == 0)
             {
-                foreach (CT_PivotHierarchy x in this.pivotHierarchy)
-                {
-                    x.Write(sw, "pivotHierarchy");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.pivotHierarchy != null && this.pivotHierarchy.Count > 0)
+                {
+                    foreach (CT_PivotHierarchy x in this.pivotHierarchy)
+                    {
+                        x.Write(sw, "pivotHierarchy");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_PivotHierarchy> pivotHierarchyField;
@@ -5750,30 +5909,38 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "outline", this.outline);
-            XmlHelper.WriteAttribute(sw, "multipleItemSelectionAllowed", this.multipleItemSelectionAllowed);
-            XmlHelper.WriteAttribute(sw, "subtotalTop", this.subtotalTop);
-            XmlHelper.WriteAttribute(sw, "showInFieldList", this.showInFieldList);
-            XmlHelper.WriteAttribute(sw, "dragToRow", this.dragToRow);
-            XmlHelper.WriteAttribute(sw, "dragToCol", this.dragToCol);
-            XmlHelper.WriteAttribute(sw, "dragToPage", this.dragToPage);
-            XmlHelper.WriteAttribute(sw, "dragToData", this.dragToData);
-            XmlHelper.WriteAttribute(sw, "dragOff", this.dragOff);
-            XmlHelper.WriteAttribute(sw, "includeNewItemsInFilter", this.includeNewItemsInFilter);
+            XmlHelper.WriteAttribute(sw, "outline", this.outline, false);
+            XmlHelper.WriteAttribute(sw, "multipleItemSelectionAllowed", this.multipleItemSelectionAllowed, false);
+            XmlHelper.WriteAttribute(sw, "subtotalTop", this.subtotalTop, false);
+            XmlHelper.WriteAttribute(sw, "showInFieldList", this.showInFieldList, false, true);
+            XmlHelper.WriteAttribute(sw, "dragToRow", this.dragToRow, false, true);
+            XmlHelper.WriteAttribute(sw, "dragToCol", this.dragToCol, false, true);
+            XmlHelper.WriteAttribute(sw, "dragToPage", this.dragToPage, false, true);
+            XmlHelper.WriteAttribute(sw, "dragToData", this.dragToData, false);
+            XmlHelper.WriteAttribute(sw, "dragOff", this.dragOff, false, true);
+            XmlHelper.WriteAttribute(sw, "includeNewItemsInFilter", this.includeNewItemsInFilter, false);
             XmlHelper.WriteAttribute(sw, "caption", this.caption);
-            sw.Write(">");
-            if (this.mps != null)
-                this.mps.Write(sw, "mps");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            if (this.members != null)
+
+            if (this.mps == null && this.extLst == null && (this.members == null || this.members.Count == 0))
             {
-                foreach (CT_Members x in this.members)
-                {
-                    x.Write(sw, "members");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.mps != null)
+                    this.mps.Write(sw, "mps");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                if (this.members != null && this.members.Count > 0)
+                {
+                    foreach (CT_Members x in this.members)
+                    {
+                        x.Write(sw, "members");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_MemberProperties mpsField;
@@ -5806,9 +5973,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         public CT_PivotHierarchy()
         {
-            this.extLstField = new CT_ExtensionList();
-            this.membersField = new List<CT_Members>();
-            this.mpsField = new CT_MemberProperties();
+            //this.extLstField = new CT_ExtensionList();
+            //this.membersField = new List<CT_Members>();
+            //this.mpsField = new CT_MemberProperties();
             this.outlineField = false;
             this.multipleItemSelectionAllowedField = false;
             this.subtotalTopField = false;
@@ -6043,15 +6210,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.mp != null)
+
+            if (this.mp == null || this.mp.Count == 0)
             {
-                foreach (CT_MemberProperty x in this.mp)
-                {
-                    x.Write(sw, "mp");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.mp != null && this.mp.Count > 0)
+                {
+                    foreach (CT_MemberProperty x in this.mp)
+                    {
+                        x.Write(sw, "mp");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_MemberProperty> mpField;
@@ -6151,8 +6326,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "pLen", this.pLen);
             XmlHelper.WriteAttribute(sw, "level", this.level);
             XmlHelper.WriteAttribute(sw, "field", this.field);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private string nameField;
@@ -6393,15 +6567,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
             XmlHelper.WriteAttribute(sw, "level", this.level);
-            sw.Write(">");
-            if (this.member != null)
+            if (this.member == null || this.member.Count == 0)
             {
-                foreach (CT_Member x in this.member)
-                {
-                    x.Write(sw, "member");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.member != null && this.member.Count > 0)
+                {
+                    foreach (CT_Member x in this.member)
+                    {
+                        x.Write(sw, "member");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_Member> memberField;
@@ -6507,8 +6688,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "name", this.name);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.Write("/>");
         }
 
         private string nameField;
@@ -6559,13 +6739,12 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "name", this.name);
-            XmlHelper.WriteAttribute(sw, "showRowHeaders", this.showRowHeaders);
-            XmlHelper.WriteAttribute(sw, "showColHeaders", this.showColHeaders);
-            XmlHelper.WriteAttribute(sw, "showRowStripes", this.showRowStripes);
-            XmlHelper.WriteAttribute(sw, "showColStripes", this.showColStripes);
-            XmlHelper.WriteAttribute(sw, "showLastColumn", this.showLastColumn);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            XmlHelper.WriteAttribute(sw, "showRowHeaders", this.showRowHeaders, false);
+            XmlHelper.WriteAttribute(sw, "showColHeaders", this.showColHeaders, false);
+            XmlHelper.WriteAttribute(sw, "showRowStripes", this.showRowStripes, false);
+            XmlHelper.WriteAttribute(sw, "showColStripes", this.showColStripes, false);
+            XmlHelper.WriteAttribute(sw, "showLastColumn", this.showLastColumn, false);
+            sw.Write("/>");
         }
 
         private string nameField;
@@ -6763,15 +6942,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.filter != null)
+            if (this.filter == null || this.filter.Count == 0)
             {
-                foreach (CT_PivotFilter x in this.filter)
-                {
-                    x.Write(sw, "filter");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.filter != null && this.filter.Count > 0)
+                {
+                    foreach (CT_PivotFilter x in this.filter)
+                    {
+                        x.Write(sw, "filter");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_PivotFilter> filterField;
@@ -6857,23 +7043,30 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "fld", this.fld);
-            XmlHelper.WriteAttribute(sw, "mpFld", this.mpFld);
-            XmlHelper.WriteAttribute(sw, "type", this.type.ToString());
-            XmlHelper.WriteAttribute(sw, "evalOrder", this.evalOrder);
-            XmlHelper.WriteAttribute(sw, "id", this.id);
-            XmlHelper.WriteAttribute(sw, "iMeasureHier", this.iMeasureHier);
-            XmlHelper.WriteAttribute(sw, "iMeasureFld", this.iMeasureFld);
-            XmlHelper.WriteAttribute(sw, "name", this.name);
-            XmlHelper.WriteAttribute(sw, "description", this.description);
-            XmlHelper.WriteAttribute(sw, "stringValue1", this.stringValue1);
-            XmlHelper.WriteAttribute(sw, "stringValue2", this.stringValue2);
-            sw.Write(">");
-            if (this.autoFilter != null)
-                this.autoFilter.Write(sw, "autoFilter");
-            if (this.extLst != null)
-                this.extLst.Write(sw, "extLst");
-            sw.Write(string.Format("</{0}>", nodeName));
+            XmlHelper.WriteAttribute(sw, "fld", this.fld, true);
+            XmlHelper.WriteAttribute(sw, "mpFld", this.mpFld, false);
+            XmlHelper.WriteAttribute(sw, "type", this.type.ToString(), true);
+            XmlHelper.WriteAttribute(sw, "evalOrder", this.evalOrder, false);
+            XmlHelper.WriteAttribute(sw, "id", this.id, true);
+            XmlHelper.WriteAttribute(sw, "iMeasureHier", this.iMeasureHier, false);
+            XmlHelper.WriteAttribute(sw, "iMeasureFld", this.iMeasureFld, false);
+            XmlHelper.WriteAttribute(sw, "name", this.name, false);
+            XmlHelper.WriteAttribute(sw, "description", this.description, false);
+            XmlHelper.WriteAttribute(sw, "stringValue1", this.stringValue1, false);
+            XmlHelper.WriteAttribute(sw, "stringValue2", this.stringValue2, false);
+            if (this.autoFilter == null && this.extLst == null)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.autoFilter != null)
+                    this.autoFilter.Write(sw, "autoFilter");
+                if (this.extLst != null)
+                    this.extLst.Write(sw, "extLst");
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private CT_AutoFilter autoFilterField;
@@ -6910,7 +7103,6 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         public CT_PivotFilter()
         {
-            this.extLstField = new CT_ExtensionList();
             this.autoFilterField = new CT_AutoFilter();
             this.evalOrderField = 0;
         }
@@ -7360,15 +7552,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.rowHierarchyUsage != null)
+            if (this.rowHierarchyUsage == null || this.rowHierarchyUsage.Count == 0)
             {
-                foreach (CT_HierarchyUsage x in this.rowHierarchyUsage)
-                {
-                    x.Write(sw, "rowHierarchyUsage");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.rowHierarchyUsage != null && this.rowHierarchyUsage.Count > 0)
+                {
+                    foreach (CT_HierarchyUsage x in this.rowHierarchyUsage)
+                    {
+                        x.Write(sw, "rowHierarchyUsage");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_HierarchyUsage> rowHierarchyUsageField;
@@ -7444,9 +7643,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "hierarchyUsage", this.hierarchyUsage);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            XmlHelper.WriteAttribute(sw, "hierarchyUsage", this.hierarchyUsage, true);
+            sw.Write("/>");
         }
 
         private int hierarchyUsageField;
@@ -7494,15 +7692,22 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            sw.Write(">");
-            if (this.colHierarchyUsage != null)
+            if (this.colHierarchyUsage == null || this.colHierarchyUsage.Count == 0)
             {
-                foreach (CT_HierarchyUsage x in this.colHierarchyUsage)
-                {
-                    x.Write(sw, "colHierarchyUsage");
-                }
+                sw.Write("/>");
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            else
+            {
+                sw.Write(">");
+                if (this.colHierarchyUsage != null && this.colHierarchyUsage.Count > 0)
+                {
+                    foreach (CT_HierarchyUsage x in this.colHierarchyUsage)
+                    {
+                        x.Write(sw, "colHierarchyUsage");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
         private List<CT_HierarchyUsage> colHierarchyUsageField;

--- a/OpenXmlFormats/Spreadsheet/Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet.cs
@@ -1633,12 +1633,12 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             ctObj.field = XmlHelper.ReadInt(node.Attributes["field"]);
             if (node.Attributes["type"] != null)
                 ctObj.type = (ST_PivotAreaType)Enum.Parse(typeof(ST_PivotAreaType), node.Attributes["type"].Value);
-            ctObj.dataOnly = XmlHelper.ReadBool(node.Attributes["dataOnly"]);
+            ctObj.dataOnly = XmlHelper.ReadBool(node.Attributes["dataOnly"], true);
             ctObj.labelOnly = XmlHelper.ReadBool(node.Attributes["labelOnly"]);
             ctObj.grandRow = XmlHelper.ReadBool(node.Attributes["grandRow"]);
             ctObj.grandCol = XmlHelper.ReadBool(node.Attributes["grandCol"]);
             ctObj.cacheIndex = XmlHelper.ReadBool(node.Attributes["cacheIndex"]);
-            ctObj.outline = XmlHelper.ReadBool(node.Attributes["outline"]);
+            ctObj.outline = XmlHelper.ReadBool(node.Attributes["outline"], true);
             ctObj.offset = XmlHelper.ReadString(node.Attributes["offset"]);
             ctObj.collapsedLevelsAreSubtotals = XmlHelper.ReadBool(node.Attributes["collapsedLevelsAreSubtotals"]);
             if (node.Attributes["axis"] != null)
@@ -1658,15 +1658,16 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "field", this.field);
-            XmlHelper.WriteAttribute(sw, "type", this.type.ToString());
-            XmlHelper.WriteAttribute(sw, "dataOnly", this.dataOnly);
-            XmlHelper.WriteAttribute(sw, "labelOnly", this.labelOnly);
-            XmlHelper.WriteAttribute(sw, "grandRow", this.grandRow);
-            XmlHelper.WriteAttribute(sw, "grandCol", this.grandCol);
-            XmlHelper.WriteAttribute(sw, "cacheIndex", this.cacheIndex);
-            XmlHelper.WriteAttribute(sw, "outline", this.outline);
+            if (this.type != ST_PivotAreaType.normal)
+                XmlHelper.WriteAttribute(sw, "type", this.type.ToString());
+            XmlHelper.WriteAttribute(sw, "dataOnly", this.dataOnly, false, true);
+            XmlHelper.WriteAttribute(sw, "labelOnly", this.labelOnly, false);
+            XmlHelper.WriteAttribute(sw, "grandRow", this.grandRow, false);
+            XmlHelper.WriteAttribute(sw, "grandCol", this.grandCol, false);
+            XmlHelper.WriteAttribute(sw, "cacheIndex", this.cacheIndex, false);
+            XmlHelper.WriteAttribute(sw, "outline", this.outline, false, true);
             XmlHelper.WriteAttribute(sw, "offset", this.offset);
-            XmlHelper.WriteAttribute(sw, "collapsedLevelsAreSubtotals", this.collapsedLevelsAreSubtotals);
+            XmlHelper.WriteAttribute(sw, "collapsedLevelsAreSubtotals", this.collapsedLevelsAreSubtotals, false);
             XmlHelper.WriteAttribute(sw, "axis", this.axis.ToString());
             XmlHelper.WriteAttribute(sw, "fieldPosition", this.fieldPosition);
             sw.Write(">");
@@ -2060,21 +2061,21 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "field", this.field);
             XmlHelper.WriteAttribute(sw, "count", this.count);
-            XmlHelper.WriteAttribute(sw, "selected", this.selected);
-            XmlHelper.WriteAttribute(sw, "byPosition", this.byPosition);
-            XmlHelper.WriteAttribute(sw, "relative", this.relative);
-            XmlHelper.WriteAttribute(sw, "defaultSubtotal", this.defaultSubtotal);
-            XmlHelper.WriteAttribute(sw, "sumSubtotal", this.sumSubtotal);
-            XmlHelper.WriteAttribute(sw, "countASubtotal", this.countASubtotal);
-            XmlHelper.WriteAttribute(sw, "avgSubtotal", this.avgSubtotal);
-            XmlHelper.WriteAttribute(sw, "maxSubtotal", this.maxSubtotal);
-            XmlHelper.WriteAttribute(sw, "minSubtotal", this.minSubtotal);
-            XmlHelper.WriteAttribute(sw, "productSubtotal", this.productSubtotal);
-            XmlHelper.WriteAttribute(sw, "countSubtotal", this.countSubtotal);
-            XmlHelper.WriteAttribute(sw, "stdDevSubtotal", this.stdDevSubtotal);
-            XmlHelper.WriteAttribute(sw, "stdDevPSubtotal", this.stdDevPSubtotal);
-            XmlHelper.WriteAttribute(sw, "varSubtotal", this.varSubtotal);
-            XmlHelper.WriteAttribute(sw, "varPSubtotal", this.varPSubtotal);
+            XmlHelper.WriteAttribute(sw, "selected", this.selected, false, true);
+            XmlHelper.WriteAttribute(sw, "byPosition", this.byPosition, false);
+            XmlHelper.WriteAttribute(sw, "relative", this.relative, false);
+            XmlHelper.WriteAttribute(sw, "defaultSubtotal", this.defaultSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "sumSubtotal", this.sumSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "countASubtotal", this.countASubtotal, false);
+            XmlHelper.WriteAttribute(sw, "avgSubtotal", this.avgSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "maxSubtotal", this.maxSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "minSubtotal", this.minSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "productSubtotal", this.productSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "countSubtotal", this.countSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "stdDevSubtotal", this.stdDevSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "stdDevPSubtotal", this.stdDevPSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "varSubtotal", this.varSubtotal, false);
+            XmlHelper.WriteAttribute(sw, "varPSubtotal", this.varPSubtotal, false);
             sw.Write(">");
             if (this.extLst != null)
                 this.extLst.Write(sw, "extLst");

--- a/OpenXmlFormats/Spreadsheet/Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet.cs
@@ -2090,8 +2090,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         public CT_PivotAreaReference()
         {
-            this.extLstField = new CT_ExtensionList();
-            this.xField = new List<CT_Index>();
+            //this.extLstField = new CT_ExtensionList();
+            //this.xField = new List<CT_Index>();
             this.selectedField = true;
             this.byPositionField = false;
             this.relativeField = false;
@@ -2109,6 +2109,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             this.varPSubtotalField = false;
         }
 
+        [XmlAttribute]
         public List<CT_Index> x
         {
             get
@@ -2121,6 +2122,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         public CT_ExtensionList extLst
         {
             get
@@ -2133,6 +2135,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         public uint field
         {
             get
@@ -2158,6 +2161,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         public uint count
         {
             get
@@ -2183,6 +2187,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(true)]
         public bool selected
         {
@@ -2196,6 +2201,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool byPosition
         {
@@ -2209,6 +2215,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool relative
         {
@@ -2222,6 +2229,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool defaultSubtotal
         {
@@ -2235,6 +2243,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool sumSubtotal
         {
@@ -2248,6 +2257,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool countASubtotal
         {
@@ -2261,6 +2271,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool avgSubtotal
         {
@@ -2274,6 +2285,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool maxSubtotal
         {
@@ -2287,6 +2299,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool minSubtotal
         {
@@ -2300,6 +2313,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool productSubtotal
         {
@@ -2313,6 +2327,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool countSubtotal
         {
@@ -2326,6 +2341,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool stdDevSubtotal
         {
@@ -2339,6 +2355,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool stdDevPSubtotal
         {
@@ -2352,6 +2369,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool varSubtotal
         {
@@ -2365,6 +2383,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
         [DefaultValue(false)]
         public bool varPSubtotal
         {
@@ -2386,6 +2405,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         private uint vField;
 
+        [XmlAttribute()]
         public uint v
         {
             get
@@ -2409,7 +2429,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "v", this.v);
+            XmlHelper.WriteAttribute(sw, "v", this.v, true);
             sw.Write(">");
             sw.Write(string.Format("</{0}>", nodeName));
         }

--- a/OpenXmlFormats/Vml/SpreadsheetDrawing.cs
+++ b/OpenXmlFormats/Vml/SpreadsheetDrawing.cs
@@ -9,10 +9,11 @@ using NPOI.OpenXml4Net.Util;
 
 namespace NPOI.OpenXmlFormats.Vml.Spreadsheet
 {
-    public class CT_AlternateContent 
+    public class CT_AlternateContent
     {
-        public string innerXml { get; set; }
-        public CT_AlternateContent() 
+        public string outerXml { get; set; }
+
+        public CT_AlternateContent()
         {
         }
         public static CT_AlternateContent Parse(XmlNode node, XmlNamespaceManager namespaceManager)
@@ -25,23 +26,13 @@ namespace NPOI.OpenXmlFormats.Vml.Spreadsheet
             {
                 return ac;
             }
-            ac.innerXml = node.InnerXml;
+            ac.outerXml = node.OuterXml;
             return ac;
         }
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<mc:{0} xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"", nodeName));
-            if (this.innerXml == null)
-            {
-                sw.Write(string.Format("/>", nodeName));
-            }
-            else
-            {
-                sw.Write(">");
-                sw.Write(this.innerXml);
-                sw.Write(string.Format("</mc:{0}>", nodeName));
-            }
-            
+            if (this.outerXml != null)
+                sw.Write(this.outerXml);
         }
 
     }

--- a/openxml4Net/Util/XmlHelper.cs
+++ b/openxml4Net/Util/XmlHelper.cs
@@ -312,9 +312,9 @@ namespace NPOI.OpenXml4Net.Util
         {
             WriteAttribute(sw, attributeName, value, true);
         }
-        public static void WriteAttribute(StreamWriter sw, string attributeName, bool value, bool writeIfBlank)
+        public static void WriteAttribute(StreamWriter sw, string attributeName, bool value, bool writeIfBlank, bool defaultValue = false)
         {
-            if (value == false && !writeIfBlank)
+            if (value == defaultValue && !writeIfBlank)
                 return;
             WriteAttribute(sw, attributeName, value ? "1" : "0");
         }
@@ -339,6 +339,17 @@ namespace NPOI.OpenXml4Net.Util
         {
             WriteAttribute(sw, attributeName, value, false);
         }
+        public static void WriteAttribute(StreamWriter sw, string attributeName, uint value, bool writeIfBlank)
+        {
+            if (value == 0 && !writeIfBlank)
+                return;
+
+            WriteAttribute(sw, attributeName, value.ToString(CultureInfo.InvariantCulture));
+        }
+        public static void WriteAttribute(StreamWriter sw, string attributeName, uint value)
+        {
+            WriteAttribute(sw, attributeName, value, false);
+        }
         public static void WriteAttribute(StreamWriter sw, string attributeName, string value)
         {
             WriteAttribute(sw, attributeName, value, false);
@@ -356,26 +367,22 @@ namespace NPOI.OpenXml4Net.Util
 
             WriteAttribute(sw, attributeName, BitConverter.ToString(value).Replace("-", ""), false);
         }
+
         public static void WriteAttribute(StreamWriter sw, string attributeName, uint value, uint defaultValue, bool writeIfBlank = false)
         {
             if(value != defaultValue)
-                WriteAttribute(sw, attributeName, (int)value, true);
+                WriteAttribute(sw, attributeName, value, true);
             else if(writeIfBlank)
-                WriteAttribute(sw, attributeName, (int)value, writeIfBlank);
-        }
-        public static void WriteAttribute(StreamWriter sw, string attributeName, uint value, bool writeIfBlank = false)
-        {
-            WriteAttribute(sw, attributeName, (int)value, writeIfBlank);
+                WriteAttribute(sw, attributeName, value, writeIfBlank);
         }
 
         public static void WriteAttribute(StreamWriter sw, string attributeName, DateTime? value)
         {
             if (value == null)
                 return;
-            WriteAttribute(sw, attributeName, value.ToString(), false);
-            //how to write xsd:datetime data
-            throw new NotImplementedException();
+            WriteAttribute(sw, attributeName, value.Value.ToString("yyyy-MM-ddTHH:mm:ss"), false);
         }
+
         public static void LoadXmlSafe(XmlDocument xmlDoc, Stream stream)
         {
             XmlReaderSettings settings = new XmlReaderSettings();


### PR DESCRIPTION
The main problem, the solution of which was the purpose of these changes, is to fill excel files with complex graphs and pivot tables using npoi, i.e. using such files as templates. I tested these changes on a relatively large file with several pivot charts, including slicers. I have not checked the creation of the Pivot tables and charts themselves in npoi, although I think it is possible.

Also please pay attention to `CT_AlternateContent` in [[OpenXmlFormats/Vml/SpreadsheetDrawing.cs](https://github.com/KnyazSh/npoi/blob/b261afeb6340174bcb3dbd134c5856b1519f8ad8/OpenXmlFormats/Vml/SpreadsheetDrawing.cs).](url) I had errors when using `innerXml` and had to use `outerXml`. I assume that something is lost by using wrapped innerXml.


