### PR TITLE
Implement AutoSizeRow method

### DIFF
--- a/main/HSSF/UserModel/HSSFSheet.cs
+++ b/main/HSSF/UserModel/HSSFSheet.cs
@@ -3249,6 +3249,16 @@ namespace NPOI.HSSF.UserModel
             throw new NotImplementedException();
         }
 
+        public void AutoSizeRow(int row)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AutoSizeRow(int row, bool useMergedCells)
+        {
+            throw new NotImplementedException();
+        }
+
         public CellAddress ActiveCell
         {
             get

--- a/main/HSSF/UserModel/HSSFSheet.cs
+++ b/main/HSSF/UserModel/HSSFSheet.cs
@@ -2338,6 +2338,55 @@ namespace NPOI.HSSF.UserModel
             }
         }
 
+        /**
+         * Adjusts the row height to fit the contents.
+         *
+         * This process can be relatively slow on large sheets, so this should
+         *  normally only be called once per row, at the end of your
+         *  Processing.
+         *
+         * @param row the row index
+         */
+        public void AutoSizeRow(int row)
+        {
+            AutoSizeRow(row, false);
+        }
+
+        /**
+         * Adjusts the row height to fit the contents.
+         * <p>
+         * This process can be relatively slow on large sheets, so this should
+         *  normally only be called once per row, at the end of your
+         *  Processing.
+         * </p>
+         * You can specify whether the content of merged cells should be considered or ignored.
+         *  Default is to ignore merged cells.
+         *
+         * @param row the row index
+         * @param useMergedCells whether to use the contents of merged cells when calculating the height of the row
+         */
+        public void AutoSizeRow(int row, bool useMergedCells)
+        {
+            var targetRow = GetRow(row) ?? CreateRow(row);
+
+            double height = SheetUtil.GetRowHeight(this, row, useMergedCells);
+
+            if (height != -1 && height != 0)
+            {
+
+                height *= 20;
+
+                int maxRowHeight = 409 * 20; // The maximum row height for an individual cell is 409 points
+
+                if (height > maxRowHeight)
+                {
+                    height = maxRowHeight;
+                }
+
+                targetRow.Height = (short)height;
+            }
+        }
+
         /// <summary>
         /// Checks if the provided region is part of the merged regions.
         /// </summary>
@@ -3245,16 +3294,6 @@ namespace NPOI.HSSF.UserModel
         }
 
         public bool IsDate1904()
-        {
-            throw new NotImplementedException();
-        }
-
-        public void AutoSizeRow(int row)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void AutoSizeRow(int row, bool useMergedCells)
         {
             throw new NotImplementedException();
         }

--- a/main/HSSF/UserModel/HSSFSheet.cs
+++ b/main/HSSF/UserModel/HSSFSheet.cs
@@ -2373,7 +2373,6 @@ namespace NPOI.HSSF.UserModel
 
             if (height != -1 && height != 0)
             {
-
                 height *= 20;
 
                 int maxRowHeight = 409 * 20; // The maximum row height for an individual cell is 409 points

--- a/main/SS/UserModel/Sheet.cs
+++ b/main/SS/UserModel/Sheet.cs
@@ -722,6 +722,30 @@ namespace NPOI.SS.UserModel
         void AutoSizeColumn(int column, bool useMergedCells);
 
         /// <summary>
+        /// Adjusts the row height to fit the contents.
+        /// </summary>
+        /// <param name="row">the row index</param>
+        /// <remarks>
+        /// This process can be relatively slow on large sheets, so this should
+        /// normally only be called once per row, at the end of your
+        /// processing.
+        /// </remarks>
+        void AutoSizeRow(int row);
+
+        /// <summary>
+        /// Adjusts the row height to fit the contents.
+        /// </summary>
+        /// <param name="row">the row index.</param>
+        /// <param name="useMergedCells">whether to use the contents of merged cells when 
+        /// calculating the height of the row. Default is to ignore merged cells.</param>
+        /// <remarks>
+        /// This process can be relatively slow on large sheets, so this should
+        /// normally only be called once per row, at the end of your
+        /// processing.
+        /// </remarks>
+        void AutoSizeRow(int row, bool useMergedCells);
+
+        /// <summary>
         /// Returns cell comment for the specified row and column
         /// </summary>
         /// <param name="row">The row.</param>

--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -318,9 +318,9 @@ namespace NPOI.SS.Util
             ICell cellToMeasure = useMergedCells ? GetFirstCellFromMergedRegion(cell) : cell;
 
             double stringHeight = GetActualHeight(cellToMeasure);
-            int rowSpan = useMergedCells ? GetRowSpan(cellToMeasure) : 1;
+            int numberOfRowsInMergedRegion = useMergedCells ? GetNumberOfRowsInMergedRegion(cellToMeasure) : 1;
 
-            return GetCellConetntHeight(stringHeight, rowSpan);
+            return GetCellConetntHeight(stringHeight, numberOfRowsInMergedRegion);
         }
 
         private static ICell GetFirstCellFromMergedRegion(ICell cell)
