### PR TITLE
Fix formula evaluation

### DIFF
--- a/main/SS/Formula/FormulaCellCacheEntrySet.cs
+++ b/main/SS/Formula/FormulaCellCacheEntrySet.cs
@@ -92,7 +92,7 @@ namespace NPOI.SS.Formula
         private static bool AddInternal(CellCacheEntry[] arr, CellCacheEntry cce)
         {
 
-            int startIx = cce.GetHashCode() % arr.Length;
+            int startIx = Math.Abs(cce.GetHashCode() % arr.Length);
 
             for (int i = startIx; i < arr.Length; i++)
             {
@@ -156,7 +156,7 @@ namespace NPOI.SS.Formula
             // else - usual case
             // delete single element (without re-Hashing)
 
-            int startIx = cce.GetHashCode() % arr.Length;
+            int startIx = Math.Abs(cce.GetHashCode() % arr.Length);
 
             // note - can't exit loops upon finding null because of potential previous deletes
             for (int i = startIx; i < arr.Length; i++)


### PR DESCRIPTION
I was trying to fix tests and found a bug that was fixed in poi long ago.
additionally this merge request fixes about 130 tests

just took fixed code from original poi class
https://github.com/apache/poi/blob/d3899d47447f60bf589c8812371a9d38097cb278/poi/src/main/java/org/apache/poi/ss/formula/FormulaCellCacheEntrySet.java