### PR TITLE
Refactoring XSSFRow

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFRow.cs
+++ b/ooxml/XSSF/UserModel/XSSFRow.cs
@@ -92,13 +92,7 @@ namespace NPOI.XSSF.UserModel
          *
          * @return the XSSFSheet that owns this row
          */
-        public ISheet Sheet
-        {
-            get
-            {
-                return _sheet;
-            }
-        }
+        public ISheet Sheet => _sheet;
 
         /**
          * Cell iterator over the physically defined cells:
@@ -111,10 +105,7 @@ namespace NPOI.XSSF.UserModel
          *
          * @return an iterator over cells in this row.
          */
-        public SortedDictionary<int, ICell>.ValueCollection.Enumerator CellIterator()
-        {
-            return _cells.Values.GetEnumerator();
-        }
+        public SortedDictionary<int, ICell>.ValueCollection.Enumerator CellIterator() => _cells.Values.GetEnumerator();
 
         /**
          * Alias for {@link #cellIterator()} to allow  foreach loops:
@@ -126,10 +117,7 @@ namespace NPOI.XSSF.UserModel
          *
          * @return an iterator over cells in this row.
          */
-        public IEnumerator<ICell> GetEnumerator()
-        {
-            return CellIterator();
-        }
+        public IEnumerator<ICell> GetEnumerator() => CellIterator();
 
         /**
          * Compares two <code>XSSFRow</code> objects.  Two rows are equal if they belong to the same worksheet and
@@ -175,10 +163,7 @@ namespace NPOI.XSSF.UserModel
                    (Sheet == other.Sheet);
         }
 
-        public override int GetHashCode()
-        {
-            return _row.GetHashCode();
-        }
+        public override int GetHashCode() => _row.GetHashCode();
 
         /**
          * Use this to create new cells within the row and return it.
@@ -191,10 +176,7 @@ namespace NPOI.XSSF.UserModel
          * @throws ArgumentException if columnIndex < 0 or greater than 16384,
          *   the maximum number of columns supported by the SpreadsheetML format (.xlsx)
          */
-        public ICell CreateCell(int columnIndex)
-        {
-            return CreateCell(columnIndex, CellType.Blank);
-        }
+        public ICell CreateCell(int columnIndex) => CreateCell(columnIndex, CellType.Blank);
 
         /**
          * Use this to create new cells within the row and return it.
@@ -242,10 +224,7 @@ namespace NPOI.XSSF.UserModel
          *
          * @return the cell at the given (0 based) index
          */
-        public ICell GetCell(int cellnum)
-        {
-            return GetCell(cellnum, _sheet.Workbook.MissingCellPolicy);
-        }
+        public ICell GetCell(int cellnum) => GetCell(cellnum, _sheet.Workbook.MissingCellPolicy);
         /// <summary>
         /// Get the hssfcell representing a given column (logical cell)
         /// 0-based. If you ask for a cell that is not defined, then
@@ -294,28 +273,16 @@ namespace NPOI.XSSF.UserModel
             }
         }
 
-        private int GetFirstKey()
-        {
-            return _cells.Keys.Min();
-        }
+        private int GetFirstKey() => _cells.Keys.Min();
 
-        private int GetLastKey()
-        {
-            return _cells.Keys.Max();
-        }
+        private int GetLastKey() => _cells.Keys.Max();
         /**
          * Get the number of the first cell Contained in this row.
          *
          * @return short representing the first logical cell in the row,
          *  or -1 if the row does not contain any cells.
          */
-        public short FirstCellNum
-        {
-            get
-            {
-                return (short)(_cells.Count == 0 ? -1 : GetFirstKey());
-            }
-        }
+        public short FirstCellNum => (short)(_cells.Count == 0 ? -1 : GetFirstKey());
 
         /**
          * Gets the index of the last cell Contained in this row <b>PLUS ONE</b>. The result also
@@ -336,13 +303,7 @@ namespace NPOI.XSSF.UserModel
          * @return short representing the last logical cell in the row <b>PLUS ONE</b>,
          *   or -1 if the row does not contain any cells.
          */
-        public short LastCellNum
-        {
-            get
-            {
-                return (short)(_cells.Count == 0 ? -1 : (GetLastKey() + 1));
-            }
-        }
+        public short LastCellNum => (short)(_cells.Count == 0 ? -1 : (GetLastKey() + 1));
 
         /**
          * Get the row's height measured in twips (1/20th of a point). If the height is not Set, the default worksheet value is returned,
@@ -352,10 +313,7 @@ namespace NPOI.XSSF.UserModel
          */
         public short Height
         {
-            get
-            {
-                return (short)(HeightInPoints * 20);
-            }
+            get => (short)(HeightInPoints * 20);
             set
             {
                 if (value < 0)
@@ -397,10 +355,7 @@ namespace NPOI.XSSF.UserModel
 
                 return _sheet.DefaultRowHeightInPoints;
             }
-            set
-            {
-                Height = (short)(value == -1 ? -1 : (value * 20));
-            }
+            set => Height = (short)(value == -1 ? -1 : (value * 20));
         }
 
         /**
@@ -409,13 +364,7 @@ namespace NPOI.XSSF.UserModel
          *
          * @return int representing the number of defined cells in the row.
          */