@@ -349,14 +349,11 @@ namespace NPOI.SS.Util
             return GetContentHeight(stringValue, windowsFont);
         }
 
-        private static int GetRowSpan(ICell cell)
+        private static int GetNumberOfRowsInMergedRegion(ICell cell)
         {
-            ISheet sheet = cell.Sheet;
-            IRow row = cell.Row;
-            
-            foreach (var region in sheet.MergedRegions)
+            foreach (var region in cell.Sheet.MergedRegions)
             {
-                if (region.IsInRange(row.RowNum, cell.ColumnIndex))
+                if (region.IsInRange(cell.RowIndex, cell.ColumnIndex))
                 {
                     return 1 + region.LastColumn - region.FirstColumn;
                 }
@@ -365,13 +362,13 @@ namespace NPOI.SS.Util
             return 1;
         }
 
-        private static double GetCellConetntHeight(double actualHeight, int rowSpan)
+        private static double GetCellConetntHeight(double actualHeight, int numberOfRowsInMergedRegion)
         {
             //for some reason the height of the content that Graphics object measures comes back
             //with a little bit of extra padding.  This is a hack to get the height back to what it should be.
             double ratioToFixHeight = 0.798;
 
-            return Math.Max(-1, actualHeight / rowSpan * ratioToFixHeight);
+            return Math.Max(-1, actualHeight / numberOfRowsInMergedRegion * ratioToFixHeight);
         }
 
         private static string GetCellStringValue(ICell cell)

--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -265,6 +265,24 @@ namespace NPOI.SS.Util
             return newRow;
         }
 
+        public static double GetRowHeight(ISheet sheet, int rowIdx, bool useMergedCells, int firstColumnIdx, int lastColumnIdx)
+        {
+            double width = -1;
+            
+            for (int cellIdx = firstColumnIdx; cellIdx <= lastColumnIdx; ++cellIdx)
+            {
+                IRow row = sheet.GetRow(rowIdx);
+                ICell cell = row.GetCell(cellIdx);
+                if (row != null && cell != null)
+                {
+                    double cellWidth = GetCellHeight(cell, useMergedCells);
+                    width = Math.Max(width, cellWidth);
+                }
+            }
+            
+            return width;
+        }
+
         public static double GetRowHeight(ISheet sheet, int rowIdx, bool useMergedCells)
         {
             IRow row = sheet.GetRow(rowIdx);

--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -265,13 +265,12 @@ namespace NPOI.SS.Util
             return newRow;
         }
 
-        public static double GetRowHeight(ISheet sheet, int rowIdx, bool useMergedCells, int firstColumnIdx, int lastColumnIdx)
+        public static double GetRowHeight(IRow row, bool useMergedCells, int firstColumnIdx, int lastColumnIdx)
         {
             double width = -1;
-            
+
             for (int cellIdx = firstColumnIdx; cellIdx <= lastColumnIdx; ++cellIdx)
             {
-                IRow row = sheet.GetRow(rowIdx);
                 ICell cell = row.GetCell(cellIdx);
                 if (row != null && cell != null)
                 {
@@ -279,14 +278,18 @@ namespace NPOI.SS.Util
                     width = Math.Max(width, cellWidth);
                 }
             }
-            
+
             return width;
         }
 
