### PR TITLE
POI 65543 Bug Fix Sync

### DIFF
--- a/main/HSSF/Record/SSTDeserializer.cs
+++ b/main/HSSF/Record/SSTDeserializer.cs
@@ -48,7 +48,7 @@ namespace NPOI.HSSF.Record
             {
                 // Extract exactly the count of strings from the SST record.
                 UnicodeString str;
-                if (in1.Available() == 0 && !in1.HasNextRecord)
+                if (in1.Available() == 0 && (!in1.HasNextRecord || in1.GetNextSid() != ContinueRecord.sid))
                 {
                     System.Console.WriteLine("Ran out of data before creating all the strings! String at index " + i + "");
                     str = new UnicodeString("");

--- a/testcases/main/HSSF/Record/TestSSTDeserializer.cs
+++ b/testcases/main/HSSF/Record/TestSSTDeserializer.cs
@@ -130,5 +130,25 @@ namespace TestCases.HSSF.Record
 
             Assert.AreEqual("At a dinner party orAt At At ", strings[0] + "");
         }
+
+        /**
+        * Ensure that invalid SST records with an incorrect number of strings specified, does not consume non-continuation records.
+        */
+        [Test]
+        public void TestInvalidSTTRecord()
+        {
+            byte[] sstRecord = ReadSampleHexData("notenoughstrings.txt", "sst-record", SSTRecord.sid);
+            byte[] nonContinuationRecord = ReadSampleHexData("notenoughstrings.txt", "non-continuation-record", ExtSSTRecord.sid);
+            RecordInputStream in1 = TestcaseRecordInputStream.Create(Concat(sstRecord, nonContinuationRecord));
+
+            IntMapper<UnicodeString> strings = new IntMapper<UnicodeString>();
+            SSTDeserializer deserializer = new SSTDeserializer(strings);
+
+            // The record data in notenoughstrings.txt only contains 1 string, deliberately pass in a larger number.
+            deserializer.ManufactureStrings(2, in1);
+
+            Assert.AreEqual("At a dinner party or", strings[0] + "");
+            Assert.AreEqual("", strings[1] + "");
+        }
     }
 }

--- a/testcases/test-data/spreadsheet/notenoughstrings.txt
+++ b/testcases/test-data/spreadsheet/notenoughstrings.txt
@@ -1,0 +1,13 @@
+[sst-record]
+14 00                                               # String length 0x14=20
+01                                                  # Option flag, 16bit
+# String: At a dinner party or
+41 00 74 00 20 00 61 00 20 00
+64 00 69 00 6E 00 6E 00 65 00
+72 00 20 00 70 00 61 00 72 00
+74 00 79 00 20 00 6F 00 72 00
+
+# This is not a complete record
+# It only matters that the record type is not 0x003C
+[non-continuation-record]
+00 11 22 33


### PR DESCRIPTION
Fixing a problem when the shared string table record reports more strings than are present in the file.
This is based on the same fix/patch for POI Java, see link => https://bz.apache.org/bugzilla/show_bug.cgi?id=66412 Credit to simon.carter for this fix.

The current behaviour is: read the number of strings in the string table. Then attempt to read that many number of strings. Using subsequent records if needed. If there are less strings present than reported, pad the internal string table with empty strings. This only works when there are no more records in the stream.

This fix adds a check to ensure that the next record is a continuation record. If it is not then the internal string table is padded as before.