-        public int PhysicalNumberOfCells
-        {
-            get
-            {
-                return _cells.Count;
-            }
-        }
+        public int PhysicalNumberOfCells => _cells.Count;
 
         /**
          * Get row number this row represents
@@ -424,10 +373,7 @@ namespace NPOI.XSSF.UserModel
          */
         public int RowNum
         {
-            get
-            {
-                return (int)_row.r - 1;
-            }
+            get => (int)_row.r - 1;
             set
             {
                 var maxrow = SpreadsheetVersion.EXCEL2007.LastRowIndex;
@@ -448,14 +394,8 @@ namespace NPOI.XSSF.UserModel
          */
         public bool ZeroHeight
         {
-            get
-            {
-                return _row.hidden;
-            }
-            set
-            {
-                _row.hidden = value;
-            }
+            get => _row.hidden;
+            set => _row.hidden = value;
         }
 
         /**
@@ -463,13 +403,7 @@ namespace NPOI.XSSF.UserModel
          *  do have whole-row styles. For those that do, you
          *  can get the formatting from {@link #GetRowStyle()}
          */
-        public bool IsFormatted
-        {
-            get
-            {
-                return _row.IsSetS();
-            }
-        }
+        public bool IsFormatted => _row.IsSetS();
         /**
          * Returns the whole-row cell style. Most rows won't
          *  have one of these, so will return null. Call
@@ -559,10 +493,7 @@ namespace NPOI.XSSF.UserModel
          *
          * @return the underlying CT_Row xml bean
          */
-        public CT_Row GetCTRow()
-        {
-            return _row;
-        }
+        public CT_Row GetCTRow() => _row;
 
         /**
          * Fired when the document is written to an output stream.
@@ -611,10 +542,7 @@ namespace NPOI.XSSF.UserModel
         /**
          * @return formatted xml representation of this row
          */
-        public override string ToString()
-        {
-            return _row.ToString();
-        }
+        public override string ToString() => _row.ToString();
 
         /**
          * update cell references when Shifting rows
@@ -737,7 +665,6 @@ namespace NPOI.XSSF.UserModel
         }
 
         #region IRow Members
-
         public List<ICell> Cells
         {
             get
@@ -752,67 +679,32 @@ namespace NPOI.XSSF.UserModel
             }
         }
 
-        public void MoveCell(ICell cell, int newColumn)
-        {
-            throw new NotImplementedException();
-        }
+        public void MoveCell(ICell cell, int newColumn) => throw new NotImplementedException();
 
-        public IRow CopyRowTo(int targetIndex)
-        {
-            return Sheet.CopyRow(RowNum, targetIndex);
-        }
+        public IRow CopyRowTo(int targetIndex) => Sheet.CopyRow(RowNum, targetIndex);
 
-        public ICell CopyCell(int sourceIndex, int targetIndex)
-        {
-            return CellUtil.CopyCell(this, sourceIndex, targetIndex);
-        }
+        public ICell CopyCell(int sourceIndex, int targetIndex) => CellUtil.CopyCell(this, sourceIndex, targetIndex);
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public bool HasCustomHeight()
-        {
-            throw new NotImplementedException();
-        }
+        public bool HasCustomHeight() => throw new NotImplementedException();
 
         public int OutlineLevel
         {
-            get
-            {
-                return _row.outlineLevel;
-            }
-            set
-            {
-                _row.outlineLevel = (byte)value;
-            }
+            get => _row.outlineLevel;
+            set => _row.outlineLevel = (byte)value;
         }
 
         public bool? Hidden
         {
-            get
-            {
-                return _row.hidden;
-            }
-
-            set
-            {
-                _row.hidden = value ?? false;
-            }
+            get => _row.hidden;
+            set => _row.hidden = value ?? false;
         }
 
         public bool? Collapsed
         {
-            get
-            {
-                return _row.collapsed;
-            }
-
-            set
-            {
-                _row.collapsed = value ?? false;
-            }
+            get => _row.collapsed;
+            set => _row.collapsed = value ?? false;
         }
         #endregion
     }

--- a/ooxml/XSSF/UserModel/XSSFRow.cs
+++ b/ooxml/XSSF/UserModel/XSSFRow.cs
@@ -30,34 +30,34 @@ using System.Linq;
 namespace NPOI.XSSF.UserModel
 {
 
-    /**
-     * High level representation of a row of a spreadsheet.
-     */
+    /// <summary>
+    /// High level representation of a row of a spreadsheet.
+    /// </summary>
     public class XSSFRow : IRow, IComparable<XSSFRow>
     {
         private static readonly POILogger _logger = POILogFactory.GetLogger(typeof(XSSFRow));
 
-        /**
-         * the xml bean Containing all cell defInitions for this row
-         */
+        /// <summary>
+        /// the xml node Containing all cell defInitions for this row
+        /// </summary>
         private readonly CT_Row _row;
 
-        /**
-         * Cells of this row keyed by their column indexes.
-         * The TreeMap ensures that the cells are ordered by columnIndex in the ascending order.
-         */
+        /// <summary>
+        /// Cells of this row keyed by their column indexes.
+        /// The SortedDictionary ensures that the cells are ordered by columnIndex in the ascending order.
+        /// </summary>
         private readonly SortedDictionary<int, ICell> _cells;
-        /**
-         * the parent sheet
-         */
+
+        /// <summary>
+        /// the parent sheet
+        /// </summary>
         private readonly XSSFSheet _sheet;
 
-        /**
-         * Construct a XSSFRow.
-         *
-         * @param row the xml bean Containing all cell defInitions for this row.
-         * @param sheet the parent sheet.
-         */
+        /// <summary>
+        /// Construct an XSSFRow.
+        /// </summary>
+        /// <param name="row">the xml node Containing all cell defInitions for this row.</param>
+        /// <param name="sheet">the parent sheet.</param>
         public XSSFRow(CT_Row row, XSSFSheet sheet)
         {
             _row = row;
@@ -87,59 +87,37 @@ namespace NPOI.XSSF.UserModel
             }
         }
 
-        /**
-         * Returns the XSSFSheet this row belongs to
-         *
-         * @return the XSSFSheet that owns this row
-         */
+        /// <summary>
+        /// XSSFSheet this row belongs to
+        /// </summary>
         public ISheet Sheet => _sheet;
 
-        /**
-         * Cell iterator over the physically defined cells:
-         * <blockquote><pre>
-         * for (Iterator<Cell> it = row.cellIterator(); it.HasNext(); ) {
-         *     Cell cell = it.next();
-         *     ...
-         * }
-         * </pre></blockquote>
-         *
-         * @return an iterator over cells in this row.
-         */
+        /// <summary>
+        /// Cell iterator over the physically defined cell
+        /// </summary>
+        /// <returns>an iterator over cells in this row.</returns>
         public SortedDictionary<int, ICell>.ValueCollection.Enumerator CellIterator() => _cells.Values.GetEnumerator();
 
-        /**
-         * Alias for {@link #cellIterator()} to allow  foreach loops:
-         * <blockquote><pre>
-         * for(Cell cell : row){
-         *     ...
-         * }
-         * </pre></blockquote>
-         *
-         * @return an iterator over cells in this row.
-         */
+        /// <summary>
+        /// Alias for <see cref="CellIterator"/> to allow  foreach loops
+        /// </summary>
+        /// <returns>an iterator over cells in this row.</returns>
         public IEnumerator<ICell> GetEnumerator() => CellIterator();
 
-        /**
-         * Compares two <code>XSSFRow</code> objects.  Two rows are equal if they belong to the same worksheet and
-         * their row indexes are equal.
-         *
-         * @param   row   the <code>XSSFRow</code> to be compared.
-         * @return  <ul>
-         *      <li>
-         *      the value <code>0</code> if the row number of this <code>XSSFRow</code> is
-         *      equal to the row number of the argument <code>XSSFRow</code>
-         *      </li>
-         *      <li>
-         *      a value less than <code>0</code> if the row number of this this <code>XSSFRow</code> is
-         *      numerically less than the row number of the argument <code>XSSFRow</code>
-         *      </li>
-         *      <li>
-         *      a value greater than <code>0</code> if the row number of this this <code>XSSFRow</code> is
-         *      numerically greater than the row number of the argument <code>XSSFRow</code>
-         *      </li>
-         *      </ul>
-         * @throws IllegalArgumentException if the argument row belongs to a different worksheet
-         */
+        /// <summary>
+        /// Compares two <see cref="XSSFRow"/> objects. Two rows are equal if they belong to the 
+        /// same worksheet and their row indexes are equal.
+        /// </summary>
+        /// <param name="other">the <see cref="XSSFRow"/> to be compared.</param>
+        /// <returns>
+        /// the value 0 if the row number of this <see cref="XSSFRow"/> is
+        /// equal to the row number of the argument <see cref="XSSFRow"/>
+        /// a value less than 0 if the row number of this this <see cref="XSSFRow"/> is
+        /// numerically less than the row number of the argument <see cref="XSSFRow"/>
+        /// a value greater than 0 if the row number of this this <see cref="XSSFRow"/> is
+        /// numerically greater than the row number of the argument <see cref="XSSFRow"/>
+        /// </returns>
+        /// <exception cref="ArgumentException">if the argument row belongs to a different worksheet</exception>
         public int CompareTo(XSSFRow other)
         {
             if (Sheet != other.Sheet)
@@ -165,34 +143,25 @@ namespace NPOI.XSSF.UserModel
 
         public override int GetHashCode() => _row.GetHashCode();
 
-        /**
-         * Use this to create new cells within the row and return it.
-         * <p>
-         * The cell that is returned is a {@link Cell#CELL_TYPE_BLANK}. The type can be Changed
-         * either through calling <code>SetCellValue</code> or <code>SetCellType</code>.
-         * </p>
-         * @param columnIndex - the column number this cell represents
-         * @return Cell a high level representation of the Created cell.
-         * @throws ArgumentException if columnIndex < 0 or greater than 16384,
-         *   the maximum number of columns supported by the SpreadsheetML format (.xlsx)
-         */
+        /// <summary>
+        /// Use this to create new cells within the row and return it.
+        /// The cell that is returned is a <see cref="CellType.Blank"/>. The type can be Changed
+        /// either through calling <see cref="ICell.SetCellValue"/> or <see cref="ICell.SetCellType"/>.
+        /// </summary>
+        /// <param name="columnIndex">the column number this cell represents</param>
+        /// <returns>a high level representation of the Created cell</returns>
+        /// <exception cref="ArgumentException">if columnIndex is less than 0 or greater than 16384, 
+        /// the maximum number of columns supported by the SpreadsheetML format(.xlsx)</exception>
         public ICell CreateCell(int columnIndex) => CreateCell(columnIndex, CellType.Blank);
 
-        /**
-         * Use this to create new cells within the row and return it.
-         *
-         * @param columnIndex - the column number this cell represents
-         * @param type - the cell's data type
-         * @return XSSFCell a high level representation of the Created cell.
-         * @throws ArgumentException if the specified cell type is invalid, columnIndex < 0
-         *   or greater than 16384, the maximum number of columns supported by the SpreadsheetML format (.xlsx)
-         * @see Cell#CELL_TYPE_BLANK
-         * @see Cell#CELL_TYPE_BOOLEAN
-         * @see Cell#CELL_TYPE_ERROR
-         * @see Cell#CELL_TYPE_FORMULA
-         * @see Cell#CELL_TYPE_NUMERIC
-         * @see Cell#CELL_TYPE_STRING
-         */
+        /// <summary>
+        /// Use this to create new cells within the row and return it.
+        /// </summary>
+        /// <param name="columnIndex">the column number this cell represents</param>
+        /// <param name="type">the cell's data type</param>
+        /// <returns>a high level representation of the Created cell.</returns>
+        /// <exception cref="ArgumentException">if columnIndex is less than 0 or greater than 16384, 
+        /// the maximum number of columns supported by the SpreadsheetML format(.xlsx)</exception>
         public ICell CreateCell(int columnIndex, CellType type)
         {
             CT_Cell ctCell;
@@ -218,13 +187,14 @@ namespace NPOI.XSSF.UserModel
             return xcell;
         }
 
-        /**
-         * Returns the cell at the given (0 based) index,
-         *  with the {@link NPOI.SS.usermodel.Row.MissingCellPolicy} from the parent Workbook.
-         *
-         * @return the cell at the given (0 based) index
-         */
+        /// <summary>
+        /// Returns the cell at the given (0 based) index,
+        /// with the <see cref="MissingCellPolicy"/> from the parent Workbook.
+        /// </summary>
+        /// <param name="cellnum"></param>
+        /// <returns>the cell at the given (0 based) index</returns>
         public ICell GetCell(int cellnum) => GetCell(cellnum, _sheet.Workbook.MissingCellPolicy);
+
         /// <summary>
         /// Get the hssfcell representing a given column (logical cell)
         /// 0-based. If you ask for a cell that is not defined, then
@@ -242,15 +212,14 @@ namespace NPOI.XSSF.UserModel
             //if (cellnum < 0 || cellnum >= cells.Count) return null;
             return _cells[cellnum];
         }
-        /**
-         * Returns the cell at the given (0 based) index, with the specified {@link NPOI.SS.usermodel.Row.MissingCellPolicy}
-         *
-         * @return the cell at the given (0 based) index
-         * @throws ArgumentException if cellnum < 0 or the specified MissingCellPolicy is invalid
-         * @see Row#RETURN_NULL_AND_BLANK
-         * @see Row#RETURN_BLANK_AS_NULL
-         * @see Row#CREATE_NULL_AS_BLANK
-         */
+
+        /// <summary>
+        /// Returns the cell at the given (0 based) index, with the specified <see cref="MissingCellPolicy"/>
+        /// </summary>
+        /// <param name="cellnum"></param>
+        /// <param name="policy"></param>
+        /// <returns>the cell at the given (0 based) index</returns>
+        /// <exception cref="ArgumentException">if cellnum is less than 0 or the specified MissingCellPolicy is invalid</exception>
         public ICell GetCell(int cellnum, MissingCellPolicy policy)
         {
             if (cellnum < 0)
@@ -276,41 +245,29 @@ namespace NPOI.XSSF.UserModel
         private int GetFirstKey() => _cells.Keys.Min();
 
         private int GetLastKey() => _cells.Keys.Max();
-        /**
-         * Get the number of the first cell Contained in this row.
-         *
-         * @return short representing the first logical cell in the row,
-         *  or -1 if the row does not contain any cells.
-         */
+
+        /// <summary>
+        /// Get the number of the first cell Contained in this row.
+        /// </summary>
+        /// <returns>short representing the first logical cell in the row,
+        /// or -1 if the row does not contain any cells.</returns>
         public short FirstCellNum => (short)(_cells.Count == 0 ? -1 : GetFirstKey());
 
-        /**
-         * Gets the index of the last cell Contained in this row <b>PLUS ONE</b>. The result also
-         * happens to be the 1-based column number of the last cell.  This value can be used as a
-         * standard upper bound when iterating over cells:
-         * <pre>
-         * short minColIx = row.GetFirstCellNum();
-         * short maxColIx = row.GetLastCellNum();
-         * for(short colIx=minColIx; colIx&lt;maxColIx; colIx++) {
-         *   XSSFCell cell = row.GetCell(colIx);
-         *   if(cell == null) {
-         *     continue;
-         *   }
-         *   //... do something with cell
-         * }
-         * </pre>
-         *
-         * @return short representing the last logical cell in the row <b>PLUS ONE</b>,
-         *   or -1 if the row does not contain any cells.
-         */
+        /// <summary>
+        /// Gets the index of the last cell Contained in this row <b>PLUS ONE</b>. The result also
+        /// happens to be the 1-based column number of the last cell. This value can be used as a
+        /// standard upper bound when iterating over cells:
+        /// </summary>
+        /// <returns>short representing the last logical cell in the row <b>PLUS ONE</b>,
+        /// or -1 if the row does not contain any cells.</returns>
         public short LastCellNum => (short)(_cells.Count == 0 ? -1 : (GetLastKey() + 1));
 
-        /**
-         * Get the row's height measured in twips (1/20th of a point). If the height is not Set, the default worksheet value is returned,
-         * See {@link NPOI.XSSF.usermodel.XSSFSheet#GetDefaultRowHeightInPoints()}
-         *
-         * @return row height measured in twips (1/20th of a point)
-         */
+        /// <summary>
+        /// Get the row's height measured in twips (1/20th of a point). 
+        /// If the height is not Set, the default worksheet value is returned,
+        /// See <see cref="XSSFSheet.DefaultRowHeight"/>
+        /// </summary>
+        /// <returns>row height measured in twips (1/20th of a point)</returns>
         public short Height
         {
             get => (short)(HeightInPoints * 20);
@@ -337,13 +294,10 @@ namespace NPOI.XSSF.UserModel
             }
         }
 
-        /**
-         * Returns row height measured in point size. If the height is not Set, the default worksheet value is returned,
-         * See {@link NPOI.XSSF.usermodel.XSSFSheet#GetDefaultRowHeightInPoints()}
-         *
-         * @return row height measured in point size
-         * @see NPOI.XSSF.usermodel.XSSFSheet#GetDefaultRowHeightInPoints()
-         */
+        /// <summary>
+        /// Returns row height measured in point size. If the height is not Set, 
+        /// the default worksheet value is returned,See <see cref="XSSFSheet.DefaultRowHeightInPoints"/>
+        /// </summary>
         public float HeightInPoints
         {
             get
@@ -358,19 +312,17 @@ namespace NPOI.XSSF.UserModel
             set => Height = (short)(value == -1 ? -1 : (value * 20));
         }
 
-        /**
-         * Gets the number of defined cells (NOT number of cells in the actual row!).
-         * That is to say if only columns 0,4,5 have values then there would be 3.
-         *
-         * @return int representing the number of defined cells in the row.
-         */
+        /// <summary>
+        /// Gets the number of defined cells (NOT number of cells in the actual row!).
+        /// That is to say if only columns 0,4,5 have values then there would be 3.
+        /// </summary>
+        /// <returns>int representing the number of defined cells in the row.</returns>
         public int PhysicalNumberOfCells => _cells.Count;
 
-        /**
-         * Get row number this row represents
-         *
-         * @return the row number (0 based)
-         */
+        /// <summary>
+        /// Get row number this row represents
+        /// </summary>
+        /// <returns>the row number (0 based)</returns>
         public int RowNum
         {
             get => (int)_row.r - 1;
@@ -387,28 +339,27 @@ namespace NPOI.XSSF.UserModel
             }
         }
 
-        /**
-         * Get whether or not to display this row with 0 height
-         *
-         * @return - height is zero or not.
-         */
+        /// <summary>
+        /// Get whether or not to display this row with 0 height
+        /// </summary>
         public bool ZeroHeight
         {
             get => _row.hidden;
             set => _row.hidden = value;
         }
 
-        /**
-         * Is this row formatted? Most aren't, but some rows
-         *  do have whole-row styles. For those that do, you
-         *  can get the formatting from {@link #GetRowStyle()}
-         */
+        /// <summary>
+        /// Is this row formatted? Most aren't, but some rows
+        /// do have whole-row styles. For those that do, you
+        /// can get the formatting from <see cref="RowStyle"/>
+        /// </summary>
         public bool IsFormatted => _row.IsSetS();
-        /**
-         * Returns the whole-row cell style. Most rows won't
-         *  have one of these, so will return null. Call
-         *  {@link #isFormatted()} to check first.
-         */
+
+        /// <summary>
+        /// Returns the whole-row cell style. Most rows won't
+        /// have one of these, so will return null. Call
+        /// <see cref="IsFormatted"/> to check first.
+        /// </summary>
         public ICellStyle RowStyle
         {
             get
@@ -452,21 +403,22 @@ namespace NPOI.XSSF.UserModel
             }
         }
 
