### PR TITLE
Implement Area and Pie chart types

### DIFF
--- a/OpenXmlFormats/Drawing/BaseTypes.cs
+++ b/OpenXmlFormats/Drawing/BaseTypes.cs
@@ -1274,6 +1274,23 @@ namespace NPOI.OpenXmlFormats.Dml
             this.itemsValueField.Add(null);
             return obj;
         }
+
+        public void AddNewLum(int dpIndex)
+        {
+            var accentsLoopIndex = dpIndex / 6;
+            //modValue and offValue allows to set custom tint on accent color
+            //in such a way we can get unique colors for each pie sector.
+            if (accentsLoopIndex != 0)
+            {
+                var modValue = 10000 * new Random().Next(2, 9);
+                var offValue = 10000 * new Random().Next(1, 5);
+                itemsElementNameField.Add(EG_ColorTransform.lumMod);
+                itemsValueField.Add(modValue.ToString());
+                itemsElementNameField.Add(EG_ColorTransform.lumOff);
+                itemsValueField.Add(offValue.ToString());
+            }
+        }
+
         public static CT_SchemeColor Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)

--- a/OpenXmlFormats/Drawing/Chart/AreaChart.cs
+++ b/OpenXmlFormats/Drawing/Chart/AreaChart.cs
@@ -510,8 +510,31 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                 this.extLstField = value;
             }
         }
-    }
 
+        public CT_UnsignedInt AddNewIdx()
+        {
+            this.idxField = new CT_UnsignedInt();
+            return this.idxField;
+        }
+
+        public CT_UnsignedInt AddNewOrder()
+        {
+            this.orderField = new CT_UnsignedInt();
+            return this.orderField;
+        }
+
+        public CT_AxDataSource AddNewCat()
+        {
+            this.catField = new CT_AxDataSource();
+            return this.catField;
+        }
+
+        public CT_NumDataSource AddNewVal()
+        {
+            this.valField = new CT_NumDataSource();
+            return this.valField;
+        }
+    }
 
     [Serializable]
 
@@ -699,6 +722,32 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             {
                 this.extLstField = value;
             }
+        }
+
+        public CT_Boolean AddNewVaryColors()
+        {
+            this.varyColorsField = new CT_Boolean();
+            return this.varyColorsField;
+        }
+
+        public CT_UnsignedInt AddNewAxId()
+        {
+            CT_UnsignedInt si = new CT_UnsignedInt();
+            if (this.axIdField == null)
+                this.axIdField = new List<CT_UnsignedInt>();
+            axIdField.Add(si);
+            return si;
+        }
+
+        public CT_AreaSer AddNewSer()
+        {
+            CT_AreaSer newSer = new CT_AreaSer();
+            if (this.serField == null)
+            {
+                this.serField = new List<CT_AreaSer>();
+            }
+            this.serField.Add(newSer);
+            return newSer;
         }
     }
 }

--- a/OpenXmlFormats/Drawing/Chart/Chart.cs
+++ b/OpenXmlFormats/Drawing/Chart/Chart.cs
@@ -10371,6 +10371,15 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             return newobj;
         }
 
+        public CT_PieChart AddNewPieChart()
+        {
+            if (this.pieChartField == null)
+                this.pieChartField = new List<CT_PieChart>();
+            CT_PieChart newobj = new CT_PieChart();
+            this.pieChartField.Add(newobj);
+            return newobj;
+        }
+
         public CT_ScatterChart AddNewScatterChart()
         {
             if (this.scatterChartField == null)
@@ -10609,6 +10618,17 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                 this.barChartField = new List<CT_BarChart>();
             }
             this.barChartField.Add(ctchart);
+            return ctchart;
+        }
+
+        public CT_AreaChart AddNewAreaChart()
+        {
+            CT_AreaChart ctchart = new CT_AreaChart();
+            if (this.areaChartField == null)
+            {
+                this.areaChartField = new List<CT_AreaChart>();
+            }
+            this.areaChartField.Add(ctchart);
             return ctchart;
         }
 

--- a/OpenXmlFormats/Drawing/Chart/PieChart.cs
+++ b/OpenXmlFormats/Drawing/Chart/PieChart.cs
@@ -279,6 +279,23 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
                 this.extLstField = value;
             }
         }
+
+        public CT_PieSer AddNewSer()
+        {
+            CT_PieSer newSer = new CT_PieSer();
+            if (this.serField == null)
+            {
+                this.serField = new List<CT_PieSer>();
+            }
+            this.serField.Add(newSer);
+            return newSer;
+        }
+
+        public CT_Boolean AddNewVaryColors()
+        {
+            this.varyColorsField = new CT_Boolean();
+            return this.varyColorsField;
+        }
     }
 
     [Serializable]
@@ -311,7 +328,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
 
         public CT_PieSer()
         {
-
+            dPt = new List<CT_DPt>();
         }
         public static CT_PieSer Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
