### PR TITLE
Add max date check in `IsValidExcelDate`

### DIFF
--- a/main/SS/UserModel/DateUtil.cs
+++ b/main/SS/UserModel/DateUtil.cs
@@ -883,7 +883,9 @@ namespace NPOI.SS.UserModel
         public static bool IsValidExcelDate(double value)
         {
             //return true;
-            return value > -Double.Epsilon;
+
+            const int maxDate = 2958465; // 31/12/9999
+            return value > -Double.Epsilon && value <= maxDate;
         }
 
     }


### PR DESCRIPTION
If date is more than `31/12/9999`, it's not a valid Excel date

![image](https://user-images.githubusercontent.com/6609929/176476107-a4040f45-f9ab-4e8f-aba4-7d9b8c833ca2.png)