-        public static double GetRowHeight(ISheet sheet, int rowIdx, bool useMergedCells)
+        public static double GetRowHeight(ISheet sheet, int rowIdx, bool useMergedCells, int firstColumnIdx, int lastColumnIdx)
         {
             IRow row = sheet.GetRow(rowIdx);
+            return GetRowHeight(row, useMergedCells, firstColumnIdx, lastColumnIdx);
+        }
 
+        public static double GetRowHeight(IRow row, bool useMergedCells)
+        {
             if (row == null)
             {
                 return -1;
@@ -299,10 +302,17 @@ namespace NPOI.SS.Util
                 double cellHeight = GetCellHeight(cell, useMergedCells);
                 rowHeight = Math.Max(rowHeight, cellHeight);
             }
-            
+
             return rowHeight;
         }
-        
+
+        public static double GetRowHeight(ISheet sheet, int rowIdx, bool useMergedCells)
+        {
+            IRow row = sheet.GetRow(rowIdx);
+
+            return GetRowHeight(row, useMergedCells);
+        }
+
         public static double GetCellHeight(ICell cell, bool useMergedCells)
         {
             ICell cellToMeasure = useMergedCells ? GetFirstCellFromMergedRegion(cell) : cell;

--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -357,13 +357,17 @@ namespace NPOI.SS.Util
             IFont defaultFont = wb.GetFontAt(0);
             Font font = IFont2Font(defaultFont);
 
-            using var image = new Bitmap(1, 1);
-            using var g = Graphics.FromImage(image);
-            g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
+            using (var image = new Bitmap(1, 1))
+            {
+                using (var g = Graphics.FromImage(image))
+                {
+                    g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.AntiAlias;
 
-            var measureResult = g.MeasureString($"{defaultChar}", font, int.MaxValue, StringFormat.GenericTypographic);
+                    var measureResult = g.MeasureString($"{defaultChar}", font, int.MaxValue, StringFormat.GenericTypographic);
 
-            return (int)measureResult.Height;
+                    return (int)measureResult.Height; 
+                }
+            }
         }
 
         private static int GetRowSpan(ICell cell)
