### PR TITLE
Fix PackageRelationship.GetHashCode Exception because the source can be null

### DIFF
--- a/openxml4Net/OPC/PackageRelationship.cs
+++ b/openxml4Net/OPC/PackageRelationship.cs
@@ -111,8 +111,8 @@ namespace NPOI.OpenXml4Net.OPC
         public override int GetHashCode()
         {
             return this.id.GetHashCode() + this.relationshipType.GetHashCode()
-                    + this.source.GetHashCode() + this.targetMode.GetHashCode()
-                    + this.targetUri.GetHashCode();
+                + this.source?.GetHashCode() ?? 0 + this.targetMode.GetHashCode()
+                + this.targetUri.GetHashCode();
         }
 
         /* Getters */

--- a/testcases/openxml4net/OPC/TestPackageRelationship.cs
+++ b/testcases/openxml4net/OPC/TestPackageRelationship.cs
@@ -1,0 +1,42 @@
+﻿
+using System;
+using System.IO;
+using NPOI.OpenXml4Net.OPC;
+using NPOI.OpenXml4Net.OPC.Internal;
+using NPOI.XWPF.UserModel;
+using TestCases.OpenXml4Net;
+
+namespace TestCases.OPC
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TestPackageRelationship
+    {
+        [Test]
+        public void PackageRelationshipNullSourceGetHashCode()
+        {
+            FileInfo targetFile = OpenXml4NetTestDataSamples.GetOutputFile("TestOpenPackageTMP.docx");
+
+            FileInfo inputFile = OpenXml4NetTestDataSamples.GetSampleFile("TestOpenPackageINPUT.docx");
+            
+            
+            // Copy the input file in the output directory
+            FileHelper.CopyFile(inputFile.FullName, targetFile.FullName);
+            
+
+            // Create a namespace
+            OPCPackage pkg = OPCPackage.OpenOrCreate(targetFile.FullName);
+            var collection = new PackageRelationshipCollection(pkg);
+            Uri baseUri = new Uri("ooxml://npoi.org"); //For test only.
+            var relationShip = collection.AddRelationship(new Uri(baseUri,"/webSettings.xml"), TargetMode.Internal,
+                "http://schemas.openxmlformats.org/officeDocument/2006/relationships/webSettings", "rId4");
+
+            var hashCode = relationShip.GetHashCode();
+            Assert.NotZero(hashCode);
+            
+            pkg.Close();
+            File.Delete(targetFile.FullName);
+        }
+    }
+}


### PR DESCRIPTION
The source can be null. I was stuck by the exception when I want to copy a table row.
To fix the problem, I add a null-condition when getting the hashcode of source.And anohter  null-coalescing operator to return 0 when the hashcode result is null.

``` C#
public override int GetHashCode()
{
    return this.id.GetHashCode() + this.relationshipType.GetHashCode()
        + this.source?.GetHashCode() ?? 0 + this.targetMode.GetHashCode()
        + this.targetUri.GetHashCode();
}

``` 