@@ -514,6 +531,30 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             {
                 this.extLstField = value;
             }
+        }
+
+        public CT_UnsignedInt AddNewIdx()
+        {
+            this.idxField = new CT_UnsignedInt();
+            return this.idxField;
+        }
+
+        public CT_UnsignedInt AddNewOrder()
+        {
+            this.orderField = new CT_UnsignedInt();
+            return this.orderField;
+        }
+
+        public CT_AxDataSource AddNewCat()
+        {
+            this.catField = new CT_AxDataSource();
+            return this.catField;
+        }
+
+        public CT_NumDataSource AddNewVal()
+        {
+            this.valField = new CT_NumDataSource();
+            return this.valField;
         }
     }
 

--- a/main/NPOI.csproj
+++ b/main/NPOI.csproj
@@ -777,11 +777,15 @@
     <Compile Include="SS\Formula\SharedFormula.cs" />
     <Compile Include="SS\UserModel\BorderDiagonal.cs" />
     <Compile Include="SS\UserModel\CellCopyPolicy.cs" />
+    <Compile Include="SS\UserModel\Charts\AreaChartData.cs" />
+    <Compile Include="SS\UserModel\Charts\AreaChartSeries.cs" />
     <Compile Include="SS\UserModel\Charts\AxisTickMark.cs" />
     <Compile Include="SS\UserModel\Charts\BarChartData.cs" />
     <Compile Include="SS\UserModel\Charts\BarChartSeries.cs" />
     <Compile Include="SS\UserModel\Charts\ChartDataSource.cs" />
     <Compile Include="SS\UserModel\Charts\ChartSeries.cs" />
+    <Compile Include="SS\UserModel\Charts\ColumnChartData.cs" />
+    <Compile Include="SS\UserModel\Charts\ColumnChartSeries.cs" />
     <Compile Include="SS\UserModel\Charts\DataSources.cs" />
     <Compile Include="SS\UserModel\Charts\LineChartData.cs" />
     <Compile Include="SS\UserModel\Charts\LineChartSeries.cs" />
@@ -789,6 +793,8 @@
     <Compile Include="SS\UserModel\ConditionalFormattingThreshold.cs" />
     <Compile Include="SS\UserModel\ConditionType.cs" />
     <Compile Include="SS\UserModel\DataBarFormatting.cs" />
+    <Compile Include="SS\UserModel\Charts\PieChartData.cs" />
+    <Compile Include="SS\UserModel\Charts\PieChartSeries.cs" />
     <Compile Include="SS\UserModel\DataConsolidateFunction.cs" />
     <Compile Include="SS\UserModel\ExcelGeneralNumberFormat.cs" />
     <Compile Include="SS\UserModel\ExtendedColor.cs" />

--- a/main/SS/UserModel/Charts/AreaChartData.cs
+++ b/main/SS/UserModel/Charts/AreaChartData.cs
@@ -5,23 +5,22 @@ using System.Text;
 namespace NPOI.SS.UserModel.Charts
 {
     /// <summary>
-    /// Data for a Bar Chart
+    /// Data for an Area Chart
     /// </summary>
-    /// <typeparam name="Tx"></typeparam>
-    /// <typeparam name="Ty"></typeparam>
-    public interface IBarChartData<Tx, Ty> : IChartData
+    public interface IAreaChartData<Tx, Ty> : IChartData
     {
+
         /// <summary>
         /// Adds the series.
         /// </summary>
         /// <param name="categories">The categories data source.</param>
         /// <param name="values">The values data source.</param>
         /// <returns>Created series.</returns>
-        IBarChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> values, IChartDataSource<Ty> categories);
+        IAreaChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> categories, IChartDataSource<Ty> values);
 
-        /**
-         * @return list of all series.
-         */
-        List<IBarChartSeries<Tx, Ty>> GetSeries();
+        /// <summary>
+        /// Return list of all series.
+        /// </summary>
+        List<IAreaChartSeries<Tx, Ty>> GetSeries();
     }
 }

--- a/main/SS/UserModel/Charts/AreaChartSeries.cs
+++ b/main/SS/UserModel/Charts/AreaChartSeries.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NPOI.SS.UserModel.Charts
+{
+    public interface IAreaChartSeries<Tx, Ty> : IChartSeries
+    {
+        /// <summary>
+        /// Return data source used for category axis data.
+        /// </summary>
+        IChartDataSource<Tx> GetCategoryAxisData();
+
+        /// <summary>
+        /// Return data source used for value axis.
+        /// </summary>
+        IChartDataSource<Ty> GetValues();
+    }
+}

--- a/main/SS/UserModel/Charts/BarChartData.cs
+++ b/main/SS/UserModel/Charts/BarChartData.cs
@@ -17,7 +17,7 @@ namespace NPOI.SS.UserModel.Charts
         /// <param name="categories">The categories data source.</param>
         /// <param name="values">The values data source.</param>
         /// <returns>Created series.</returns>