@@ -432,27 +436,33 @@ namespace NPOI.SS.Util
 
         private static double GetRotatedContentHeight(ICell cell, string stringValue, Font windowsFont)
         {
-            using Bitmap bmp = new Bitmap(1, 1);
-            using Graphics g = Graphics.FromImage(bmp);
-            
-            var angle = cell.CellStyle.Rotation * 2.0 * Math.PI / 360.0;
-            var measureResult = g.MeasureString(stringValue, windowsFont);
-            
-            var x1 = Math.Abs(measureResult.Height * Math.Cos(angle));
-            var x2 = Math.Abs(measureResult.Width * Math.Sin(angle));
-            
-            return Math.Round(x1 + x2, 0, MidpointRounding.ToEven); ;
+            using (Bitmap bmp = new Bitmap(1, 1))
+            {
+                using (Graphics g = Graphics.FromImage(bmp))
+                {
+                    var angle = cell.CellStyle.Rotation * 2.0 * Math.PI / 360.0;
+                    var measureResult = g.MeasureString(stringValue, windowsFont);
+
+                    var x1 = Math.Abs(measureResult.Height * Math.Cos(angle));
+                    var x2 = Math.Abs(measureResult.Width * Math.Sin(angle));
+
+                    return Math.Round(x1 + x2, 0, MidpointRounding.ToEven); ;  
+                }
+            }
         }
 
         private static double GetContentHeight(string stringValue, Font windowsFont)
         {
 
-            using Bitmap bmp = new Bitmap(1, 1);
-            using Graphics g = Graphics.FromImage(bmp);
-            
-            SizeF measureResult = g.MeasureString(stringValue, windowsFont, int.MaxValue, StringFormat.GenericTypographic);
+            using (Bitmap bmp = new Bitmap(1, 1))
+            {
+                using (Graphics g = Graphics.FromImage(bmp))
+                {
+                    SizeF measureResult = g.MeasureString(stringValue, windowsFont, int.MaxValue, StringFormat.GenericTypographic);
 
-            return Math.Round(measureResult.Height, 0, MidpointRounding.ToEven);
+                    return Math.Round(measureResult.Height, 0, MidpointRounding.ToEven);  
+                }
+            }
         }
 
         /**

--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -364,11 +364,7 @@ namespace NPOI.SS.Util
 
         private static double GetCellConetntHeight(double actualHeight, int numberOfRowsInMergedRegion)
         {
-            //for some reason the height of the content that Graphics object measures comes back
-            //with a little bit of extra padding.  This is a hack to get the height back to what it should be.
-            double ratioToFixHeight = 0.798;
-
-            return Math.Max(-1, actualHeight / numberOfRowsInMergedRegion * ratioToFixHeight);
+            return Math.Max(-1, actualHeight / numberOfRowsInMergedRegion);
         }
 
         private static string GetCellStringValue(ICell cell)
@@ -416,33 +412,20 @@ namespace NPOI.SS.Util
 
         private static double GetRotatedContentHeight(ICell cell, string stringValue, Font windowsFont)
         {
-            using (Bitmap bmp = new Bitmap(1, 1))
-            {
-                using (Graphics g = Graphics.FromImage(bmp))
-                {
-                    var angle = cell.CellStyle.Rotation * 2.0 * Math.PI / 360.0;
-                    var measureResult = g.MeasureString(stringValue, windowsFont);
+            var angle = cell.CellStyle.Rotation * 2.0 * Math.PI / 360.0;
+            var measureResult = TextMeasurer.Measure(stringValue, new TextOptions(windowsFont));
 
-                    var x1 = Math.Abs(measureResult.Height * Math.Cos(angle));
-                    var x2 = Math.Abs(measureResult.Width * Math.Sin(angle));
+            var x1 = Math.Abs(measureResult.Height * Math.Cos(angle));
+            var x2 = Math.Abs(measureResult.Width * Math.Sin(angle));
 
-                    return Math.Round(x1 + x2, 0, MidpointRounding.ToEven); ;  
-                }
-            }
+            return Math.Round(x1 + x2, 0, MidpointRounding.ToEven);
         }
 
         private static double GetContentHeight(string stringValue, Font windowsFont)
         {
-
-            using (Bitmap bmp = new Bitmap(1, 1))
-            {
-                using (Graphics g = Graphics.FromImage(bmp))
-                {
-                    SizeF measureResult = g.MeasureString(stringValue, windowsFont, int.MaxValue, StringFormat.GenericTypographic);
-
-                    return Math.Round(measureResult.Height, 0, MidpointRounding.ToEven);  
-                }
-            }
+            var measureResult = TextMeasurer.Measure(stringValue, new TextOptions(windowsFont));
+            
+            return Math.Round(measureResult.Height, 0, MidpointRounding.ToEven);
         }
 
         /**

--- a/ooxml/XSSF/Streaming/SXSSFSheet.cs
+++ b/ooxml/XSSF/Streaming/SXSSFSheet.cs
@@ -1428,5 +1428,15 @@ namespace NPOI.XSSF.Streaming
         {
             throw new NotImplementedException();
         }
+
+        public void AutoSizeRow(int row)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AutoSizeRow(int row, bool useMergedCells)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -543,7 +543,6 @@ namespace NPOI.XSSF.UserModel
             
             if (height != -1 && height != 0)
             {
-
                 height *= 20;
 
                 int maxRowHeight = 409 * 20; // The maximum row height for an individual cell is 409 points

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -508,7 +508,6 @@ namespace NPOI.XSSF.UserModel
             }
         }
 
-
         /**
          * Adjusts the row height to fit the contents.
          *
@@ -538,19 +537,23 @@ namespace NPOI.XSSF.UserModel
          */
         public void AutoSizeRow(int row, bool useMergedCells)
         {
+            var targetRow = GetRow(row) ?? CreateRow(row);
+
             double height = SheetUtil.GetRowHeight(this, row, useMergedCells);
-            height *= 20;
             
             if (height != -1 && height != 0)
             {
-                int maxRowHeight = 409; // The maximum row height for an individual cell is 409 points
+
+                height *= 20;
+
+                int maxRowHeight = 409 * 20; // The maximum row height for an individual cell is 409 points
                 
                 if (height > maxRowHeight)
                 {
                     height = maxRowHeight;
                 }
-                
-                GetRow(row).Height = (short)height;
+
+                targetRow.Height = (short)height;
             }
         }
 

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -507,6 +507,53 @@ namespace NPOI.XSSF.UserModel
                 columnHelper.SetColBestFit(column, true);
             }
         }
