### PR TITLE
Able to open files with ill-formed datetime, exported by SAS

### DIFF
--- a/main/SS/Util/Format.cs
+++ b/main/SS/Util/Format.cs
@@ -365,7 +365,17 @@ namespace NPOI.SS.Util
         }
         public DateTime Parse(string source)
         {
-            var dt = DateTime.Parse(source, CultureInfo.InvariantCulture);
+            if (!DateTime.TryParse(source, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
+            {
+                // Compatibility stub for SAS-generated ill-formed datetime, such as 2020-07-03T 9:41:11-04:00
+                // There should be a leading zero before the one-digit hour.
+                // See https://github.com/nissl-lab/npoi/issues/846 for more information.
+
+                const string AlternativeDateTimeFormat = "yyyy-MM-ddT H:mm:sszzz";
+
+                dt = DateTime.ParseExact(source, AlternativeDateTimeFormat, CultureInfo.InvariantCulture);
+            }
+
             return TimeZone != null ? TimeZoneInfo.ConvertTime(dt, TimeZone) : dt;
         }
         

--- a/testcases/main/NPOI.TestCases.csproj
+++ b/testcases/main/NPOI.TestCases.csproj
@@ -242,6 +242,7 @@
     <Compile Include="SS\Util\TestAreaReference.cs" />
     <Compile Include="SS\Util\TestCellAddress.cs" />
     <Compile Include="SS\Util\BaseTestCellUtil.cs" />
+    <Compile Include="SS\Util\TestSimpleDateFormat.cs" />
     <Compile Include="SS\Util\TestDateFormatConverter.cs" />
     <Compile Include="SS\Util\TestHSSFCellUtil.cs" />
     <Compile Include="SS\Util\TestSheetUtil.cs" />

--- a/testcases/main/SS/Util/TestSimpleDateFormat.cs
+++ b/testcases/main/SS/Util/TestSimpleDateFormat.cs
@@ -1,0 +1,54 @@
+﻿/*
+ *  ====================================================================
+ *    Licensed to the Apache Software Foundation (ASF) under one or more
+ *    contributor license agreements.  See the NOTICE file distributed with
+ *    this work for additional information regarding copyright ownership.
+ *    The ASF licenses this file to You under the Apache License, Version 2.0
+ *    (the "License"); you may not use this file except in compliance with
+ *    the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ * ====================================================================
+ */
+
+using System;
+using System.Globalization;
+using System.IO;
+using NPOI.SS.Util;
+using NPOI.Util;
+using NUnit.Framework;
+
+namespace TestCases.SS.Util
+{
+    [TestFixture]
+    public class TestSimpleDateFormat
+    {
+        /*
+         * Test SimpleDateFormat.Parse with ill-formed datetime string.
+         */
+        [Test]
+        public void TestIllformedDatetimeParsing()
+        {
+            // See https://github.com/nissl-lab/npoi/issues/846 for more information.
+
+            var format = new SimpleDateFormat();
+
+            DateTime standardForm = default;
+            DateTime illForm = default;
+
+            Assert.DoesNotThrow(() => standardForm = format.Parse("2020-07-03T09:41:11-04:00"));
+            Assert.DoesNotThrow(() => illForm = format.Parse("2020-07-03T 9:41:11-04:00"));
+            Assert.Throws<FormatException>(() => format.Parse("2020-07-03T09: 1:11-04:00"));
+
+            Assert.AreEqual(standardForm, illForm);
+        }
+
+    }
+
+}


### PR DESCRIPTION
Fixed the issue as portrayed in #846. Also added a basic test regarding `SimpleDateFormat.Parse`.

This fix is done by adding a compatibility stub into the aforementioned method allowing a leading space before one-digit hour instead of the regular zero.

Since the new approach utilizes `DateTime.ParseExact`, the change won't enable other ill-formed datetime strings.