-        /**
-         * Applies a whole-row cell styling to the row.
-         * If the value is null then the style information is Removed,
-         *  causing the cell to used the default workbook style.
-         */
+        /// <summary>
+        /// Applies a whole-row cell styling to the row.
+        /// If the value is null then the style information is Removed,
+        /// causing the cell to used the default workbook style.
+        /// </summary>
+        /// <param name="style"></param>
         public void SetRowStyle(ICellStyle style)
         {
 
         }
-
-        /**
-         * Remove the Cell from this row.
-         *
-         * @param cell the cell to remove
-         */
+        
+        /// <summary>
+        /// Remove the Cell from this row.
+        /// </summary>
+        /// <param name="cell">the cell to remove</param>
+        /// <exception cref="ArgumentException"></exception>
         public void RemoveCell(ICell cell)
         {
             if (cell.Row != this)
@@ -487,19 +439,17 @@ namespace NPOI.XSSF.UserModel
 
             _cells.Remove(cell.ColumnIndex);
         }
-
-        /**
-         * Returns the underlying CT_Row xml bean Containing all cell defInitions in this row
-         *
-         * @return the underlying CT_Row xml bean
-         */
+        
+        /// <summary>
+        /// Returns the underlying CT_Row xml node Containing all cell defInitions in this row
+        /// </summary>
+        /// <returns>the underlying CT_Row xml node</returns>
         public CT_Row GetCTRow() => _row;
 
