### PR TITLE
DOLLAR / IF(a>b;c) testcases failures bugfixes

### DIFF
--- a/OpenXmlFormats/Drawing/Chart/Chart.cs
+++ b/OpenXmlFormats/Drawing/Chart/Chart.cs
@@ -18,8 +18,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
     using System.Xml;
     using NPOI.OpenXml4Net.Util;
     using System.Text;
-
-
+    using System.Globalization;
 
     [Serializable]
     
@@ -8944,7 +8943,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             XmlHelper.WriteAttribute(sw, "formatCode", this.formatCode);
             sw.Write(">");
             if (this.v != null)
-                sw.Write(string.Format("<c:v>{0}</c:v>", this.v));
+                sw.Write(string.Format("<c:v>{0}</c:v>", this.v.ToString(CultureInfo.InvariantCulture)));
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 

--- a/main/SS/Formula/Eval/OperandResolver.cs
+++ b/main/SS/Formula/Eval/OperandResolver.cs
@@ -274,7 +274,8 @@ namespace NPOI.SS.Formula.Eval
             //if (Regex.Match(fpRegex, pText).Success)
                 try
                 {
-                    double ret = double.Parse(pText, CultureInfo.CurrentCulture);
+                // Added NumberStyle.Any to parse "$1.00" strings (e.g. DOLLAR function)
+                double ret = double.Parse(pText, NumberStyles.Any, CultureInfo.CurrentCulture);
                     if (double.IsInfinity(ret))
                         return double.NaN;
                     return ret;

--- a/main/SS/Formula/WorkbookEvaluator.cs
+++ b/main/SS/Formula/WorkbookEvaluator.cs
@@ -637,7 +637,7 @@ namespace NPOI.SS.Formula
                                {
                                    // this is an if statement without a false param (as opposed to MissingArgPtg as the false param)
                                    i++;
-                                   stack.Push(arg0);
+                                   //stack.Push(arg0);
                                    stack.Push(BoolEval.FALSE);
                                }
                            }

--- a/testcases/main/SS/Formula/Functions/TestNumericFunction.cs
+++ b/testcases/main/SS/Formula/Functions/TestNumericFunction.cs
@@ -20,8 +20,8 @@ namespace TestCases.SS.Formula.Functions
             //the following INT(-880000000.0001) resulting in -880000001.0 has been observed in excel
             //see also https://support.microsoft.com/en-us/office/int-function-a6c4af9e-356d-4369-ab6a-cb1fd9d343ef
             SS.Util.Utils.AssertDouble(fe, cell, "INT(-880000000.0001)", -880000001.0);
-            SS.Util.Utils.AssertDouble(fe, cell, "880000000*0.00849", 7471200.0);
-            SS.Util.Utils.AssertDouble(fe, cell, "880000000*0.00849/3", 2490400.0);
+            SS.Util.Utils.AssertDouble(fe, cell, "880000000*0.00849", 7471200.0, 0.000000001);
+            SS.Util.Utils.AssertDouble(fe, cell, "880000000*0.00849/3", 2490400.0, 0.000000001);
             SS.Util.Utils.AssertDouble(fe, cell, "INT(880000000*0.00849/3)", 2490400.0);
         }
 

--- a/testcases/ooxml/XSSF/Extractor/TestXSSFExcelExtractor.cs
+++ b/testcases/ooxml/XSSF/Extractor/TestXSSFExcelExtractor.cs
@@ -68,11 +68,11 @@ namespace TestCases.XSSF.Extractor
                 "elit\t888\n" +
                 "Nunc\t999\n";
             String CHUNK2 =
-                "The quick brown fox jumps over the lazy dog\n" +
-                "\thello, xssf\t\thello, xssf\n" +
-                "\thello, xssf\t\thello, xssf\n" +
-                "\thello, xssf\t\thello, xssf\n" +
-                "\thello, xssf\t\thello, xssf\n";
+                "The quick brown fox jumps over the lazy dog\n\t" +
+                "hello, xssf		hello, xssf\n\t" +
+                "hello, xssf		hello, xssf\n\t" +
+                "hello, xssf		hello, xssf\n\t" +
+                "hello, xssf		hello, xssf\n";
             Assert.AreEqual(
                     CHUNK1 +
                     "at\t4995\n" +


### PR DESCRIPTION
Formulas:
- fixed DOLLAR testcase function failure (parsing of Operand with $1.00 string)
- fixed IF without third argument testcase failure because the stack had 2 arguments (only the default result FALSE, shall be pushed). The testcases succeeds, but it is strange that the bug has been unnoticed before. Please double-check!

Testcases Numeric Function:
- Added delta 10^-9 for rounding errors failures