### PR TITLE
fix/test27405

### DIFF
--- a/main/SS/Formula/OperationEvaluationContext.cs
+++ b/main/SS/Formula/OperationEvaluationContext.cs
@@ -28,16 +28,13 @@ namespace NPOI.SS.Formula
         private bool _isSingleValue;
         private WorkbookEvaluator _bookEvaluator;
         private bool _isInArrayContext;
+        
         public OperationEvaluationContext(WorkbookEvaluator bookEvaluator, IEvaluationWorkbook workbook, int sheetIndex, int srcRowNum,
-                int srcColNum, EvaluationTracker tracker)
+                int srcColNum, EvaluationTracker tracker) 
+            : this(bookEvaluator, workbook, sheetIndex, srcRowNum, srcColNum, tracker, isSingleValue: true)
         {
-            _bookEvaluator = bookEvaluator;
-            _workbook = workbook;
-            _sheetIndex = sheetIndex;
-            _rowIndex = srcRowNum;
-            _columnIndex = srcColNum;
-            _tracker = tracker;
         }
+        
         public OperationEvaluationContext(WorkbookEvaluator bookEvaluator, IEvaluationWorkbook workbook, int sheetIndex, int srcRowNum,
             int srcColNum, EvaluationTracker tracker, bool isSingleValue)
         {


### PR DESCRIPTION
Unit test `TestFormulaBugs.test27405` was failing as an exception was thrown during cell evaluation

```
  Message: 
System.InvalidOperationException : Unexpected eval class (LazyRefEval)

  Stack Trace: 
HSSFFormulaEvaluator.EvaluateFormulaCellValue(ICell cell) line 181
BaseFormulaEvaluator.Evaluate(ICell cell) line 105
TestFormulaBugs.Test27405() line 111
```

After further investigation I noticed a difference in the constructor of `OperationEvaluationContext` between NPOI and POI

https://github.com/apache/poi/blob/4b2913afd36232bd826883c20c4169098054a805/poi/src/main/java/org/apache/poi/ss/formula/OperationEvaluationContext.java#L64-L67

I've also added some missing conditions in `WorkbookEvaluator->EvaluateFormula` method.