+
+
+        /**
+         * Adjusts the row height to fit the contents.
+         *
+         * This process can be relatively slow on large sheets, so this should
+         *  normally only be called once per row, at the end of your
+         *  Processing.
+         *
+         * @param row the row index
+         */
+        public void AutoSizeRow(int row)
+        {
+            AutoSizeRow(row, false);
+        }
+
+        /**
+         * Adjusts the row height to fit the contents.
+         * <p>
+         * This process can be relatively slow on large sheets, so this should
+         *  normally only be called once per row, at the end of your
+         *  Processing.
+         * </p>
+         * You can specify whether the content of merged cells should be considered or ignored.
+         *  Default is to ignore merged cells.
+         *
+         * @param row the row index
+         * @param useMergedCells whether to use the contents of merged cells when calculating the height of the row
+         */
+        public void AutoSizeRow(int row, bool useMergedCells)
+        {
+            double height = SheetUtil.GetRowHeight(this, row, useMergedCells);
+            height *= 20;
+            
+            if (height != -1 && height != 0)
+            {
+                int maxRowHeight = 409; // The maximum row height for an individual cell is 409 points
+                
+                if (height > maxRowHeight)
+                {
+                    height = maxRowHeight;
+                }
+                
+                GetRow(row).Height = (short)height;
+            }
+        }
+
         XSSFDrawing drawing = null;
         /**
          * Return the sheet's existing Drawing, or null if there isn't yet one.

--- a/testcases/main/HSSF/UserModel/TestHSSFSheet.cs
+++ b/testcases/main/HSSF/UserModel/TestHSSFSheet.cs
@@ -849,7 +849,7 @@ namespace TestCases.HSSF.UserModel
             sheet.AutoSizeRow(row.RowNum);
 
             Assert.AreNotEqual(100, row.Height);
-            Assert.AreEqual(478, row.Height);
+            Assert.AreEqual(460, row.Height);
 
             workbook.Close();
         }

--- a/testcases/main/HSSF/UserModel/TestHSSFSheet.cs
+++ b/testcases/main/HSSF/UserModel/TestHSSFSheet.cs
@@ -830,6 +830,31 @@ namespace TestCases.HSSF.UserModel
 
             wb.Close();
         }
+
+
+        [Test]
+        public void TestAutoSizeRow()
+        {
+            HSSFWorkbook workbook = new HSSFWorkbook();
+            ISheet sheet = workbook.CreateSheet("Sheet 1");
+
+            var row = sheet.CreateRow(0);
+            var cell = row.CreateCell(13);
+            cell.SetCellValue("test");
+            var font = cell.CellStyle.GetFont(workbook);
+            font.FontHeightInPoints = 20;
+            cell.CellStyle.SetFont(font);
+            row.Height = 100;
+
+            sheet.AutoSizeRow(row.RowNum);
+
+            Assert.AreNotEqual(100, row.Height);
+            Assert.AreEqual(478, row.Height);
+
+            workbook.Close();
+        }
+
+
         ///**
         // * Setting ForceFormulaRecalculation on sheets
         // */

--- a/testcases/main/SS/Util/TestSheetUtil.cs
+++ b/testcases/main/SS/Util/TestSheetUtil.cs
@@ -153,5 +153,25 @@ namespace TestCases.SS.Util
             wb.Close();
         }
 
+        [Test]
+        public void testGetRowHeight()
+        {
+            IWorkbook wb = new HSSFWorkbook();
+            ISheet sheet = wb.CreateSheet("sheet");
+            IRow row = sheet.CreateRow(0);
+            ICell cell = row.CreateCell(0);
+            ICell emptyCell = row.CreateCell(1);
+            row.CreateCell(2);
+
+            cell.SetCellValue("sometext");
+
+            Assert.IsTrue(SheetUtil.GetCellHeight(cell, false) > 0, "Having some height for a cell with content");
+            Assert.IsTrue(SheetUtil.GetCellHeight(emptyCell, false) == 0, "Having some height for a cell with content");
+            Assert.IsTrue(SheetUtil.GetRowHeight(sheet, 0, true) > 0, "Having some width for rows with actual cells");
+            Assert.AreEqual(0.0, SheetUtil.GetRowHeight(sheet, 0, true, 1, 2)
+                    , "Not having any widht for rows with all empty cells");
+
+            wb.Close();
+        }
     }
 }

