### PR TITLE
Expose out list of styles for use

### DIFF
--- a/ooxml/XWPF/Usermodel/XWPFStyles.cs
+++ b/ooxml/XWPF/Usermodel/XWPFStyles.cs
@@ -35,7 +35,7 @@ namespace NPOI.XWPF.UserModel
     {
         private CT_Styles ctStyles;
         private List<XWPFStyle> listStyle = new List<XWPFStyle>();
-
+        public IReadOnlyList<XWPFStyle> listOfStyles { get => listStyle; }
         private XWPFLatentStyles latentStyles;
         private XWPFDefaultRunStyle defaultRunStyle;
         private XWPFDefaultParagraphStyle defaultParaStyle;


### PR DESCRIPTION
I don't see a reason the actual list of styles can't be exposed publicly, but without understanding the library enough in depth, I think this is an easy way to expose the list without causing any changes to the functionality of this class.