### PR TITLE
Adding CloneStyleFrom to avoid losing custom style properties 

### DIFF
--- a/main/SS/Util/CellUtil.cs
+++ b/main/SS/Util/CellUtil.cs
@@ -395,6 +395,7 @@ namespace NPOI.SS.Util
             if (newStyle == null)
             {
                 newStyle = workbook.CreateCellStyle();
+                newStyle.CloneStyleFrom(originalStyle);
                 SetFormatProperties(newStyle, workbook, values);
             }
 


### PR DESCRIPTION
Adding call to `CloneStyleFrom(originalStyle)` after creating the style when not found, and before overriding the style properties on `CellUtil.SetCellStyleProperties`. 

This is to avoid losing any other custom style properties set, i.e. FillForegroundXSSFColor