--- a/testcases/main/SS/Util/TestSheetUtil.cs
+++ b/testcases/main/SS/Util/TestSheetUtil.cs
@@ -160,16 +160,35 @@ namespace TestCases.SS.Util
             ISheet sheet = wb.CreateSheet("sheet");
             IRow row = sheet.CreateRow(0);
             ICell cell = row.CreateCell(0);
-            ICell emptyCell = row.CreateCell(1);
+            row.CreateCell(1);
             row.CreateCell(2);
+
+            cell.SetCellValue("sometext");
+            
+            Assert.IsTrue(SheetUtil.GetRowHeight(sheet, 0, true) > 0, "Having some height for a row with a cell with content");
+            Assert.AreEqual(0.0, SheetUtil.GetRowHeight(sheet, 0, true, 1, 2)
+                    , "Not having any height for row with empty cells");
+            Assert.IsTrue(SheetUtil.GetRowHeight(row, true) > 0, "Having some height for a row with a cell with content");
+            Assert.AreEqual(0.0, SheetUtil.GetRowHeight(row, true, 1, 2)
+                    , "Not having any height for row with empty cells");
+
+            wb.Close();
+        }
+
+
+        [Test]
+        public void testCellHeight()
+        {
+            IWorkbook wb = new HSSFWorkbook();
+            ISheet sheet = wb.CreateSheet("sheet");
+            IRow row = sheet.CreateRow(0);
+            ICell cell = row.CreateCell(0);
+            ICell emptyCell = row.CreateCell(1);
 
             cell.SetCellValue("sometext");
 
             Assert.IsTrue(SheetUtil.GetCellHeight(cell, false) > 0, "Having some height for a cell with content");
-            Assert.IsTrue(SheetUtil.GetCellHeight(emptyCell, false) == 0, "Having some height for a cell with content");
-            Assert.IsTrue(SheetUtil.GetRowHeight(sheet, 0, true) > 0, "Having some width for rows with actual cells");
-            Assert.AreEqual(0.0, SheetUtil.GetRowHeight(sheet, 0, true, 1, 2)
-                    , "Not having any widht for rows with all empty cells");
+            Assert.AreEqual(0.0, SheetUtil.GetCellHeight(emptyCell, false), "Not having any height for a cell with no content");
 
             wb.Close();
         }

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
@@ -116,6 +116,7 @@ namespace TestCases.XSSF.UserModel
 
             wb2.Close();
         }
+        
         [Test]
         public void TestGetAllHeadersFooters()
         {
@@ -174,6 +175,27 @@ namespace TestCases.XSSF.UserModel
             workbook.Close();
         }
 
+        [Test]
+        public void TestAutoSizeRow()
+        {
+            XSSFWorkbook workbook = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)workbook.CreateSheet("Sheet 1");
+
+            var row = sheet.CreateRow(0);
+            var cell = row.CreateCell(13);
+            cell.SetCellValue("test");
+            var font = cell.CellStyle.GetFont(workbook);
+            font.FontHeightInPoints = 20;
+            cell.CellStyle.SetFont(font);
+            row.Height = 100;
+            
+            sheet.AutoSizeRow(row.RowNum);
+
+            Assert.AreNotEqual(100, row.Height);
+            Assert.AreEqual(525, row.Height);
+
+            workbook.Close();
+        }
 
         [Test]
         public void TestSetCellComment()

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
@@ -192,7 +192,7 @@ namespace TestCases.XSSF.UserModel
             sheet.AutoSizeRow(row.RowNum);
 
             Assert.AreNotEqual(100, row.Height);
-            Assert.AreEqual(525, row.Height);
+            Assert.AreEqual(500, row.Height);
 
             workbook.Close();
         }


### PR DESCRIPTION
There was AutoSizeColumn method, that adjusts width of the column to fit it's contents, but no such method to adjust the height of the row. This change implements such a method in a very similar to AutoSizeColumn way. It also adds a tests for new methods.