### PR TITLE
Various minor fixes (more in the description)

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Workbook/CT_WebPublishObjects.cs
+++ b/OpenXmlFormats/Spreadsheet/Workbook/CT_WebPublishObjects.cs
@@ -88,7 +88,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             ctObj.allowPng = XmlHelper.ReadBool(node.Attributes["allowPng"]);
             if (node.Attributes["targetScreenSize"] != null)
             {
-               ctObj.targetScreenSize = Enums.Parse<ST_TargetScreenSize>(node.Attributes["targetScreenSize"].Value,false, EnumFormat.Description);
+               ctObj.targetScreenSize = Enums.Parse<ST_TargetScreenSize>(node.Attributes["targetScreenSize"].Value,false, EnumFormat.Name);
             }
             ctObj.dpi = XmlHelper.ReadUInt(node.Attributes["dpi"]);
             ctObj.codePage = XmlHelper.ReadUInt(node.Attributes["codePage"]);

--- a/main/HPSF/MutableSection.cs
+++ b/main/HPSF/MutableSection.cs
@@ -230,7 +230,10 @@ namespace NPOI.HPSF
         {
             long id = p.ID;
             RemoveProperty(id);
-            preprops.Add(p);
+            if (p.Value != null)
+            {
+                preprops.Add(p);
+            }
             dirty = true;
         }
 

--- a/main/HPSF/VariantSupport.cs
+++ b/main/HPSF/VariantSupport.cs
@@ -185,7 +185,7 @@ namespace NPOI.HPSF
                     {
                         Filetime filetime = (Filetime)typedPropertyValue.Value;
                         return Util.FiletimeToDate((int)filetime.High,
-                                (int)filetime.Low);
+                                (int)filetime.Low).ToUniversalTime();
                     }
                 case Variant.VT_LPSTR:
                     {

--- a/main/SS/Formula/Function/FunctionMetadataReader.cs
+++ b/main/SS/Formula/Function/FunctionMetadataReader.cs
@@ -25,6 +25,7 @@ namespace NPOI.SS.Formula.Function
     using NPOI.SS.Formula.PTG;
     using System.Globalization;
     using System.Text;
+    using System.Reflection;
 
     /**
      * Converts the text meta-data file into a <c>FunctionMetadataRegistry</c>
@@ -36,7 +37,7 @@ namespace NPOI.SS.Formula.Function
 #if NETSTANDARD2_1 || NETSTANDARD2_0
         private const String METADATA_FILE_NAME = "NPOI.Resources.functionMetadata.txt";
 #else
-        private const String METADATA_FILE_NAME = "functionMetadata.txt";
+        private const String METADATA_FILE_NAME = "NPOI.Resources.functionMetadata.txt";
 #endif
 
         /** plain ASCII text metadata file uses three dots for ellipsis */
@@ -55,7 +56,7 @@ namespace NPOI.SS.Formula.Function
 
         public static FunctionMetadataRegistry CreateRegistry()
         {
-            using (StreamReader br = new StreamReader (typeof (FunctionMetadataReader).Assembly.GetManifestResourceStream (METADATA_FILE_NAME)))
+            using (StreamReader br = new StreamReader(Assembly.GetAssembly(typeof(FunctionMetadataReader)).GetManifestResourceStream(METADATA_FILE_NAME)))
             {
 
                 FunctionDataBuilder fdb = new FunctionDataBuilder(400);


### PR DESCRIPTION
**Fix bug with StreamReader not initialising in FunctionMetadataReader.**
Fixed the way assembly containing functionMetadata.txt resource is chosen.

**Prefvent MutableSection from setting MutableProperty with null Value.**
It was messing up getting a Size property of a Mutable Section, as it reads the MutableProperty's Value and tries to get it's length, throwing exception when it’s null.

**Fix the way enum is parsed for ST_TargetScreenSize.**
It was using Description of enum, when should have been using Name.

**Read HSSF metadata date properties same way as the XSSF metadata.**
XSSF was made to read date properties of a file as UniversalTime, HSSF was not so behavior was different. This fixes that discrepancy.