### PR TITLE
Pivot tables serialization fixes

### DIFF
--- a/OpenXmlFormats/Spreadsheet/AutoFilter.cs
+++ b/OpenXmlFormats/Spreadsheet/AutoFilter.cs
@@ -140,23 +140,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         private bool showButtonField;
 
+        private CT_CustomFilters customFiltersField;
+
         public CT_FilterColumn()
         {
             this.hiddenButtonField = false;
             this.showButtonField = true;
         }
-        //[XmlAttribute]
-        //public object Item
-        //{
-        //    get
-        //    {
-        //        return this.itemField;
-        //    }
-        //    set
-        //    {
-        //        this.itemField = value;
-        //    }
-        //}
+
         [XmlAttribute]
         public uint colId
         {
@@ -196,6 +187,19 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
+        [XmlAttribute]
+        public CT_CustomFilters customFilters
+        {
+            get
+            {
+                return this.customFiltersField;
+            }
+            set
+            {
+                this.customFiltersField = value;
+            }
+        }
+
         public static CT_FilterColumn Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
@@ -204,12 +208,12 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             ctObj.colId = XmlHelper.ReadUInt(node.Attributes["colId"]);
             ctObj.hiddenButton = XmlHelper.ReadBool(node.Attributes["hiddenButton"]);
             ctObj.showButton = XmlHelper.ReadBool(node.Attributes["showButton"]);
-            //TODO: implement http://www.schemacentral.com/sc/ooxml/t-ssml_CT_FilterColumn.html
-            //foreach (XmlNode childNode in node.ChildNodes)
-            //{
-            //    if (childNode.LocalName == "Item")
-            //        ctObj.Item = new Object();
-            //}
+            
+            foreach (XmlNode childNode in node.ChildNodes)
+            {
+                if (childNode.LocalName == "customFilters")
+                    ctObj.customFilters = CT_CustomFilters.Parse(childNode, namespaceManager);
+            }
             return ctObj;
         }
 
@@ -219,10 +223,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "colId", this.colId, true);
-            XmlHelper.WriteAttribute(sw, "hiddenButton", this.hiddenButton);
-            XmlHelper.WriteAttribute(sw, "showButton", this.showButton);
-            sw.Write(">");
-            sw.Write(string.Format("</{0}>", nodeName));
+            XmlHelper.WriteAttribute(sw, "hiddenButton", this.hiddenButton, false);
+            XmlHelper.WriteAttribute(sw, "showButton", this.showButton, false);
+
+            if (this.customFilters == null || this.customFilters.customFilter.Count == 0)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.customFilters != null && this.customFilters.customFilter.Count > 0)
+                {
+                    if (this.customFilters != null)
+                        this.customFilters.Write(sw, "customFilters");
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
         }
 
     }
@@ -317,6 +334,46 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 this.andField = value;
             }
         }
+
+        public static CT_CustomFilters Parse(XmlNode node, XmlNamespaceManager namespaceManager)
+        {
+            if (node == null)
+                return null;
+            CT_CustomFilters ctObj = new CT_CustomFilters();
+            if (node.Attributes["and"] != null)
+                ctObj.and = XmlHelper.ReadBool(node.Attributes["and"]);
+
+            ctObj.customFilterField = new List<CT_CustomFilter>();
+            foreach (XmlNode childNode in node.ChildNodes)
+            {
+                if (childNode.LocalName == "customFilter")
+                    ctObj.customFilter.Add(CT_CustomFilter.Parse(childNode, namespaceManager));
+            }
+            return ctObj;
+        }
+
+        internal void Write(StreamWriter sw, string nodeName)
+        {
+            sw.Write(string.Format("<{0}", nodeName));
+            XmlHelper.WriteAttribute(sw, "and", this.and, false);
+
+            if (this.customFilter == null || this.customFilter.Count == 0)
+            {
+                sw.Write("/>");
+            }
+            else
+            {
+                sw.Write(">");
+                if (this.customFilter != null && this.customFilter.Count > 0)
+                {
+                    foreach (CT_CustomFilter x in this.customFilter)
+                    {
+                        x.Write(sw, "customFilter");
+                    }
+                }
+                sw.Write(string.Format("</{0}>", nodeName));
+            }
+        }
     }
 
     public class CT_CustomFilter
