### PR TITLE
Fixes internationalization bugs #930 #944 #376

### DIFF
--- a/OpenXmlFormats/Drawing/Chart/Chart.cs
+++ b/OpenXmlFormats/Drawing/Chart/Chart.cs
@@ -8943,7 +8943,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             XmlHelper.WriteAttribute(sw, "formatCode", this.formatCode);
             sw.Write(">");
             if (this.v != null)
-                sw.Write(string.Format("<c:v>{0}</c:v>", this.v.ToString(CultureInfo.InvariantCulture)));
+                sw.Write(string.Format("<c:v>{0}</c:v>", this.v.ToString()));
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 

--- a/ooxml/XSSF/UserModel/Charts/XSSFChartUtil.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFChartUtil.cs
@@ -134,7 +134,7 @@ namespace NPOI.XSSF.UserModel.Charts
                 {
                     CT_NumVal ctNumVal = cache.AddNewPt();
                     ctNumVal.idx = (uint)(i);
-                    ctNumVal.v = (value.ToString());
+                    ctNumVal.v = (value.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 }
             }
         }

--- a/openxml4Net/OPC/PackagePartName.cs
+++ b/openxml4Net/OPC/PackagePartName.cs
@@ -475,7 +475,7 @@ namespace NPOI.OpenXml4Net.OPC
                 String fragment = this.partNameURI.OriginalString;
                 if (fragment.Length > 0)
                 {
-                    int i = fragment.LastIndexOf(".");
+                    int i = fragment.LastIndexOf(".", StringComparison.Ordinal);
                     if (i > -1)
                         return fragment.Substring(i + 1);
                 }

