### PR TITLE
Fix XWPFTable row cannot insert to the last position of table

### DIFF
--- a/OpenXmlFormats/Wordprocessing/Table.cs
+++ b/OpenXmlFormats/Wordprocessing/Table.cs
@@ -651,7 +651,8 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                         pos++;
                 }
             }
-            if(pos == p && index == -1)
+            // Check if the position should be the last position when index cannot be find in for loop
+            if( index == -1&&pos == p)
                 index = items1Field.Count;
             return index;
         }

--- a/OpenXmlFormats/Wordprocessing/Table.cs
+++ b/OpenXmlFormats/Wordprocessing/Table.cs
@@ -651,6 +651,8 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                         pos++;
                 }
             }
+            if(pos == p && index == -1)
+                index = items1Field.Count;
             return index;
         }
         private void RemoveItems1(Items1ChoiceType type, int p)

--- a/ooxml/XWPF/Usermodel/XWPFTable.cs
+++ b/ooxml/XWPF/Usermodel/XWPFTable.cs
@@ -186,11 +186,6 @@ namespace NPOI.XWPF.UserModel
             }
         }
 
-        public void AddNewRowBetween(int start, int end)
-        {
-            throw new NotImplementedException();
-        }
-
         /**
          * add a new column for each row in this table
          */

--- a/testcases/ooxml/XWPF/UserModel/TestXWPFTable.cs
+++ b/testcases/ooxml/XWPF/UserModel/TestXWPFTable.cs
@@ -122,7 +122,7 @@ namespace TestCases.XWPF.UserModel
             Assert.AreEqual(1, xtab.GetCTTbl().GetTrArray(0).SizeOfTcArray());
         }
         [Test]
-        public void TestInsertCreateRow()
+        public void TestInsertRow()
         {
             XWPFDocument doc = new XWPFDocument();
 

--- a/testcases/ooxml/XWPF/UserModel/TestXWPFTable.cs
+++ b/testcases/ooxml/XWPF/UserModel/TestXWPFTable.cs
@@ -121,6 +121,37 @@ namespace TestCases.XWPF.UserModel
             xtab = new XWPFTable(new CT_Tbl(), doc);
             Assert.AreEqual(1, xtab.GetCTTbl().GetTrArray(0).SizeOfTcArray());
         }
+        [Test]
+        public void TestInsertCreateRow()
+        {
+            XWPFDocument doc = new XWPFDocument();
+
+            CT_Tbl table = new CT_Tbl();
+            CT_Row r1 = table.AddNewTr();
+            r1.AddNewTc().AddNewP();
+            r1.AddNewTc().AddNewP();
+            CT_Row r2 = table.AddNewTr();
+            r2.AddNewTc().AddNewP();
+            r2.AddNewTc().AddNewP();
+            CT_Row r3 = table.AddNewTr();
+            r3.AddNewTc().AddNewP();
+            r3.AddNewTc().AddNewP();
+
+            XWPFTable xtab = new XWPFTable(table, doc);
+            Assert.AreEqual(3, xtab.NumberOfRows);
+            Assert.IsNotNull(xtab.GetRow(2));
+
+            //add a new row
+            xtab.CreateRow();
+            Assert.AreEqual(4, xtab.NumberOfRows);
+
+            xtab.InsertNewTableRow(0);
+            Assert.AreEqual(5, xtab.NumberOfRows);
+            xtab.InsertNewTableRow(xtab.NumberOfRows);
+            Assert.AreEqual(6, xtab.NumberOfRows);
+
+
+        }
 
         [Test]
         public void TestSetGetWidth()


### PR DESCRIPTION
Fix XWPFTable row cannot insert to the last position of table.
The problem is in CT_Tbl.GetItems1Index method.
Because pos can never be equal to p in for loop, I add a statement to check if the index is -1 and ``` pos == p ``` after for loop. It means that the position is the end of the list. 

``` C#
for (int i = 0; i < items1ElementNameField.Count; i++)
{
    if (items1ElementNameField[i] == type)
    {
        if (pos == p)
        {
            //return itemsField[p] as T;
            index = i;
            break;
        }
        else
            pos++;
    }
}
// Check if the position should be the last position
if(index == -1 && pos == p) 
    index = items1Field.Count;
```