-        IBarChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> values, IChartDataSource<Ty> categories);
+        IBarChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> categories, IChartDataSource<Ty> values);
 
         /**
          * @return list of all series.

--- a/main/SS/UserModel/Charts/BarChartSeries.cs
+++ b/main/SS/UserModel/Charts/BarChartSeries.cs
@@ -9,11 +9,11 @@ namespace NPOI.SS.UserModel.Charts
         /**
          * @return data source used for category axis data.
          */
-        IChartDataSource<Tx> GetCategoryAxisData();
+        IChartDataSource<Ty> GetCategoryAxisData();
 
         /**
          * @return data source used for value axis.
          */
-        IChartDataSource<Ty> GetValues();
+        IChartDataSource<Tx> GetValues();
     }
 }

--- a/main/SS/UserModel/Charts/BarChartSeries.cs
+++ b/main/SS/UserModel/Charts/BarChartSeries.cs
@@ -9,11 +9,11 @@ namespace NPOI.SS.UserModel.Charts
         /**
          * @return data source used for category axis data.
          */
-        IChartDataSource<Ty> GetCategoryAxisData();
+        IChartDataSource<Tx> GetCategoryAxisData();
 
         /**
          * @return data source used for value axis.
          */
-        IChartDataSource<Tx> GetValues();
+        IChartDataSource<Ty> GetValues();
     }
 }

--- a/main/SS/UserModel/Charts/ChartDataFactory.cs
+++ b/main/SS/UserModel/Charts/ChartDataFactory.cs
@@ -32,6 +32,9 @@ namespace NPOI.SS.UserModel.Charts
         IScatterChartData<Tx, Ty> CreateScatterChartData<Tx, Ty>();
         ILineChartData<Tx, Ty> CreateLineChartData<Tx, Ty>();
         IBarChartData<Tx, Ty> CreateBarChartData<Tx, Ty>();
+        IPieChartData<Tx, Ty> CreatePieChartData<Tx, Ty>();
+        IColumnChartData<Tx, Ty> CreateColumnChartData<Tx, Ty>();
+        IAreaChartData<Tx, Ty> CreateAreaChartData<Tx, Ty>();
     }
 
 }

--- a/main/SS/UserModel/Charts/ColumnChartData.cs
+++ b/main/SS/UserModel/Charts/ColumnChartData.cs
@@ -5,11 +5,9 @@ using System.Text;
 namespace NPOI.SS.UserModel.Charts
 {
     /// <summary>
-    /// Data for a Bar Chart
+    /// Data for a Column Chart
     /// </summary>
-    /// <typeparam name="Tx"></typeparam>
-    /// <typeparam name="Ty"></typeparam>
-    public interface IBarChartData<Tx, Ty> : IChartData
+    public interface IColumnChartData<Tx, Ty> : IChartData
     {
         /// <summary>
         /// Adds the series.
@@ -17,11 +15,11 @@ namespace NPOI.SS.UserModel.Charts
         /// <param name="categories">The categories data source.</param>
         /// <param name="values">The values data source.</param>
         /// <returns>Created series.</returns>
-        IBarChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> values, IChartDataSource<Ty> categories);
+        IColumnChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> categories, IChartDataSource<Ty> values);
 
-        /**
-         * @return list of all series.
-         */
-        List<IBarChartSeries<Tx, Ty>> GetSeries();
+        /// <summary>
+        /// Returns list of all series.
+        /// </summary>
+        List<IColumnChartSeries<Tx, Ty>> GetSeries();
     }
 }

--- a/main/SS/UserModel/Charts/ColumnChartSeries.cs
+++ b/main/SS/UserModel/Charts/ColumnChartSeries.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NPOI.SS.UserModel.Charts
+{
+    public interface IColumnChartSeries<Tx, Ty> : IChartSeries
+    {
+        /// <summary>
+        /// Return data source used for category axis data.
+        /// </summary>
+        IChartDataSource<Tx> GetCategoryAxisData();
+
+        /// <summary>
+        /// Return data source used for value axis.
+        /// </summary>
+        IChartDataSource<Ty> GetValues();
+    }
+}

--- a/main/SS/UserModel/Charts/PieChartData.cs
+++ b/main/SS/UserModel/Charts/PieChartData.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace NPOI.SS.UserModel.Charts
 {
     /// <summary>
-    /// Data for a Bar Chart
+    /// Data for a Pie Chart
     /// </summary>
-    /// <typeparam name="Tx"></typeparam>
-    /// <typeparam name="Ty"></typeparam>
-    public interface IBarChartData<Tx, Ty> : IChartData
+    public interface IPieChartData<Tx, Ty> : IChartData
     {
         /// <summary>
         /// Adds the series.
@@ -17,11 +17,11 @@ namespace NPOI.SS.UserModel.Charts
         /// <param name="categories">The categories data source.</param>
         /// <param name="values">The values data source.</param>
         /// <returns>Created series.</returns>
-        IBarChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> values, IChartDataSource<Ty> categories);
+        IPieChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> categories, IChartDataSource<Ty> values);
 
