### PR TITLE
Update Chart.cs

### DIFF
--- a/OpenXmlFormats/Drawing/Chart/Chart.cs
+++ b/OpenXmlFormats/Drawing/Chart/Chart.cs
@@ -18,8 +18,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
     using System.Xml;
     using NPOI.OpenXml4Net.Util;
     using System.Text;
-
-
+    using System.Globalization;
 
     [Serializable]
     
@@ -8944,7 +8943,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             XmlHelper.WriteAttribute(sw, "formatCode", this.formatCode);
             sw.Write(">");
             if (this.v != null)
-                sw.Write(string.Format("<c:v>{0}</c:v>", this.v));
+                sw.Write(string.Format("<c:v>{0}</c:v>", this.v.ToString(CultureInfo.InvariantCulture));
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 


### PR DESCRIPTION
fix for #930 and #376 : force invariant culture as non-english version of Excel expect "1.23" format for 1.23 double and the double->string conversion is dependent on current culture, resulting in "1,23" being generated in the XML.

Ran the testsuite with no regressions on charts:
![image](https://user-images.githubusercontent.com/6236243/197042262-2b2990b6-8f50-47c8-9794-8f116ab1081d.png)