-        /**
-         * Fired when the document is written to an output stream.
-         *
-         * @see NPOI.XSSF.usermodel.XSSFSheet#Write(java.io.OutputStream) ()
-         */
+        /// <summary>
+        /// Fired when the document is written to an output stream.
+        /// See <see cref="XSSFSheet.Write"/>
+        /// </summary>
         internal void OnDocumentWrite()
         {
             // check if cells in the CT_Row are ordered
@@ -538,17 +488,17 @@ namespace NPOI.XSSF.UserModel
                 _row.SetCArray(cArray);
             }
         }
-
-        /**
-         * @return formatted xml representation of this row
-         */
+        
+        /// <summary>
+        /// formatted xml representation of this row
+        /// </summary>
+        /// <returns>formatted xml representation of this row</returns>
         public override string ToString() => _row.ToString();
 
-        /**
-         * update cell references when Shifting rows
-         *
-         * @param n the number of rows to move
-         */
+        /// <summary>
+        /// update cell references when Shifting rows
+        /// </summary>
+        /// <param name="n">n the number of rows to move</param>
         internal void Shift(int n)
         {
             var rownum = RowNum + n;
@@ -578,15 +528,15 @@ namespace NPOI.XSSF.UserModel
             RowNum = rownum;
         }
 
-        /**
-         * Copy the cells from srcRow to this row
-         * If this row is not a blank row, this will merge the two rows, overwriting
-         * the cells in this row with the cells in srcRow
-         * If srcRow is null, overwrite cells in destination row with blank values, styles, etc per cell copy policy
-         * srcRow may be from a different sheet in the same workbook
-         * @param srcRow the rows to copy from
-         * @param policy the policy to determine what gets copied
-         */
+        /// <summary>
+        /// Copy the cells from srcRow to this row
+        /// If this row is not a blank row, this will merge the two rows, overwriting
+        /// the cells in this row with the cells in srcRow
+        /// If srcRow is null, overwrite cells in destination row with blank values, styles, etc per cell copy policy
+        /// srcRow may be from a different sheet in the same workbook
+        /// </summary>
+        /// <param name="srcRow">the rows to copy from</param>
+        /// <param name="policy">policy the policy to determine what gets copied</param>
         public void CopyRowFrom(IRow srcRow, CellCopyPolicy policy)
         {
             if (srcRow == null)
@@ -687,7 +637,10 @@ namespace NPOI.XSSF.UserModel
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public bool HasCustomHeight() => throw new NotImplementedException();
+        public bool HasCustomHeight()
+        {
+            throw new NotImplementedException();
+        }
 
         public int OutlineLevel
         {

--- a/ooxml/XSSF/UserModel/XSSFRow.cs
+++ b/ooxml/XSSF/UserModel/XSSFRow.cs
@@ -59,14 +59,26 @@ namespace NPOI.XSSF.UserModel
         /// <summary>
         /// XSSFSheet this row belongs to
         /// </summary>
-        public ISheet Sheet => _sheet;
+        public ISheet Sheet
+        {
+            get
+            {
+                return _sheet;
+            }
+        }
 
         /// <summary>
         /// Get the number of the first cell Contained in this row.
         /// </summary>
         /// <returns>short representing the first logical cell in the row,
         /// or -1 if the row does not contain any cells.</returns>
-        public short FirstCellNum => (short)(_cells.Count == 0 ? -1 : GetFirstKey());
+        public short FirstCellNum
+        {
+            get
+            {
+                return (short)(_cells.Count == 0 ? -1 : GetFirstKey());
+            }
+        }
 
         /// <summary>
         /// Gets the index of the last cell Contained in this row <b>PLUS ONE</b>. The result also
@@ -75,7 +87,13 @@ namespace NPOI.XSSF.UserModel
         /// </summary>
         /// <returns>short representing the last logical cell in the row <b>PLUS ONE</b>,
         /// or -1 if the row does not contain any cells.</returns>
-        public short LastCellNum => (short)(_cells.Count == 0 ? -1 : (GetLastKey() + 1));
+        public short LastCellNum
+        {
+            get
+            {
+                return (short)(_cells.Count == 0 ? -1 : (GetLastKey() + 1));
+            }
+        }
 
         /// <summary>
         /// Get the row's height measured in twips (1/20th of a point). 
@@ -85,7 +103,11 @@ namespace NPOI.XSSF.UserModel
         /// <returns>row height measured in twips (1/20th of a point)</returns>
         public short Height
         {
-            get => (short)(HeightInPoints * 20);
+            get
+            {
+                return (short)(HeightInPoints * 20);
+            }
+
             set
             {
                 if (value < 0)
@@ -124,7 +146,10 @@ namespace NPOI.XSSF.UserModel
 
                 return _sheet.DefaultRowHeightInPoints;
             }
-            set => Height = (short)(value == -1 ? -1 : (value * 20));
+            set
+            {
+                Height = (short)(value == -1 ? -1 : (value * 20));
+            }
         }
 
         /// <summary>
@@ -132,7 +157,13 @@ namespace NPOI.XSSF.UserModel
         /// That is to say if only columns 0,4,5 have values then there would be 3.
         /// </summary>
         /// <returns>int representing the number of defined cells in the row.</returns>
-        public int PhysicalNumberOfCells => _cells.Count;
+        public int PhysicalNumberOfCells
+        {
+            get
+            {
+                return _cells.Count;
+            }
+        }
 
         /// <summary>
         /// Get row number this row represents
@@ -140,10 +171,14 @@ namespace NPOI.XSSF.UserModel
         /// <returns>the row number (0 based)</returns>
         public int RowNum
         {
-            get => (int)_row.r - 1;
+            get
+            {
+                return (int)_row.r - 1;
+            }
+
             set
             {
-                var maxrow = SpreadsheetVersion.EXCEL2007.LastRowIndex;
+                int maxrow = SpreadsheetVersion.EXCEL2007.LastRowIndex;
                 if (value < 0 || value > maxrow)
                 {
                     throw new ArgumentException("Invalid row number (" + value
@@ -159,8 +194,15 @@ namespace NPOI.XSSF.UserModel
         /// </summary>
         public bool ZeroHeight
         {
-            get => _row.hidden;
-            set => _row.hidden = value;
+            get
+            {
+                return _row.hidden;
+            }
+
+            set
+            {
+                _row.hidden = value;
+            }
         }
 
         /// <summary>
@@ -168,7 +210,13 @@ namespace NPOI.XSSF.UserModel
         /// do have whole-row styles. For those that do, you
         /// can get the formatting from <see cref="RowStyle"/>
         /// </summary>
-        public bool IsFormatted => _row.IsSetS();
+        public bool IsFormatted
+        {
+            get
+            {
+                return _row.IsSetS();
+            }
+        }
 
         /// <summary>
         /// Returns the whole-row cell style. Most rows won't
@@ -184,7 +232,7 @@ namespace NPOI.XSSF.UserModel
                     return null;
                 }
 
-                var stylesSource = ((XSSFWorkbook)Sheet.Workbook).GetStylesSource();
+                Model.StylesTable stylesSource = ((XSSFWorkbook)Sheet.Workbook).GetStylesSource();
                 if (stylesSource.NumCellStyles > 0)
                 {
                     return stylesSource.GetStyleAt((int)_row.s);
@@ -206,9 +254,9 @@ namespace NPOI.XSSF.UserModel
                 }
                 else
                 {
-                    var styleSource = ((XSSFWorkbook)Sheet.Workbook).GetStylesSource();
+                    Model.StylesTable styleSource = ((XSSFWorkbook)Sheet.Workbook).GetStylesSource();
 
-                    var xStyle = (XSSFCellStyle)value;
+                    XSSFCellStyle xStyle = (XSSFCellStyle)value;
                     xStyle.VerifyBelongsToStylesSource(styleSource);
 
                     long idx = styleSource.PutStyle(xStyle);
@@ -233,9 +281,9 @@ namespace NPOI.XSSF.UserModel
             _cells = new SortedDictionary<int, ICell>();
             if (0 < row.SizeOfCArray())
             {
-                foreach (var c in row.c)
+                foreach (CT_Cell c in row.c)
                 {
-                    var cell = new XSSFCell(this, c);
+                    XSSFCell cell = new XSSFCell(this, c);
                     _cells.Add(cell.ColumnIndex, cell);
                     sheet.OnReadCell(cell);
                 }
@@ -245,7 +293,7 @@ namespace NPOI.XSSF.UserModel
             {
                 // Certain file format writers skip the row number
                 // Assume no gaps, and give this the next row number
-                var nextRowNum = sheet.LastRowNum + 2;
+                int nextRowNum = sheet.LastRowNum + 2;
                 if (nextRowNum == 2 && sheet.PhysicalNumberOfRows == 0)
                 {
                     nextRowNum = 1;
@@ -266,7 +314,10 @@ namespace NPOI.XSSF.UserModel
         /// <returns>a high level representation of the Created cell</returns>
         /// <exception cref="ArgumentException">if columnIndex is less than 0 or greater than 16384, 
         /// the maximum number of columns supported by the SpreadsheetML format(.xlsx)</exception>
-        public ICell CreateCell(int columnIndex) => CreateCell(columnIndex, CellType.Blank);
+        public ICell CreateCell(int columnIndex)
+        {
+            return CreateCell(columnIndex, CellType.Blank);
+        }
 
         /// <summary>
         /// Use this to create new cells within the row and return it.
@@ -279,7 +330,7 @@ namespace NPOI.XSSF.UserModel
         public ICell CreateCell(int columnIndex, CellType type)
         {
             CT_Cell ctCell;
-            var prev = _cells.ContainsKey(columnIndex) ? (XSSFCell)_cells[columnIndex] : null;
+            XSSFCell prev = _cells.ContainsKey(columnIndex) ? (XSSFCell)_cells[columnIndex] : null;
             if (prev != null)
             {
                 ctCell = prev.GetCTCell();
@@ -290,7 +341,7 @@ namespace NPOI.XSSF.UserModel
                 ctCell = _row.AddNewC();
             }
 
-            var xcell = new XSSFCell(this, ctCell);
+            XSSFCell xcell = new XSSFCell(this, ctCell);
             xcell.SetCellNum(columnIndex);
             if (type != CellType.Blank)
             {
@@ -307,7 +358,10 @@ namespace NPOI.XSSF.UserModel
         /// </summary>
         /// <param name="cellnum"></param>
         /// <returns>the cell at the given (0 based) index</returns>
-        public ICell GetCell(int cellnum) => GetCell(cellnum, _sheet.Workbook.MissingCellPolicy);
+        public ICell GetCell(int cellnum)
+        {
+            return GetCell(cellnum, _sheet.Workbook.MissingCellPolicy);
+        }
 
         /// <summary>
         /// Returns the cell at the given (0 based) index, with the specified <see cref="MissingCellPolicy"/>
@@ -323,13 +377,13 @@ namespace NPOI.XSSF.UserModel
                 throw new ArgumentException("Cell index must be >= 0");
             }
 
-            var cell = (XSSFCell)RetrieveCell(cellnum);
+            XSSFCell cell = (XSSFCell)RetrieveCell(cellnum);
             switch (policy)
             {
                 case MissingCellPolicy.RETURN_NULL_AND_BLANK:
                     return cell;
                 case MissingCellPolicy.RETURN_BLANK_AS_NULL:
-                    var isBlank = cell != null && cell.CellType == CellType.Blank;
+                    bool isBlank = cell != null && cell.CellType == CellType.Blank;
                     return isBlank ? null : cell;
                 case MissingCellPolicy.CREATE_NULL_AS_BLANK:
                     return cell ?? CreateCell(cellnum, CellType.Blank);
@@ -350,7 +404,7 @@ namespace NPOI.XSSF.UserModel
                 throw new ArgumentException("Specified cell does not belong to this row");
             }
 
-            var xcell = (XSSFCell)cell;
+            XSSFCell xcell = (XSSFCell)cell;
             if (xcell.IsPartOfArrayFormulaGroup)
             {
                 xcell.NotifyArrayFormulaChanging();
@@ -378,7 +432,7 @@ namespace NPOI.XSSF.UserModel
             if (srcRow == null)
             {
                 // srcRow is blank. Overwrite cells with blank values, blank styles, etc per cell copy policy
-                foreach (var destCell in this)
+                foreach (ICell destCell in this)
                 {
                     XSSFCell srcCell = null;
                     // FIXME: remove type casting when copyCellFrom(Cell, CellCopyPolicy) is added to Cell interface
@@ -388,10 +442,10 @@ namespace NPOI.XSSF.UserModel
                 if (policy.IsCopyMergedRegions)
                 {
                     // Remove MergedRegions in dest row
-                    var destRowNum = RowNum;
-                    var index = 0;
-                    var indices = new HashSet<int>();
-                    foreach (var destRegion in Sheet.MergedRegions)
+                    int destRowNum = RowNum;
+                    int index = 0;
+                    HashSet<int> indices = new HashSet<int>();
+                    foreach (CellRangeAddress destRegion in Sheet.MergedRegions)
                     {
                         if (destRowNum == destRegion.FirstRow && destRowNum == destRegion.LastRow)
                         {
@@ -412,30 +466,30 @@ namespace NPOI.XSSF.UserModel
             }
             else
             {
-                foreach (var c in srcRow)
+                foreach (ICell c in srcRow)
                 {
-                    var srcCell = (XSSFCell)c;
-                    var destCell = CreateCell(srcCell.ColumnIndex, srcCell.CellType) as XSSFCell;
+                    XSSFCell srcCell = (XSSFCell)c;
+                    XSSFCell destCell = CreateCell(srcCell.ColumnIndex, srcCell.CellType) as XSSFCell;
                     destCell.CopyCellFrom(srcCell, policy);
                 }
 
-                var rowShifter = new XSSFRowShifter(_sheet);
-                var sheetIndex = _sheet.Workbook.GetSheetIndex(_sheet);
-                var sheetName = _sheet.Workbook.GetSheetName(sheetIndex);
-                var srcRowNum = srcRow.RowNum;
-                var destRowNum = RowNum;
-                var rowDifference = destRowNum - srcRowNum;
-                var shifter = FormulaShifter.CreateForRowCopy(sheetIndex, sheetName, srcRowNum, srcRowNum, rowDifference, SpreadsheetVersion.EXCEL2007);
+                XSSFRowShifter rowShifter = new XSSFRowShifter(_sheet);
+                int sheetIndex = _sheet.Workbook.GetSheetIndex(_sheet);
+                string sheetName = _sheet.Workbook.GetSheetName(sheetIndex);
+                int srcRowNum = srcRow.RowNum;
+                int destRowNum = RowNum;
+                int rowDifference = destRowNum - srcRowNum;
+                FormulaShifter shifter = FormulaShifter.CreateForRowCopy(sheetIndex, sheetName, srcRowNum, srcRowNum, rowDifference, SpreadsheetVersion.EXCEL2007);
                 rowShifter.UpdateRowFormulas(this, shifter);
                 // Copy merged regions that are fully contained on the row
                 // FIXME: is this something that rowShifter could be doing?
                 if (policy.IsCopyMergedRegions)
                 {
-                    foreach (var srcRegion in srcRow.Sheet.MergedRegions)
+                    foreach (CellRangeAddress srcRegion in srcRow.Sheet.MergedRegions)
                     {
                         if (srcRowNum == srcRegion.FirstRow && srcRowNum == srcRegion.LastRow)
                         {
-                            var destRegion = srcRegion.Copy();
+                            CellRangeAddress destRegion = srcRegion.Copy();
                             destRegion.FirstRow = destRowNum;
                             destRegion.LastRow = destRowNum;
                             Sheet.AddMergedRegion(destRegion);
@@ -465,7 +519,10 @@ namespace NPOI.XSSF.UserModel
         /// Returns the underlying CT_Row xml node Containing all cell defInitions in this row
         /// </summary>
         /// <returns>the underlying CT_Row xml node</returns>
-        public CT_Row GetCTRow() => _row;
+        public CT_Row GetCTRow()
+        {
+            return _row;
+        }
 
         /// <summary>
         /// Fired when the document is written to an output stream.
@@ -474,21 +531,21 @@ namespace NPOI.XSSF.UserModel
         internal void OnDocumentWrite()
         {
             // check if cells in the CT_Row are ordered
-            var isOrdered = true;
+            bool isOrdered = true;
             if (_row.SizeOfCArray() != _cells.Count)
             {
                 isOrdered = false;
             }
             else
             {
-                var i = 0;
-                foreach (var cell in _cells.Values.Cast<XSSFCell>())
+                int i = 0;
+                foreach (XSSFCell cell in _cells.Values.Cast<XSSFCell>())
                 {
-                    var c1 = cell.GetCTCell();
-                    var c2 = _row.GetCArray(i++);
+                    CT_Cell c1 = cell.GetCTCell();
+                    CT_Cell c2 = _row.GetCArray(i++);
 
-                    var r1 = c1.r;
-                    var r2 = c2.r;
+                    string r1 = c1.r;
+                    string r2 = c2.r;
                     if (!(r1 == null ? r2 == null : r1.Equals(r2)))
                     {
                         isOrdered = false;
@@ -499,9 +556,9 @@ namespace NPOI.XSSF.UserModel
 
             if (!isOrdered)
             {
-                var cArray = new CT_Cell[_cells.Count];
-                var i = 0;
-                foreach (var c in _cells.Values.Cast<XSSFCell>())
+                CT_Cell[] cArray = new CT_Cell[_cells.Count];
+                int i = 0;
+                foreach (XSSFCell c in _cells.Values.Cast<XSSFCell>())
                 {
                     cArray[i++] = c.GetCTCell();
                 }
@@ -518,14 +575,14 @@ namespace NPOI.XSSF.UserModel
         /// <param name="n">n the number of rows to move</param>
         internal void Shift(int n)
         {
-            var rownum = RowNum + n;
-            var calcChain = ((XSSFWorkbook)_sheet.Workbook).GetCalculationChain();
-            var sheetId = (int)_sheet.sheet.sheetId;
-            var msg = "Row[rownum=" + RowNum + "] contains cell(s) included in a multi-cell array formula. " +
+            int rownum = RowNum + n;
+            Model.CalculationChain calcChain = ((XSSFWorkbook)_sheet.Workbook).GetCalculationChain();
+            int sheetId = (int)_sheet.sheet.sheetId;
+            string msg = "Row[rownum=" + RowNum + "] contains cell(s) included in a multi-cell array formula. " +
                     "You cannot change part of an array.";
-            foreach (var c in this)
+            foreach (ICell c in this)
             {
-                var cell = (XSSFCell)c;
+                XSSFCell cell = (XSSFCell)c;
                 if (cell.IsPartOfArrayFormulaGroup)
                 {
                     cell.NotifyArrayFormulaChanging(msg);
@@ -537,8 +594,8 @@ namespace NPOI.XSSF.UserModel
                     calcChain.RemoveItem(sheetId, cell.GetReference());
                 }
 
-                var CT_Cell = cell.GetCTCell();
-                var r = new CellReference(rownum, cell.ColumnIndex).FormatAsString();
+                CT_Cell CT_Cell = cell.GetCTCell();
+                string r = new CellReference(rownum, cell.ColumnIndex).FormatAsString();
                 CT_Cell.r = r;
             }
 
@@ -551,13 +608,19 @@ namespace NPOI.XSSF.UserModel
         /// Cell iterator over the physically defined cell
         /// </summary>
         /// <returns>an iterator over cells in this row.</returns>
-        public SortedDictionary<int, ICell>.ValueCollection.Enumerator CellIterator() => _cells.Values.GetEnumerator();
+        public SortedDictionary<int, ICell>.ValueCollection.Enumerator CellIterator()
+        {
+            return _cells.Values.GetEnumerator();
+        }
 
         /// <summary>
         /// Alias for <see cref="CellIterator"/> to allow  foreach loops
         /// </summary>
         /// <returns>an iterator over cells in this row.</returns>
-        public IEnumerator<ICell> GetEnumerator() => CellIterator();
+        public IEnumerator<ICell> GetEnumerator()
+        {
+            return CellIterator();
+        }
 
         /// <summary>
         /// Compares two <see cref="XSSFRow"/> objects. Two rows are equal if they belong to the 
@@ -590,13 +653,16 @@ namespace NPOI.XSSF.UserModel
                 return false;
             }
 
-            var other = (XSSFRow)obj;
+            XSSFRow other = (XSSFRow)obj;
 
             return (RowNum == other.RowNum) &&
                    (Sheet == other.Sheet);
         }
 
-        public override int GetHashCode() => _row.GetHashCode();
+        public override int GetHashCode()
+        {
+            return _row.GetHashCode();
+        }
         #endregion
 
         #region IRow Members
@@ -604,8 +670,8 @@ namespace NPOI.XSSF.UserModel
         {
             get
             {
-                var cells = new List<ICell>();
-                foreach (var cell in _cells.Values)
+                List<ICell> cells = new List<ICell>();
+                foreach (ICell cell in _cells.Values)
                 {
                     cells.Add(cell);
                 }
@@ -614,13 +680,25 @@ namespace NPOI.XSSF.UserModel
             }
         }
 
-        public void MoveCell(ICell cell, int newColumn) => throw new NotImplementedException();
+        public void MoveCell(ICell cell, int newColumn)
+        {
+            throw new NotImplementedException();
+        }
 
-        public IRow CopyRowTo(int targetIndex) => Sheet.CopyRow(RowNum, targetIndex);
+        public IRow CopyRowTo(int targetIndex)
+        {
+            return Sheet.CopyRow(RowNum, targetIndex);
+        }
 
-        public ICell CopyCell(int sourceIndex, int targetIndex) => CellUtil.CopyCell(this, sourceIndex, targetIndex);
+        public ICell CopyCell(int sourceIndex, int targetIndex)
+        {
+            return CellUtil.CopyCell(this, sourceIndex, targetIndex);
+        }
 
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
 
         public bool HasCustomHeight()
         {
@@ -629,20 +707,41 @@ namespace NPOI.XSSF.UserModel
 
         public int OutlineLevel
         {
-            get => _row.outlineLevel;
-            set => _row.outlineLevel = (byte)value;
+            get
+            {
+                return _row.outlineLevel;
+            }
+
+            set
+            {
+                _row.outlineLevel = (byte)value;
+            }
         }
 
         public bool? Hidden
         {
-            get => _row.hidden;
-            set => _row.hidden = value ?? false;
+            get
+            {
+                return _row.hidden;
+            }
+
+            set
+            {
+                _row.hidden = value ?? false;
+            }
         }
 
         public bool? Collapsed
         {
-            get => _row.collapsed;
-            set => _row.collapsed = value ?? false;
+            get
+            {
+                return _row.collapsed;
+            }
+
+            set
+            {
+                _row.collapsed = value ?? false;
+            }
         }
         #endregion
 
@@ -651,7 +750,10 @@ namespace NPOI.XSSF.UserModel
         /// formatted xml representation of this row
         /// </summary>
         /// <returns>formatted xml representation of this row</returns>
-        public override string ToString() => _row.ToString();
+        public override string ToString()
+        {
+            return _row.ToString();
+        }
 
         /// <summary>
         /// Get the hssfcell representing a given column (logical cell)
@@ -671,9 +773,15 @@ namespace NPOI.XSSF.UserModel
             return _cells[cellnum];
         }
 
-        private int GetFirstKey() => _cells.Keys.Min();
+        private int GetFirstKey()
+        {
+            return _cells.Keys.Min();
+        }
 
-        private int GetLastKey() => _cells.Keys.Max();
+        private int GetLastKey()
+        {
+            return _cells.Keys.Max();
+        }
         #endregion
     }
 }


### PR DESCRIPTION
Code clean-up, refactor into more of C# style code, use expression body style for properties and methods where applicable, use 'var' instead of explicit types where possible, add curly brackets for clarity in places where they were omitted, re-arrange members into regions.

Change javadoc to c# xml documentation.

No changes in code itself or logic, only refactoring.