### PR TITLE
Stop MutableSection from setting null MutableProperty

### DIFF
--- a/main/HPSF/MutableSection.cs
+++ b/main/HPSF/MutableSection.cs
@@ -230,7 +230,10 @@ namespace NPOI.HPSF
         {
             long id = p.ID;
             RemoveProperty(id);
-            preprops.Add(p);
+            if (p.Value != null)
+            {
+                preprops.Add(p);
+            }
             dirty = true;
         }
 


### PR DESCRIPTION
It was messing up getting a Size property of a MutableSection, as it reads the MutableProperty's Value and tries to get it's length, throwing a null reference exception.