### PR TITLE
Fix delete and add chart throws exception

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFDrawing.cs
+++ b/ooxml/XSSF/UserModel/XSSFDrawing.cs
@@ -184,6 +184,28 @@ namespace NPOI.XSSF.UserModel
             return chart;
         }
 
+        /// <summary>
+        /// Removes chart.
+        /// </summary>
+        /// <param name="chart">The chart to be removed.</param>
+        public void RemoveChart(XSSFChart chart)
+        {
+            CT_Drawing ctDrawing = GetCTDrawing();
+            XSSFGraphicFrame frame = chart.GetGraphicFrame();
+            CT_GraphicalObjectFrame internalFrame = frame.GetCTGraphicalObjectFrame();
+            int anchorIndex = ctDrawing.CellAnchors.FindIndex(anchor => anchor.graphicFrame == internalFrame);
+
+            if (anchorIndex != -1)
+            {
+                ctDrawing.CellAnchors.RemoveAt(anchorIndex);
+
+                foreach (var part in GetRelations().Where(part => part is XSSFChart && part == chart))
+                {
+                    RemoveRelation(part);
+                }
+            }
+        }
+
         private int GetNewChartNumber()
         {
             List<PackagePart> existingCharts = GetPackagePart().Package.

--- a/ooxml/XSSF/UserModel/XSSFDrawing.cs
+++ b/ooxml/XSSF/UserModel/XSSFDrawing.cs
@@ -26,7 +26,8 @@ using System.Xml;
 using NPOI.OpenXmlFormats.Dml;
 using NPOI.SS.Util;
 using NPOI.Util;
-
+using System.Text.RegularExpressions;
+using System.Linq;
 
 namespace NPOI.XSSF.UserModel
 {
@@ -170,8 +171,7 @@ namespace NPOI.XSSF.UserModel
         /// <returns>the newly created chart</returns>
         public IChart CreateChart(IClientAnchor anchor)
         {
-            int chartNumber = GetPackagePart().Package.
-                GetPartsByContentType(XSSFRelation.CHART.ContentType).Count + 1;
+            int chartNumber = GetNewChartNumber();
 
             RelationPart rp = CreateRelationship(
             XSSFRelation.CHART, XSSFFactory.GetInstance(), chartNumber, false);
@@ -182,6 +182,32 @@ namespace NPOI.XSSF.UserModel
             frame.SetChart(chart, chartRelId);
 
             return chart;
+        }
+
+        private int GetNewChartNumber()
+        {
+            List<PackagePart> existingCharts = GetPackagePart().Package.
+                GetPartsByContentType(XSSFRelation.CHART.ContentType);
+            HashSet<int> numbers = new HashSet<int>();
+
+            foreach (PackagePart chart in existingCharts)
+            {
+                var match = Regex.Match(chart.PartName.Name, @"\d+");
+
+                if (match.Success)
+                {
+                    numbers.Add(int.Parse(match.Value));
+                }
+            }
+
+            var newChartNumber = 1;
+
+            while (numbers.Contains(newChartNumber))
+            {
+                newChartNumber++;
+            }
+
+            return newChartNumber;
         }
 
         //public XSSFChart CreateChart(IClientAnchor anchor)

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFChart.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFChart.cs
@@ -68,6 +68,7 @@ namespace TestCases.XSSF.UserModel
 
             Assert.IsNotNull(XSSFTestDataSamples.WriteOutAndReadBack(wb));
         }
+
         [Test]
         public void TestAddChartsToNewWorkbook()
         {
@@ -91,6 +92,24 @@ namespace TestCases.XSSF.UserModel
         }
 
         [Test]
+        public void TestRemoveChart()
+        {
+            XSSFWorkbook workbook = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)workbook.CreateSheet();
+            XSSFDrawing drawingPatriarch = (XSSFDrawing)sheet.CreateDrawingPatriarch();
+            XSSFClientAnchor anchor1 = new XSSFClientAnchor(0, 0, 0, 0, 1, 1, 10, 30);
+            XSSFChart chart = (XSSFChart)drawingPatriarch.CreateChart(anchor1);
+            XSSFClientAnchor anchor2 = new XSSFClientAnchor(0, 0, 0, 0, 1, 11, 10, 60);
+            _ = (XSSFChart)drawingPatriarch.CreateChart(anchor2);
+
+            Assert.AreEqual(2, drawingPatriarch.GetCharts().Count);
+
+            drawingPatriarch.RemoveChart(chart);
+
+            Assert.AreEqual(1, drawingPatriarch.GetCharts().Count);
+        }
+
+        [Test]
         public void TestRemoveOneOfTwoChartsAndAddNewOne()
         {
             XSSFWorkbook workbook = new XSSFWorkbook();
@@ -103,7 +122,7 @@ namespace TestCases.XSSF.UserModel
 
             Assert.AreEqual(2, drawingPatriarch.GetCharts().Count);
 
-            RemoveChart(drawingPatriarch, chart);
+            drawingPatriarch.RemoveChart(chart);
 
             Assert.AreEqual(1, drawingPatriarch.GetCharts().Count);
 
@@ -111,32 +130,6 @@ namespace TestCases.XSSF.UserModel
             _ = (XSSFChart)drawingPatriarch.CreateChart(a3);
 
             Assert.AreEqual(2, drawingPatriarch.GetCharts().Count);
-        }
-
-        private static void RemoveChart(XSSFDrawing drawingPatriarch, XSSFChart chart)
-        {
-            CT_Drawing ctDrawing = drawingPatriarch.GetCTDrawing();
-            XSSFGraphicFrame frame = chart.GetGraphicFrame();
-            CT_GraphicalObjectFrame internalFrame = frame.GetCTGraphicalObjectFrame();
-            int anchorIndex = ctDrawing.CellAnchors.FindIndex(anchor => anchor.graphicFrame == internalFrame);
-            
-            if (anchorIndex != -1)
-            {
-                ctDrawing.CellAnchors.RemoveAt(anchorIndex);
-
-                foreach (var part in drawingPatriarch.GetRelations().Where(part => part is XSSFChart && part == chart))
-                {
-                    drawingPatriarch.RemoveRelation(part);
-                }
-            }
-        }
-
-        private static void RemoveChartFromDrawing(XSSFDrawing xssfDrawing, XSSFChart chart)
-        {
-            foreach (var part in xssfDrawing.GetRelations().Where(part => part is XSSFChart && part == chart))
-            {
-                xssfDrawing.RemoveRelation(part);
-            }
         }
 
         [Test]


### PR DESCRIPTION
When new chart was created it's number was determined by the number of previously existing charts. This created a bug, when there were charts chart1.xml and chart2.xml, chart1 was deleted and the new chart was created. Since there is a chart already (chart2), the number for a new chart would be 2 (CountOfCharts + 1). This will throw an exception, because chart2.xml already exists.

Also added a RemoveChart method to XSSFDrawing and tests for the fixed bug and for the the RemoveChart method