### PR TITLE
Add correction to row height and column width obtained in SheetUtil methods

### DIFF
--- a/OpenXmlFormats/Drawing/Chart/Chart.cs
+++ b/OpenXmlFormats/Drawing/Chart/Chart.cs
@@ -8943,7 +8943,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             XmlHelper.WriteAttribute(sw, "formatCode", this.formatCode);
             sw.Write(">");
             if (this.v != null)
-                sw.Write(string.Format("<c:v>{0}</c:v>", this.v.ToString(CultureInfo.InvariantCulture));
+                sw.Write(string.Format("<c:v>{0}</c:v>", this.v.ToString(CultureInfo.InvariantCulture)));
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 

--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -364,7 +364,8 @@ namespace NPOI.SS.Util
 
         private static double GetCellConetntHeight(double actualHeight, int numberOfRowsInMergedRegion)
         {
-            return Math.Max(-1, actualHeight / numberOfRowsInMergedRegion);
+            var correction = 1.1;
+            return Math.Max(-1, actualHeight / numberOfRowsInMergedRegion * correction);
         }
 
         private static string GetCellStringValue(ICell cell)
@@ -544,7 +545,8 @@ namespace NPOI.SS.Util
             // entireWidth accounts for leading spaces which is excluded from bounds.getWidth()
             //double frameWidth = bounds.getX() + bounds.getWidth();
             //width = Math.max(width, ((frameWidth / colspan) / defaultCharWidth) + style.getIndention());
-            width = Math.Max(width, (actualWidth / colspan / defaultCharWidth) + cell.CellStyle.Indention);
+            var correction = 1.1;
+            width = Math.Max(width, (actualWidth / colspan / defaultCharWidth * correction) + cell.CellStyle.Indention);
             return width;
         }
 

--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -355,7 +355,7 @@ namespace NPOI.SS.Util
             {
                 if (region.IsInRange(cell.RowIndex, cell.ColumnIndex))
                 {
-                    return 1 + region.LastColumn - region.FirstColumn;
+                    return 1 + region.LastRow - region.FirstRow;
                 }
             }
 


### PR DESCRIPTION
SixLabors.TextMeasurer measures strings differently than System.Common.Drawing did. The corrective coefficients here are not 100% accurate either, but they make sure, that cell contents are not cut off. The coefficient's values were tweaked by testing them on sizable sample of test strings with different fonts, font sizes and string lengths (and heights in case of multi-line strings). Accuracy will vary depending on font size and font itself, but on average accuracy is improved for most cases.

Fix incorrect number of rows count in merged region returned by GetNumberOfRowsInMergedRegion method:
Due to copy-paste it was actually returning a number of columns.