-        /**
-         * @return list of all series.
-         */
-        List<IBarChartSeries<Tx, Ty>> GetSeries();
+        /// <summary>
+        /// Return list of all series.
+        /// </summary>
+        List<IPieChartSeries<Tx, Ty>> GetSeries();
     }
 }

--- a/main/SS/UserModel/Charts/PieChartSeries.cs
+++ b/main/SS/UserModel/Charts/PieChartSeries.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NPOI.SS.UserModel.Charts
+{
+    public interface IPieChartSeries<Tx, Ty> : IChartSeries
+    {
+        /// <summary>
+        /// Return data source used for category axis data.
+        /// </summary>
+        IChartDataSource<Tx> GetCategoryAxisData();
+
+        /// <summary>
+        /// Return data source used for value axis.
+        /// </summary>
+        IChartDataSource<Ty> GetValues();
+
+    }
+}

--- a/main/SS/UserModel/Charts/ScatterChartData.cs
+++ b/main/SS/UserModel/Charts/ScatterChartData.cs
@@ -33,6 +33,8 @@ namespace NPOI.SS.UserModel.Charts
          */
         IScatterChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> xs, IChartDataSource<Ty> ys);
 
+        IScatterChartSeries<Tx, Ty> AddSeries(IChartDataSource<Ty> values);
+
         /**
          * @return list of all series
          */

--- a/ooxml/NPOI.OOXML.csproj
+++ b/ooxml/NPOI.OOXML.csproj
@@ -176,6 +176,7 @@
     <Compile Include="XSSF\UserModel\BaseXSSFEvaluationWorkbook.cs" />
     <Compile Include="XSSF\UserModel\BaseXSSFFormulaEvaluator.cs" />
     <Compile Include="XSSF\UserModel\Charts\AbstractXSSFChartSeries.cs" />
+    <Compile Include="XSSF\UserModel\Charts\XSSFAreaChartData.cs" />
     <Compile Include="XSSF\UserModel\Charts\XSSFBarChartData.cs" />
     <Compile Include="XSSF\UserModel\Charts\XSSFCategoryAxis.cs" />
     <Compile Include="XSSF\UserModel\Charts\XSSFChartAxis.cs">
@@ -188,11 +189,13 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="XSSF\UserModel\Charts\XSSFChartUtil.cs" />
+    <Compile Include="XSSF\UserModel\Charts\XSSFColumnChartData.cs" />
     <Compile Include="XSSF\UserModel\Charts\XSSFDateAxis.cs" />
     <Compile Include="XSSF\UserModel\Charts\XSSFLineChartData.cs" />
     <Compile Include="XSSF\UserModel\Charts\XSSFManualLayout.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="XSSF\UserModel\Charts\XSSFPieChartData.cs" />
     <Compile Include="XSSF\UserModel\Charts\XSSFScatterChartData.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/ooxml/XSSF/UserModel/Charts/XSSFAreaChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFAreaChartData.cs
