### PR TITLE
Add AddColor method to CT_Font

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Styles/CT_Font.cs
+++ b/OpenXmlFormats/Spreadsheet/Styles/CT_Font.cs
@@ -512,6 +512,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             this.colorField.Add(newColor);
             return newColor;
         }
+        public int AddColor(CT_Color value)
+        {
+            colorField = colorField ?? new List<CT_Color>();
+
+            colorField.Add(value);
+
+            return this.colorField.Count - 1;
+        }
         #endregion color
 
         #region sz

--- a/ooxml/XSSF/UserModel/XSSFFontFormatting.cs
+++ b/ooxml/XSSF/UserModel/XSSFFontFormatting.cs
@@ -108,7 +108,7 @@ namespace NPOI.XSSF.UserModel
                 }
                 else
                 {
-                    _font.SetColorArray(0, xcolor.GetCTColor());
+                    _font.AddColor(xcolor.GetCTColor());
                 }
             }
         }


### PR DESCRIPTION
XSSFFontFormatting.FontColor setter used to set a new color to the CT_Font.colorField list which was not always initialized. This adds a method which first will check if the list is initialized and then adds a color to it. XSSFFontFormatting.FontColor setter now uses this method to set a color.