--- a/openxml4Net/OPC/PackagingUriHelper.cs
+++ b/openxml4Net/OPC/PackagingUriHelper.cs
@@ -198,7 +198,7 @@ namespace NPOI.OpenXml4Net.OPC
         public static String GetFilenameWithoutExtension(Uri uri)
         {
             String filename = GetFilename(uri);
-            int dotIndex = filename.LastIndexOf(".");
+            int dotIndex = filename.LastIndexOf(".", StringComparison.Ordinal);
             if (dotIndex == -1)
                 return filename;
             return filename.Substring(0, dotIndex);

--- a/testcases/openxml4net/TestPackagingURIHelper.cs
+++ b/testcases/openxml4net/TestPackagingURIHelper.cs
@@ -15,8 +15,12 @@
    limitations under the License.
 ==================================================================== */
 using NPOI.OpenXml4Net.OPC;
+using NPOI.OpenXmlFormats;
 using NUnit.Framework;
 using System;
+using System.Globalization;
+using System.Threading;
+
 namespace TestCases.OpenXml4Net.OPC
 {
 
@@ -30,45 +34,51 @@ namespace TestCases.OpenXml4Net.OPC
         [Test]
         public void TestRelativizeUri()
         {
-            Uri Uri1 = new Uri("/word/document.xml", UriKind.Relative);
-            Uri Uri2 = new Uri("/word/media/image1.gif", UriKind.Relative);
-            Uri Uri3 = new Uri("/word/media/image1.gif#Sheet1!A1", UriKind.Relative);
-            Uri Uri4 = new Uri("#'My%20Sheet1'!A1", UriKind.Relative);
+            CultureInfo orig = Thread.CurrentThread.CurrentCulture;
+            foreach (var ci in System.Globalization.CultureInfo.GetCultures(System.Globalization.CultureTypes.NeutralCultures))
+            {
+                Thread.CurrentThread.CurrentCulture = ci;
+                Uri Uri1 = new Uri("/word/document.xml", UriKind.Relative);
+                Uri Uri2 = new Uri("/word/media/image1.gif", UriKind.Relative);
+                Uri Uri3 = new Uri("/word/media/image1.gif#Sheet1!A1", UriKind.Relative);
+                Uri Uri4 = new Uri("#'My%20Sheet1'!A1", UriKind.Relative);
 
-            // Document to image is down a directory
-            Uri retUri1to2 = PackagingUriHelper.RelativizeUri(Uri1, Uri2);
-            Assert.AreEqual("media/image1.gif", retUri1to2.OriginalString);
-            // Image to document is up a directory
-            Uri retUri2to1 = PackagingUriHelper.RelativizeUri(Uri2, Uri1);
-            Assert.AreEqual("../document.xml", retUri2to1.OriginalString);
+                // Document to image is down a directory
+                Uri retUri1to2 = PackagingUriHelper.RelativizeUri(Uri1, Uri2);
+                Assert.AreEqual("media/image1.gif", retUri1to2.OriginalString);
+                // Image to document is up a directory
+                Uri retUri2to1 = PackagingUriHelper.RelativizeUri(Uri2, Uri1);
+                Assert.AreEqual("../document.xml", retUri2to1.OriginalString);
 
-            // Document and CustomXML parts totally different [Julien C.]
-            Uri UriCustomXml = new Uri("/customXml/item1.xml", UriKind.RelativeOrAbsolute);
+                // Document and CustomXML parts totally different [Julien C.]
+                Uri UriCustomXml = new Uri("/customXml/item1.xml", UriKind.RelativeOrAbsolute);
 
-            Uri UriRes = PackagingUriHelper.RelativizeUri(Uri1, UriCustomXml);
-            Assert.AreEqual("../customXml/item1.xml", UriRes.ToString());
+                Uri UriRes = PackagingUriHelper.RelativizeUri(Uri1, UriCustomXml);
+                Assert.AreEqual("../customXml/item1.xml", UriRes.ToString());
 
-            // Document to itself is the same place (empty Uri)
-            Uri retUri2 = PackagingUriHelper.RelativizeUri(Uri1, Uri1);
-            // YK: the line below used to assert empty string which is wrong
-            // if source and target are the same they should be relaitivized as the last segment,
-            // see Bugzilla 51187
-            Assert.AreEqual("document.xml", retUri2.OriginalString);
+                // Document to itself is the same place (empty Uri)
+                Uri retUri2 = PackagingUriHelper.RelativizeUri(Uri1, Uri1);
+                // YK: the line below used to assert empty string which is wrong
+                // if source and target are the same they should be relaitivized as the last segment,
+                // see Bugzilla 51187
+                Assert.AreEqual("document.xml", retUri2.OriginalString);
 
-            // relativization against root
-            Uri root = new Uri("/", UriKind.Relative);
-            UriRes = PackagingUriHelper.RelativizeUri(root, Uri1);
-            Assert.AreEqual("/word/document.xml", UriRes.ToString());
+                // relativization against root
+                Uri root = new Uri("/", UriKind.Relative);
+                UriRes = PackagingUriHelper.RelativizeUri(root, Uri1);
+                Assert.AreEqual("/word/document.xml", UriRes.ToString());
 
-            //Uri compatible with MS Office and OpenOffice: leading slash is Removed
-            UriRes = PackagingUriHelper.RelativizeUri(root, Uri1, true);
-            Assert.AreEqual("word/document.xml", UriRes.ToString());
+                //Uri compatible with MS Office and OpenOffice: leading slash is Removed
+                UriRes = PackagingUriHelper.RelativizeUri(root, Uri1, true);
+                Assert.AreEqual("word/document.xml", UriRes.ToString());
 
-            //preserve Uri fragments
-            UriRes = PackagingUriHelper.RelativizeUri(Uri1, Uri3, true);
-            Assert.AreEqual("media/image1.gif#Sheet1!A1", UriRes.ToString());
-            UriRes = PackagingUriHelper.RelativizeUri(root, Uri4, true);
-            Assert.AreEqual("#'My%20Sheet1'!A1", UriRes.ToString());
+                //preserve Uri fragments
+                UriRes = PackagingUriHelper.RelativizeUri(Uri1, Uri3, true);
+                Assert.AreEqual("media/image1.gif#Sheet1!A1", UriRes.ToString());
+                UriRes = PackagingUriHelper.RelativizeUri(root, Uri4, true);
+                Assert.AreEqual("#'My%20Sheet1'!A1", UriRes.ToString());
+            }
+            Thread.CurrentThread.CurrentCulture = orig;
         }
 
         /**
@@ -77,21 +87,27 @@ namespace TestCases.OpenXml4Net.OPC
         [Test]
         public void TestCreatePartNameRelativeString()
         {
-            PackagePartName partNameToValid = PackagingUriHelper
+            CultureInfo orig = Thread.CurrentThread.CurrentCulture;
+            foreach (var ci in System.Globalization.CultureInfo.GetCultures(System.Globalization.CultureTypes.NeutralCultures))
+            {
+                Thread.CurrentThread.CurrentCulture = ci;
+                PackagePartName partNameToValid = PackagingUriHelper
                     .CreatePartName("/word/media/image1.gif");
 
-            OPCPackage pkg = OPCPackage.Create("DELETEIFEXISTS.docx");
-            // Base part
-            PackagePartName nameBase = PackagingUriHelper
-                    .CreatePartName("/word/document.xml");
-            PackagePart partBase = pkg.CreatePart(nameBase, ContentTypes.XML);
-            // Relative part name
-            PackagePartName relativeName = PackagingUriHelper.CreatePartName(
-                    "media/image1.gif", partBase);
-            Assert.AreEqual(partNameToValid
-                    , relativeName, "The part name must be equal to "
-                    + partNameToValid.Name);
-            pkg.Revert();
+                OPCPackage pkg = OPCPackage.Create("DELETEIFEXISTS.docx");
+                // Base part
+                PackagePartName nameBase = PackagingUriHelper
+                        .CreatePartName("/word/document.xml");
+                PackagePart partBase = pkg.CreatePart(nameBase, ContentTypes.XML);
+                // Relative part name
+                PackagePartName relativeName = PackagingUriHelper.CreatePartName(
+                        "media/image1.gif", partBase);
+                Assert.AreEqual(partNameToValid
+                        , relativeName, "The part name must be equal to "
+                        + partNameToValid.Name);
+                pkg.Revert();
+            }
+            Thread.CurrentThread.CurrentCulture = orig;
         }
 
         /**
@@ -100,20 +116,26 @@ namespace TestCases.OpenXml4Net.OPC
         [Test]
         public void TestCreatePartNameRelativeUri()
         {
-            PackagePartName partNameToValid = PackagingUriHelper
+            CultureInfo orig = Thread.CurrentThread.CurrentCulture;
+            foreach (var ci in System.Globalization.CultureInfo.GetCultures(System.Globalization.CultureTypes.NeutralCultures))
+            {
+                Thread.CurrentThread.CurrentCulture = ci;
+                PackagePartName partNameToValid = PackagingUriHelper
                     .CreatePartName("/word/media/image1.gif");
 
-            OPCPackage pkg = OPCPackage.Create("DELETEIFEXISTS.docx");
-            // Base part
-            PackagePartName nameBase = PackagingUriHelper
-                    .CreatePartName("/word/document.xml");
-            PackagePart partBase = pkg.CreatePart(nameBase, ContentTypes.XML);
-            // Relative part name
-            PackagePartName relativeName = PackagingUriHelper.CreatePartName(
-                    new Uri("media/image1.gif", UriKind.RelativeOrAbsolute), partBase);
-            Assert.AreEqual(partNameToValid, relativeName, "The part name must be equal to "
-                    + partNameToValid.Name);
-            pkg.Revert();
+                OPCPackage pkg = OPCPackage.Create("DELETEIFEXISTS.docx");
+                // Base part
+                PackagePartName nameBase = PackagingUriHelper
+                        .CreatePartName("/word/document.xml");
+                PackagePart partBase = pkg.CreatePart(nameBase, ContentTypes.XML);
+                // Relative part name
+                PackagePartName relativeName = PackagingUriHelper.CreatePartName(
+                        new Uri("media/image1.gif", UriKind.RelativeOrAbsolute), partBase);
+                Assert.AreEqual(partNameToValid, relativeName, "The part name must be equal to "
+                        + partNameToValid.Name);
+                pkg.Revert();
+            }
+            Thread.CurrentThread.CurrentCulture = orig;
         }
         [Test]
         public void TestCreateUriFromString()
@@ -147,5 +169,44 @@ namespace TestCases.OpenXml4Net.OPC
             Assert.AreEqual("javascript:///", uri.ToString());
         }
 
+        [Test]
+        public void TestGetFilenameWithoutExtension()
+        {
+            // Testing fix for th-TH culture see https://github.com/nissl-lab/npoi/issues/944
+            String[] href = {
+                "..\\\\\\cygwin\\home\\yegor\\.vim\\filetype.vim",
+                "..\\Program%20Files\\AGEIA%20Technologies\\v2.3.3\\NxCooking.dll",
+                "file:///D:\\seva\\1981\\r810102ns.mp3",
+                "..\\cygwin\\home\\yegor\\dinom\\%5baccess%5d.2010-10-26.log",
+                "#'Instructions (Text)'!B21",
+                "javascript://" };
+            String[] fileNameNoExt = {
+                "filetype",
+                "NxCooking",
+                "r810102ns",
+                "%5baccess%5d.2010-10-26",
+                "",
+                "" };
+
+            CultureInfo orig = Thread.CurrentThread.CurrentCulture;
+            foreach (var ci in System.Globalization.CultureInfo.GetCultures(System.Globalization.CultureTypes.NeutralCultures))
+            {
+                Thread.CurrentThread.CurrentCulture = ci;
+                for (int idx = 0; idx < href.Length; idx++)
+                {
+                    try
+                    {
+                        Uri Uri = PackagingUriHelper.ToUri(href[idx]);
+                        String fileName = PackagingUriHelper.GetFilenameWithoutExtension(Uri);
+                        Assert.AreEqual(fileNameNoExt[idx], fileName, "GetFilenameWithoutExtension fails with culture : " + ci.Name);
+                    }
+                    catch (UriFormatException)
+                    {
+                        Assert.Fail("Failed to create Uri from " + href[idx]);
+                    }
+                }
+            }
+            Thread.CurrentThread.CurrentCulture = orig;
+        }
     }
 }


### PR DESCRIPTION
This reverts previous incorrect #930 fix.
I have reproduced and tested #930 fix with .net core 6.0 version as follows:
I have used LineChart.cs example with 277 different locales and all files open fine on my italian Excel version. 
The generated files are attached.

During this process I found a bug with locale th-TH which I fixed under #944 
The ru-ru culture bug found, under #376 is also checked and fixed.

[testlinechart-locales.zip](https://github.com/nissl-lab/npoi/files/9893406/testlinechart-locales.zip)