@@ -9,33 +9,33 @@ using System.Text;
 namespace NPOI.XSSF.UserModel.Charts
 {
     /// <summary>
-    /// Holds data for a XSSF Bar Chart
+    /// Holds data for a XSSF Area Chart
     /// </summary>
     /// <typeparam name="Tx"></typeparam>
     /// <typeparam name="Ty"></typeparam>
-    public class XSSFBarChartData<Tx, Ty> : IBarChartData<Tx, Ty>
+    public class XSSFAreaChartData<Tx, Ty> : IAreaChartData<Tx, Ty>
     {
         /**
          * List of all data series.
          */
-        private List<IBarChartSeries<Tx, Ty>> series;
+        private List<IAreaChartSeries<Tx, Ty>> series;
 
-        public XSSFBarChartData()
+        public XSSFAreaChartData()
         {
-            series = new List<IBarChartSeries<Tx, Ty>>();
+            series = new List<IAreaChartSeries<Tx, Ty>>();
         }
 
-        public class Series : AbstractXSSFChartSeries, IBarChartSeries<Tx, Ty>
+        public class Series : AbstractXSSFChartSeries, IAreaChartSeries<Tx, Ty>
         {
             private int id;
             private int order;
             private byte[] fillColor;
-            private IChartDataSource<Tx> values;
-            private IChartDataSource<Ty> categories;
+            private IChartDataSource<Tx> categories;
+            private IChartDataSource<Ty> values;
 
             internal Series(int id, int order,
-                            IChartDataSource<Tx> values,
-                            IChartDataSource<Ty> categories)
+                            IChartDataSource<Tx> categories,
+                            IChartDataSource<Ty> values)
             {
                 this.id = id;
                 this.order = order;
@@ -61,63 +61,62 @@ namespace NPOI.XSSF.UserModel.Charts
                 fillColor[2] = color.B;
             }
 
-            public IChartDataSource<Ty> GetCategoryAxisData()
+            public IChartDataSource<Tx> GetCategoryAxisData()
             {
                 return categories;
             }
 
-            public IChartDataSource<Tx> GetValues()
+            public IChartDataSource<Ty> GetValues()
             {
                 return values;
             }
 
-            internal void AddToChart(CT_BarChart ctBarChart)
+            internal void AddToChart(CT_AreaChart ctAreaChart)
             {
-                CT_BarSer ctBarSer = ctBarChart.AddNewSer();
-                CT_BarGrouping ctGrouping = ctBarChart.AddNewGrouping();
-                ctGrouping.val = ST_BarGrouping.clustered;
-                ctBarSer.AddNewIdx().val = (uint)id;
-                ctBarSer.AddNewOrder().val = (uint)order;
-                CT_Boolean ctNoInvertIfNegative = new CT_Boolean();
-                ctNoInvertIfNegative.val = 0;
-                ctBarSer.invertIfNegative = ctNoInvertIfNegative;
+                CT_AreaSer ctAreaSer = ctAreaChart.AddNewSer();
+                //TODO: resolve grouping
+                //CT_BarGrouping ctGrouping = ctAreaSer.AddNewGrouping();
+                //ctGrouping.val = ST_BarGrouping.clustered;
+                ctAreaSer.AddNewIdx().val = (uint)id;
+                ctAreaSer.AddNewOrder().val = (uint)order;
+                //TODO: resolve negative
+                //CT_Boolean ctNoInvertIfNegative = new CT_Boolean();
+                //ctNoInvertIfNegative.val = 0;
+                //ctAreaSer.invertIfNegative = ctNoInvertIfNegative;
 
-                CT_BarDir ctBarDir = ctBarChart.AddNewBarDir();
-                ctBarDir.val = ST_BarDir.bar;
-
-                CT_AxDataSource catDS = ctBarSer.AddNewCat();
+                CT_AxDataSource catDS = ctAreaSer.AddNewCat();
                 XSSFChartUtil.BuildAxDataSource(catDS, categories);
-                CT_NumDataSource valueDS = ctBarSer.AddNewVal();
+                CT_NumDataSource valueDS = ctAreaSer.AddNewVal();
                 XSSFChartUtil.BuildNumDataSource(valueDS, values);
 
                 if (IsTitleSet)
                 {
-                    ctBarSer.tx = GetCTSerTx();
+                    ctAreaSer.tx = GetCTSerTx();
                 }
 
                 if (fillColor != null)
                 {
-                    ctBarSer.spPr = new OpenXmlFormats.Dml.Chart.CT_ShapeProperties();
-                    CT_SolidColorFillProperties ctSolidColorFillProperties = ctBarSer.spPr.AddNewSolidFill();
+                    ctAreaSer.spPr = new NPOI.OpenXmlFormats.Dml.Chart.CT_ShapeProperties();
+                    CT_SolidColorFillProperties ctSolidColorFillProperties = ctAreaSer.spPr.AddNewSolidFill();
                     CT_SRgbColor ctSRgbColor = ctSolidColorFillProperties.AddNewSrgbClr();
                     ctSRgbColor.val = fillColor;
                 }
             }
         }
 
-        public IBarChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> values, IChartDataSource<Ty> categoryAxisData)
+        public IAreaChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> categoryAxisData, IChartDataSource<Ty> values)
         {
             if (!values.IsNumeric)
             {
                 throw new ArgumentException("Value data source must be numeric.");
             }
             int numOfSeries = series.Count;
-            Series newSeries = new Series(numOfSeries, numOfSeries, values, categoryAxisData);
+            Series newSeries = new Series(numOfSeries, numOfSeries, categoryAxisData, values);
             series.Add(newSeries);
             return newSeries;
         }
 
-        public List<IBarChartSeries<Tx, Ty>> GetSeries()
+        public List<IAreaChartSeries<Tx, Ty>> GetSeries()
         {
             return series;
         }
@@ -132,20 +131,20 @@ namespace NPOI.XSSF.UserModel.Charts
             XSSFChart xssfChart = (XSSFChart)chart;
             CT_PlotArea plotArea = xssfChart.GetCTChart().plotArea;
             int allSeriesCount = plotArea.GetAllSeriesCount();
-            CT_BarChart barChart = plotArea.AddNewBarChart();
-            barChart.AddNewVaryColors().val = 0;
+            CT_AreaChart areaChart = plotArea.AddNewAreaChart();
+            areaChart.AddNewVaryColors().val = 0;
 
             for (int i = 0; i < series.Count; ++i)
             {
                 Series s = (Series)series[i];
                 s.SetId(allSeriesCount + i);
                 s.SetOrder(allSeriesCount + i);
-                s.AddToChart(barChart);
+                s.AddToChart(areaChart);
             }
 
             foreach (IChartAxis ax in axis)
             {
-                barChart.AddNewAxId().val = (uint)ax.Id;
+                areaChart.AddNewAxId().val = (uint)ax.Id;
             }
         }
     }