@@ -354,6 +411,27 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             {
                 this.valField = value;
             }
+        }
+
+        public static CT_CustomFilter Parse(XmlNode node, XmlNamespaceManager namespaceManager)
+        {
+            if (node == null)
+                return null;
+            CT_CustomFilter ctObj = new CT_CustomFilter();
+            if (node.Attributes["operator"] != null 
+                && Enum.TryParse<ST_FilterOperator>(XmlHelper.ReadString(node.Attributes["operator"]), out ST_FilterOperator _operator))
+                ctObj.@operator = _operator;
+            if (node.Attributes["val"] != null)
+                ctObj.val = XmlHelper.ReadString(node.Attributes["val"]);
+            return ctObj;
+        }
+
+        internal void Write(StreamWriter sw, string nodeName)
+        {
+            sw.Write(string.Format("<{0}", nodeName));
+            XmlHelper.WriteAttribute(sw, "operator", this.@operator.ToString(), true);
+            XmlHelper.WriteAttribute(sw, "val", this.val, true);
+            sw.Write("/>");
         }
     }
 

--- a/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotCacheDefinition.cs
+++ b/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotCacheDefinition.cs
@@ -89,6 +89,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write("<pivotCacheDefinition xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" ");
             sw.Write("xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" ");
             sw.Write("xmlns:s=\"http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes\" ");
+            sw.Write("xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\" ");
+            sw.Write("mc:Ignorable=\"xr\" ");
+            sw.Write("xmlns:xr=\"http://schemas.microsoft.com/office/spreadsheetml/2014/revision\" ");
             XmlHelper.WriteAttribute(sw, "r:id", this.id);
             XmlHelper.WriteAttribute(sw, "invalid", this.invalid);
             XmlHelper.WriteAttribute(sw, "saveData", this.saveData);
@@ -2978,7 +2981,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "v", this.v, true);
+            XmlHelper.WriteAttribute(sw, "v", this.v, false);
             sw.Write("/>");
         }
     }
@@ -3529,7 +3532,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "st", this.st, false);
             XmlHelper.WriteAttribute(sw, "b", this.b, false);
 
-            if (this.tpls == null && (this.x == null || this.x.Count == 0))
+            if ((this.tpls == null || this.tpls.tpl.Count == 0) && (this.x == null || this.x.Count == 0))
             {
                 sw.Write("/>");
             }
@@ -4451,7 +4454,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "v", this.v);
+            XmlHelper.WriteAttribute(sw, "v", this.v, true);
             XmlHelper.WriteAttribute(sw, "u", this.u, false);
             XmlHelper.WriteAttribute(sw, "f", this.f, false);
             XmlHelper.WriteAttribute(sw, "c", this.c, false);
@@ -4821,7 +4824,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "v", this.v);
+            XmlHelper.WriteAttribute(sw, "v", this.v, true);
             XmlHelper.WriteAttribute(sw, "u", this.u, false);
             XmlHelper.WriteAttribute(sw, "f", this.f, false);
             XmlHelper.WriteAttribute(sw, "c", this.c, false);

