### PR TITLE
Create zip for SXSSFWorkbook setting Use64bit=Off

### DIFF
--- a/ooxml/XSSF/Streaming/SXSSFWorkbook.cs
+++ b/ooxml/XSSF/Streaming/SXSSFWorkbook.cs
@@ -443,6 +443,7 @@ namespace NPOI.XSSF.Streaming
                 ZipOutputStream zos = new ZipOutputStream(outStream);
                 try
                 {
+                    zos.UseZip64 = UseZip64.Off;
                     //ZipEntrySource zipEntrySource = new ZipFileZipEntrySource(zip);
                     //var en =  zipEntrySource.Entries;
                     var en = zip.GetEnumerator();


### PR DESCRIPTION
fixes #583 by setting `zos.UseZip64 = UseZip64.Off` in `SXSSFWorkbook.InjectData`. This generates a zip file with header `04 03 4b 50 14`, which can be opened also in Google Drive and LibreOffice.