### PR TITLE
Fix minValue and maxValue in SharedItems in CT_PivotCacheDefinition

### DIFF
--- a/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotCacheDefinition.cs
+++ b/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotCacheDefinition.cs
@@ -1848,8 +1848,17 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "containsMixedTypes", this.containsMixedTypes, false);
             XmlHelper.WriteAttribute(sw, "containsNumber", this.containsNumber, false);
             XmlHelper.WriteAttribute(sw, "containsInteger", this.containsInteger, false);
-            XmlHelper.WriteAttribute(sw, "minValue", this.minValue);
-            XmlHelper.WriteAttribute(sw, "maxValue", this.maxValue);
+            if (this.containsNumber)
+            {
+                XmlHelper.WriteAttribute(sw, "minValue", this.minValue, true);
+                XmlHelper.WriteAttribute(sw, "maxValue", this.maxValue, true);
+            }
+            else
+            {
+                XmlHelper.WriteAttribute(sw, "minValue", this.minValue);
+                XmlHelper.WriteAttribute(sw, "maxValue", this.maxValue);
+            }
+
             XmlHelper.WriteAttribute(sw, "minDate", this.minDate);
             XmlHelper.WriteAttribute(sw, "maxDate", this.maxDate);
             XmlHelper.WriteAttribute(sw, "count", this.count);


### PR DESCRIPTION
Hi @tonyqus.
I'm sorry I've been gone so long. I don't see the point in writing an explanation. But I will try to at least close this issue. I analyzed the request from @solarding and found another inconsistency in the pivotCacheDefinition entry. I think that with this fix we can close this issue and solve the rest within the new Issue. And so the fix turned out to be very big.
I will continue to try to improve your project, as this topic is close to me.