--- a/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotCacheRecords.cs
+++ b/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotCacheRecords.cs
@@ -40,6 +40,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write("<pivotCacheRecords xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" ");
             sw.Write("xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" ");
             sw.Write("xmlns:s=\"http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes\" ");
+            sw.Write("xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\" ");
+            sw.Write("mc:Ignorable=\"xr\" ");
+            sw.Write("xmlns:xr=\"http://schemas.microsoft.com/office/spreadsheetml/2014/revision\" ");
             XmlHelper.WriteAttribute(sw, "count", this.count);
             sw.Write(">");
             if (this.extLst != null)

--- a/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotTableDefinition.cs
+++ b/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotTableDefinition.cs
@@ -193,6 +193,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write("<pivotTableDefinition xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" ");
             sw.Write("xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" ");
             sw.Write("xmlns:s=\"http://schemas.openxmlformats.org/officeDocument/2006/sharedTypes\" ");
+            sw.Write("xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\" ");
+            sw.Write("mc:Ignorable=\"xr\" ");
+            sw.Write("xmlns:xr=\"http://schemas.microsoft.com/office/spreadsheetml/2014/revision\" ");
             XmlHelper.WriteAttribute(sw, "name", this.name);
             XmlHelper.WriteAttribute(sw, "cacheId", this.cacheId, true);
             XmlHelper.WriteAttribute(sw, "dataOnRows", this.dataOnRows);
@@ -4467,7 +4470,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "name", this.name, false);
             XmlHelper.WriteAttribute(sw, "cap", this.cap, false);
 
-            if (this.extLst == null)
+            if (this.extLst == null || this.extLst.ext.Count == 0)
             {
                 sw.Write("/>");
             }
@@ -7048,7 +7051,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "evalOrder", this.evalOrder, false);
             XmlHelper.WriteAttribute(sw, "id", this.id, true);
             XmlHelper.WriteAttribute(sw, "iMeasureHier", this.iMeasureHier, false);
-            XmlHelper.WriteAttribute(sw, "iMeasureFld", this.iMeasureFld, false);
+            XmlHelper.WriteAttribute(sw, "iMeasureFld", this.iMeasureFld, true);
             XmlHelper.WriteAttribute(sw, "name", this.name, false);
             XmlHelper.WriteAttribute(sw, "description", this.description, false);
             XmlHelper.WriteAttribute(sw, "stringValue1", this.stringValue1, false);

--- a/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotTableDefinition.cs
+++ b/OpenXmlFormats/Spreadsheet/PivotTable/CT_PivotTableDefinition.cs
@@ -5080,9 +5080,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "action", this.action.ToString());
+            XmlHelper.WriteAttribute(sw, "action", this.action.ToString(), false, ST_FormatAction.formatting.ToString());
             XmlHelper.WriteAttribute(sw, "dxfId", this.dxfId);
-            if (this.pivotArea == null && this.extLst == null)
+            if (this.pivotArea == null && (this.extLst == null || this.extLst.ext.Count == 0))
             {
                 sw.Write("/>");
             }
@@ -5091,7 +5091,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 sw.Write(">");
                 if (this.pivotArea != null)
                     this.pivotArea.Write(sw, "pivotArea");
-                if (this.extLst != null)
+                if (this.extLst != null && this.extLst.ext.Count != 0)
                     this.extLst.Write(sw, "extLst");
                 sw.Write(string.Format("</{0}>", nodeName));
             }

--- a/OpenXmlFormats/Spreadsheet/Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet.cs
@@ -1673,7 +1673,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(">");
             if (this.references != null)
                 this.references.Write(sw, "references");
-            if (this.extLst != null)
+            if (this.extLst != null && this.extLst.ext.Count != 0)
                 this.extLst.Write(sw, "extLst");
             sw.Write(string.Format("</{0}>", nodeName));
         }
