### PR TITLE
fix IndexOutOfRangeException thrown in FormulaCellCacheEntrySet

### DIFF
--- a/main/SS/Formula/FormulaCellCacheEntrySet.cs
+++ b/main/SS/Formula/FormulaCellCacheEntrySet.cs
@@ -92,7 +92,7 @@ namespace NPOI.SS.Formula
         private static bool AddInternal(CellCacheEntry[] arr, CellCacheEntry cce)
         {
 
-            int startIx = cce.GetHashCode() % arr.Length;
+            int startIx = Math.Abs(cce.GetHashCode() % arr.Length);
 
             for (int i = startIx; i < arr.Length; i++)
             {
@@ -156,7 +156,7 @@ namespace NPOI.SS.Formula
             // else - usual case
             // delete single element (without re-Hashing)
 
-            int startIx = cce.GetHashCode() % arr.Length;
+            int startIx = Math.Abs(cce.GetHashCode() % arr.Length);
 
             // note - can't exit loops upon finding null because of potential previous deletes
             for (int i = startIx; i < arr.Length; i++)


### PR DESCRIPTION
While adding or removing an item from the cache entry set, the item hash code is used to determine the first potential cache index.
But this logic could end up being a negative value, hence throwing an `IndexOutOfRangeException` when trying to access the array with that index.

This PR should fix issue https://github.com/nissl-lab/npoi/issues/683 

Note: This error had been noticed while running a Xamarin iOS app (Mono).