--- a/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
@@ -30,12 +30,12 @@ namespace NPOI.XSSF.UserModel.Charts
             private int id;
             private int order;
             private byte[] fillColor;
-            private IChartDataSource<Tx> values;
-            private IChartDataSource<Ty> categories;
+            private IChartDataSource<Tx> categories;
+            private IChartDataSource<Ty> values;
 
             internal Series(int id, int order,
-                            IChartDataSource<Tx> values,
-                            IChartDataSource<Ty> categories)
+                IChartDataSource<Tx> categories,
+                IChartDataSource<Ty> values)
             {
                 this.id = id;
                 this.order = order;
@@ -61,12 +61,12 @@ namespace NPOI.XSSF.UserModel.Charts
                 fillColor[2] = color.B;
             }
 
-            public IChartDataSource<Ty> GetCategoryAxisData()
+            public IChartDataSource<Tx> GetCategoryAxisData()
             {
                 return categories;
             }
 
-            public IChartDataSource<Tx> GetValues()
+            public IChartDataSource<Ty> GetValues()
             {
                 return values;
             }
@@ -105,14 +105,14 @@ namespace NPOI.XSSF.UserModel.Charts
             }
         }
 
-        public IBarChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> values, IChartDataSource<Ty> categoryAxisData)
+        public IBarChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> categoryAxisData, IChartDataSource<Ty> values)
         {
             if (!values.IsNumeric)
             {
                 throw new ArgumentException("Value data source must be numeric.");
             }
             int numOfSeries = series.Count;
-            Series newSeries = new Series(numOfSeries, numOfSeries, values, categoryAxisData);
+            Series newSeries = new Series(numOfSeries, numOfSeries, categoryAxisData, values);
             series.Add(newSeries);
             return newSeries;
         }

--- a/ooxml/XSSF/UserModel/Charts/XSSFChartDataFactory.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFChartDataFactory.cs
@@ -50,6 +50,21 @@ namespace NPOI.XSSF.UserModel.Charts
         {
             return new XSSFBarChartData<Tx, Ty>();
         }
+
+        public IPieChartData<Tx, Ty> CreatePieChartData<Tx, Ty>()
+        {
+            return new XSSFPieChartData<Tx, Ty>();
+        }
+
+        public IColumnChartData<Tx, Ty> CreateColumnChartData<Tx, Ty>()
+        {
+            return new XSSFColumnChartData<Tx, Ty>();
+        }
+
+        public IAreaChartData<Tx, Ty> CreateAreaChartData<Tx, Ty>()
+        {
+            return new XSSFAreaChartData<Tx, Ty>();
+        }
         /**
          * @return factory instance
          */

