### PR TITLE
fix #909

### DIFF
--- a/OpenXmlFormats/Wordprocessing/Paragraph.cs
+++ b/OpenXmlFormats/Wordprocessing/Paragraph.cs
@@ -7456,8 +7456,16 @@ cnfStyleField == null;
             CT_Br ctObj = new CT_Br();
             if (node.Attributes["w:type"] != null)
                 ctObj.type = (ST_BrType)Enum.Parse(typeof(ST_BrType), node.Attributes["w:type"].Value);
+            else
+                ctObj.type = ST_BrType.textWrapping; // Default value as http://officeopenxml.com/WPtextSpecialContent-break.php
+
             if (node.Attributes["w:clear"] != null)
                 ctObj.clear = (ST_BrClear)Enum.Parse(typeof(ST_BrClear), node.Attributes["w:clear"].Value);
+            else
+            {
+                if (ctObj.type == ST_BrType.textWrapping)
+                    ctObj.clear = ST_BrClear.none;
+            }
             return ctObj;
         }
 


### PR DESCRIPTION
Set the default value required by ECMA specification when parsing <w:br> tags. This avoids to unintentionally convert TextWrapping breaks (who are implicit when there is no type attribute) to Page breaks. 