@@ -2059,7 +2059,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw, string nodeName)
         {
             sw.Write(string.Format("<{0}", nodeName));
-            XmlHelper.WriteAttribute(sw, "field", this.field);
+            XmlHelper.WriteAttribute(sw, "field", this.field, true);
             XmlHelper.WriteAttribute(sw, "count", this.count);
             XmlHelper.WriteAttribute(sw, "selected", this.selected, false, true);
             XmlHelper.WriteAttribute(sw, "byPosition", this.byPosition, false);

--- a/OpenXmlFormats/Spreadsheet/Workbook/CT_Workbook.cs
+++ b/OpenXmlFormats/Spreadsheet/Workbook/CT_Workbook.cs
@@ -113,10 +113,15 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(StreamWriter sw)
         {
             sw.Write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
-            sw.Write("<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"");
-            sw.Write(" xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\" mc:Ignorable=\"x15 xr xr6 xr10 xr2\" xmlns:x15=\"http://schemas.microsoft.com/office/spreadsheetml/2010/11/main\" xmlns:xr=\"http://schemas.microsoft.com/office/spreadsheetml/2014/revision\""); 
-            sw.Write(" xmlns:xr6=\"http://schemas.microsoft.com/office/spreadsheetml/2016/revision6\" xmlns:xr10=\"http://schemas.microsoft.com/office/spreadsheetml/2016/revision10\" xmlns:xr2=\"http://schemas.microsoft.com/office/spreadsheetml/2015/revision2\"");
-            sw.Write(">");
+            sw.Write("<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" ");
+            sw.Write("xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" ");
+            sw.Write("xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\" ");
+            sw.Write("mc:Ignorable=\"x15 xr xr6 xr10 xr2\" ");
+            sw.Write("xmlns:x15=\"http://schemas.microsoft.com/office/spreadsheetml/2010/11/main\" ");
+            sw.Write("xmlns:xr=\"http://schemas.microsoft.com/office/spreadsheetml/2014/revision\" ");
+            sw.Write("xmlns:xr6=\"http://schemas.microsoft.com/office/spreadsheetml/2016/revision6\" ");
+            sw.Write("xmlns:xr10=\"http://schemas.microsoft.com/office/spreadsheetml/2016/revision10\" ");
+            sw.Write("xmlns:xr2=\"http://schemas.microsoft.com/office/spreadsheetml/2015/revision2\">");
             if (this.fileVersion != null)
                 this.fileVersion.Write(sw, "fileVersion");
             if (this.fileSharing != null)

--- a/ooxml/XSSF/Model/CommentsTable.cs
+++ b/ooxml/XSSF/Model/CommentsTable.cs
@@ -24,7 +24,7 @@ namespace NPOI.XSSF.Model
     using NPOI.SS.UserModel;
     using NPOI.SS.Util;
     using NPOI.XSSF.UserModel;
-    using OpenXmlFormats.Spreadsheet;
+    using NPOI.OpenXmlFormats.Spreadsheet;
 
     public class CommentsTable : POIXMLDocumentPart
     {

--- a/openxml4Net/Util/XmlHelper.cs
+++ b/openxml4Net/Util/XmlHelper.cs
@@ -356,7 +356,11 @@ namespace NPOI.OpenXml4Net.Util
         }
         public static void WriteAttribute(StreamWriter sw, string attributeName, string value, bool writeIfBlank)
         {
-            if (string.IsNullOrEmpty(value) && !writeIfBlank)
+            WriteAttribute(sw, attributeName, value, writeIfBlank, string.Empty);
+        }
+        public static void WriteAttribute(StreamWriter sw, string attributeName, string value, bool writeIfBlank, string defaultValue)
+        {
+            if ((string.IsNullOrEmpty(value) || defaultValue.Equals(value)) && !writeIfBlank)
                 return;
             sw.Write(string.Format(" {0}=\"{1}\"", attributeName, value == null ? string.Empty : EncodeXml(value)));
         }

--- a/testcases/main/NPOI.TestCases.csproj
+++ b/testcases/main/NPOI.TestCases.csproj
@@ -719,6 +719,9 @@
     <PackageReference Include="NUnit">
       <Version>3.13.1</Version>
     </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter">
+      <Version>4.2.1</Version>
+    </PackageReference>
     <PackageReference Include="SharpZipLib">
       <Version>1.3.3</Version>
     </PackageReference>

--- a/testcases/ooxml/NPOI.OOXML.TestCases.csproj
+++ b/testcases/ooxml/NPOI.OOXML.TestCases.csproj
@@ -310,6 +310,9 @@
     <PackageReference Include="NUnit">
       <Version>3.13.1</Version>
     </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter">
+      <Version>4.2.1</Version>
+    </PackageReference>
     <PackageReference Include="Portable.BouncyCastle">
       <Version>1.8.9</Version>
     </PackageReference>

--- a/testcases/openxml4net/NPOI.OOXML4Net.Testcases.csproj
+++ b/testcases/openxml4net/NPOI.OOXML4Net.Testcases.csproj
@@ -162,6 +162,9 @@
     <PackageReference Include="NUnit">
       <Version>3.13.1</Version>
     </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter">
+      <Version>4.2.1</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Completed CT_CustomFilters and CT_CustomFilter classes and their usage in AutoFilter

Added namespaces to pivot tables definition: xmlns:mc, mc:Ignorable, xmlns:xr. Changed some nodes serialization in pivot table parts, to conform with ECMA standard XSD of OOXML. 

Added reload for XmlHelper.WriteAttribute for string type values, that can accept a default value, to decide if this attribute should be present in stream or it can be omitted.

Pivot area property was serializing wrong, omitting "field" property when it has value of 0, which causes excel to repair the pivot tables that contain this object.