--- a/ooxml/XSSF/UserModel/Charts/XSSFColumnChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFColumnChartData.cs
@@ -9,33 +9,33 @@ using System.Text;
 namespace NPOI.XSSF.UserModel.Charts
 {
     /// <summary>
-    /// Holds data for a XSSF Bar Chart
+    /// Holds data for a XSSF Column Chart
     /// </summary>
     /// <typeparam name="Tx"></typeparam>
     /// <typeparam name="Ty"></typeparam>
-    public class XSSFBarChartData<Tx, Ty> : IBarChartData<Tx, Ty>
+    public class XSSFColumnChartData<Tx, Ty> : IColumnChartData<Tx, Ty>
     {
         /**
          * List of all data series.
          */
-        private List<IBarChartSeries<Tx, Ty>> series;
+        private List<IColumnChartSeries<Tx, Ty>> series;
 
-        public XSSFBarChartData()
+        public XSSFColumnChartData()
         {
-            series = new List<IBarChartSeries<Tx, Ty>>();
+            series = new List<IColumnChartSeries<Tx, Ty>>();
         }
 
-        public class Series : AbstractXSSFChartSeries, IBarChartSeries<Tx, Ty>
+        public class Series : AbstractXSSFChartSeries, IColumnChartSeries<Tx, Ty>
         {
             private int id;
             private int order;
             private byte[] fillColor;
-            private IChartDataSource<Tx> values;
-            private IChartDataSource<Ty> categories;
+            private IChartDataSource<Tx> categories;
+            private IChartDataSource<Ty> values;
 
             internal Series(int id, int order,
-                            IChartDataSource<Tx> values,
-                            IChartDataSource<Ty> categories)
+                            IChartDataSource<Tx> categories,
+                            IChartDataSource<Ty> values)
             {
                 this.id = id;
                 this.order = order;
@@ -61,12 +61,12 @@ namespace NPOI.XSSF.UserModel.Charts
                 fillColor[2] = color.B;
             }
 
-            public IChartDataSource<Ty> GetCategoryAxisData()
+            public IChartDataSource<Tx> GetCategoryAxisData()
             {
                 return categories;
             }
 
-            public IChartDataSource<Tx> GetValues()
+            public IChartDataSource<Ty> GetValues()
             {
                 return values;
             }
@@ -83,7 +83,7 @@ namespace NPOI.XSSF.UserModel.Charts
                 ctBarSer.invertIfNegative = ctNoInvertIfNegative;
 
                 CT_BarDir ctBarDir = ctBarChart.AddNewBarDir();
-                ctBarDir.val = ST_BarDir.bar;
+                ctBarDir.val = ST_BarDir.col;
 
                 CT_AxDataSource catDS = ctBarSer.AddNewCat();
                 XSSFChartUtil.BuildAxDataSource(catDS, categories);
@@ -97,7 +97,7 @@ namespace NPOI.XSSF.UserModel.Charts
 
                 if (fillColor != null)
                 {
-                    ctBarSer.spPr = new OpenXmlFormats.Dml.Chart.CT_ShapeProperties();
+                    ctBarSer.spPr = new NPOI.OpenXmlFormats.Dml.Chart.CT_ShapeProperties();
                     CT_SolidColorFillProperties ctSolidColorFillProperties = ctBarSer.spPr.AddNewSolidFill();
                     CT_SRgbColor ctSRgbColor = ctSolidColorFillProperties.AddNewSrgbClr();
                     ctSRgbColor.val = fillColor;
@@ -105,19 +105,19 @@ namespace NPOI.XSSF.UserModel.Charts
             }
         }
 
-        public IBarChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> values, IChartDataSource<Ty> categoryAxisData)
+        public IColumnChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> categoryAxisData, IChartDataSource<Ty> values)
         {
             if (!values.IsNumeric)
             {
                 throw new ArgumentException("Value data source must be numeric.");
             }
             int numOfSeries = series.Count;
-            Series newSeries = new Series(numOfSeries, numOfSeries, values, categoryAxisData);
+            Series newSeries = new Series(numOfSeries, numOfSeries, categoryAxisData, values);
             series.Add(newSeries);
             return newSeries;
         }
 
-        public List<IBarChartSeries<Tx, Ty>> GetSeries()
+        public List<IColumnChartSeries<Tx, Ty>> GetSeries()
         {
             return series;
         }

--- a/ooxml/XSSF/UserModel/Charts/XSSFPieChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFPieChartData.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NPOI.OpenXmlFormats.Dml;
+using NPOI.OpenXmlFormats.Dml.Chart;
+using NPOI.SS.UserModel.Charts;
+
+namespace NPOI.XSSF.UserModel.Charts
+{
+    /// <summary>
+    /// Holds data for a XSSF Pie Chart
+    /// </summary>
+    /// <typeparam name="Tx"></typeparam>
+    /// <typeparam name="Ty"></typeparam>
+    public class XSSFPieChartData<Tx, Ty> : IPieChartData<Tx, Ty>
+    {
+        /// <summary>
+        /// List of all data series.
+        /// </summary>
+        private List<IPieChartSeries<Tx, Ty>> series;
+
+        public XSSFPieChartData()
+        {
+            series = new List<IPieChartSeries<Tx, Ty>>();
+        }
+
+        public class Series : AbstractXSSFChartSeries, IPieChartSeries<Tx, Ty>
+        {
+            private int id;
+            private int order;
+            private byte[] fillColor;
+            private IChartDataSource<Tx> categories;
+            private IChartDataSource<Ty> values;
+
+            internal Series(int id, int order,
+                            IChartDataSource<Tx> categories,
+                            IChartDataSource<Ty> values)
+            {
+                this.id = id;
+                this.order = order;
+                this.categories = categories;
+                this.values = values;
+            }
+
+            public void SetId(int id)
+            {
+                this.id = id;
+            }
+
+            public void SetOrder(int order)
+            {
+                this.order = order;
+            }
+
+            public IChartDataSource<Tx> GetCategoryAxisData()
+            {
+                return categories;
+            }
+
+            public IChartDataSource<Ty> GetValues()
+            {
+                return values;
+            }
+
+            internal void AddToChart(CT_PieChart ctPieChart)
+            {
+                CT_PieSer ctPieSer = ctPieChart.AddNewSer();
+                ctPieSer.AddNewIdx().val = (uint) id;
+                ctPieSer.AddNewOrder().val = (uint) order;
+
+                CT_AxDataSource catDS = ctPieSer.AddNewCat();
+                XSSFChartUtil.BuildAxDataSource(catDS, categories);
+                for (var i = 0; i < categories.PointCount; i++)
+                {
+                    var accentIndex = (i % 6) + 4;
+                    var colorVal = (ST_SchemeColorVal)Enum.Parse(typeof(ST_SchemeColorVal), accentIndex.ToString());
+                    var schemeColor = new CT_SchemeColor {val = colorVal};
+                    schemeColor.AddNewLum(i);
+                    var solidFill = new CT_SolidColorFillProperties {schemeClr = schemeColor};
+                    var shapeProperties = new NPOI.OpenXmlFormats.Dml.Chart.CT_ShapeProperties {solidFill = solidFill};
+                    var dPt = new CT_DPt
+                    {
+                        spPr = shapeProperties,
+                        idx = new CT_UnsignedInt {val = (uint) i},
+                    };
+                    
+                    ctPieSer.dPt.Add(dPt);
+                }
+
+                CT_NumDataSource valueDS = ctPieSer.AddNewVal();
+                XSSFChartUtil.BuildNumDataSource(valueDS, values);
+
+                if (IsTitleSet)
+                {
+                    ctPieSer.tx = GetCTSerTx();
+                }
+            }
+        }
+
+        public IPieChartSeries<Tx, Ty> AddSeries(IChartDataSource<Tx> categoryAxisData, IChartDataSource<Ty> values)
+        {
+            if (!values.IsNumeric)
+            {
+                throw new ArgumentException("Value data source must be numeric.");
+            }
+            int numOfSeries = series.Count;
+            Series newSeries = new Series(numOfSeries, numOfSeries, categoryAxisData, values);
+            series.Add(newSeries);
+            return newSeries;
+        }
+
+        public List<IPieChartSeries<Tx, Ty>> GetSeries()
+        {
+            return series;
+        }
+
+        public void FillChart(SS.UserModel.IChart chart, params IChartAxis[] axis)
+        {
+            if (!(chart is XSSFChart))
+            {
+                throw new ArgumentException("Chart must be instance of XSSFChart");
+            }
+
+            XSSFChart xssfChart = (XSSFChart)chart;
+            CT_PlotArea plotArea = xssfChart.GetCTChart().plotArea;
+            int allSeriesCount = plotArea.GetAllSeriesCount();
+
+            CT_PieChart pieChart = plotArea.AddNewPieChart();
+            pieChart.AddNewVaryColors().val = 0;
+
+            for (int i = 0; i < series.Count; ++i)
+            {
+                Series s = (Series)series[i];
+                s.SetId(allSeriesCount + i);
+                s.SetOrder(allSeriesCount + i);
+                s.AddToChart(pieChart);
+            }
+        }
+    }
+}

--- a/ooxml/XSSF/UserModel/Charts/XSSFScatterChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFScatterChartData.cs
@@ -113,8 +113,11 @@ namespace NPOI.XSSF.UserModel.Charts
                 scatterSer.AddNewIdx().val = (uint)this.id;
                 scatterSer.AddNewOrder().val = (uint)this.order;
 
-                CT_AxDataSource xVal = scatterSer.AddNewXVal();
-                XSSFChartUtil.BuildAxDataSource<Tx>(xVal, xs);
+                if (xs != null)
+                {
+                    CT_AxDataSource xVal = scatterSer.AddNewXVal();
+                    XSSFChartUtil.BuildAxDataSource<Tx>(xVal, xs);
+                }
                 CT_NumDataSource yVal = scatterSer.AddNewYVal();
                 XSSFChartUtil.BuildNumDataSource<Ty>(yVal, ys);
 
@@ -135,6 +138,11 @@ namespace NPOI.XSSF.UserModel.Charts
             Series newSerie = new Series(numOfSeries, numOfSeries, xs, ys);
             series.Add(newSerie);
             return newSerie;
+        }
+
+        public IScatterChartSeries<Tx, Ty> AddSeries(IChartDataSource<Ty> values)
+        {
+            return AddSeries(null, values);
         }
 
         public void FillChart(IChart chart, IChartAxis[] axis)
@@ -171,6 +179,7 @@ namespace NPOI.XSSF.UserModel.Charts
 
         private void AddStyle(CT_ScatterChart ctScatterChart)
         {
+            ctScatterChart.varyColors = new CT_Boolean { val = 0 };
             CT_ScatterStyle scatterStyle = ctScatterChart.AddNewScatterStyle();
             scatterStyle.val = ST_ScatterStyle.lineMarker;
         }

--- a/ooxml/XSSF/UserModel/XSSFChart.cs
+++ b/ooxml/XSSF/UserModel/XSSFChart.cs
@@ -97,6 +97,7 @@ namespace NPOI.XSSF.UserModel
         private void CreateChart()
         {
             chartSpaceDocument = new ChartSpaceDocument();
+            chartSpaceDocument.GetChartSpace().roundedCorners = new CT_Boolean {val = 0};
             chart = chartSpaceDocument.GetChartSpace().AddNewChart();
             CT_PlotArea plotArea = chart.AddNewPlotArea();
 


### PR DESCRIPTION
Add implementation for Area, Pie and partly a Column chart types, minor fixes for charts. 

Column chart still needs the _AddNewColumnChart_ implemented in _OpenXmlFormats/Drawing/Chart/Chart.cs_

Part of the implementation for #581 