### PR TITLE
fix POI Bug 60197 - setSheetOrder doesn't update names scope

### DIFF
--- a/main/HSSF/UserModel/HSSFWorkbook.cs
+++ b/main/HSSF/UserModel/HSSFWorkbook.cs
@@ -460,20 +460,64 @@ namespace NPOI.HSSF.UserModel
             }
 
             workbook.UpdateNamesAfterCellShift(shifter);
+            UpdateNamedRangesAfterSheetReorder(oldSheetIndex, pos);
 
+            UpdateActiveSheetAfterSheetReorder(oldSheetIndex, pos);
+        }
+
+        /**
+         * copy-pasted from XSSFWorkbook#updateNamedRangesAfterSheetReorder(int, int)
+         * <p>
+         * update sheet-scoped named ranges in this workbook after changing the sheet order
+         * of a sheet at oldIndex to newIndex.
+         * Sheets between these indices will move left or right by 1.
+         *
+         * @param oldIndex the original index of the re-ordered sheet
+         * @param newIndex the new index of the re-ordered sheet
+         */
+        private void UpdateNamedRangesAfterSheetReorder(int oldIndex, int newIndex)
+        {
+            // update sheet index of sheet-scoped named ranges
+            foreach (HSSFName name in names)
+            {
+                int i = name.SheetIndex;
+                // name has sheet-level scope
+                if (i != -1)
+                {
+                    // name refers to this sheet
+                    if (i == oldIndex)
+                    {
+                        name.SheetIndex = newIndex;
+                    }
+                    // if oldIndex > newIndex then this sheet moved left and sheets between newIndex and oldIndex moved right
+                    else if (newIndex <= i && i < oldIndex)
+                    {
+                        name.SheetIndex = i + 1;
+                    }
+                    // if oldIndex < newIndex then this sheet moved right and sheets between oldIndex and newIndex moved left
+                    else if (oldIndex < i && i <= newIndex)
+                    {
+                        name.SheetIndex = i - 1;
+                    }
+                }
+            }
+        }
+
+        private void UpdateActiveSheetAfterSheetReorder(int oldIndex, int newIndex)
+        {
             // adjust active sheet if necessary
             int active = ActiveSheetIndex;
-            if (active == oldSheetIndex)
+            if (active == oldIndex)
             {
                 // moved sheet was the active one
-                SetActiveSheet(pos);
+                SetActiveSheet(newIndex);
             }
-            else if ((active < oldSheetIndex && active < pos) ||
-                  (active > oldSheetIndex && active > pos))
+            else if ((active < oldIndex && active < newIndex) ||
+                     (active > oldIndex && active > newIndex))
             {
                 // not affected
             }
-            else if (pos > oldSheetIndex)
+            else if (newIndex > oldIndex)
             {
                 // moved sheet was below before and is above now => active is one less
                 SetActiveSheet(active - 1);

--- a/testcases/ooxml/XSSF/Streaming/TestSXSSFBugs.cs
+++ b/testcases/ooxml/XSSF/Streaming/TestSXSSFBugs.cs
@@ -1,8 +1,10 @@
 ﻿using NPOI.SS.UserModel;
 using NPOI.SS.Util;
+using NPOI.Util;
 using NPOI.XSSF;
 using NPOI.XSSF.Streaming;
 using NUnit.Framework;
+using System.IO;
 using TestCases.SS.UserModel;
 
 namespace TestCases.XSSF.Streaming
@@ -24,7 +26,7 @@ namespace TestCases.XSSF.Streaming
         [Ignore("Reading data is not supported")] public override void Bug57798() { /* Reading data is not supported */ }
 
         [Test]
-        public void Tug49253()
+        public void Bug49253()
         {
             IWorkbook wb1 = new SXSSFWorkbook();
             IWorkbook wb2 = new SXSSFWorkbook();
@@ -56,6 +58,31 @@ namespace TestCases.XSSF.Streaming
 
             wb1.Close();
             wb2.Close();
+        }
+
+        // bug 60197: setSheetOrder should update sheet-scoped named ranges to maintain references to the sheets before the re-order
+        [Test]
+        override
+        public void bug60197_NamedRangesReferToCorrectSheetWhenSheetOrderIsChanged()
+        {
+            try
+            {
+                base.bug60197_NamedRangesReferToCorrectSheetWhenSheetOrderIsChanged();
+            }
+            catch (RuntimeException e)
+            {
+                var cause = e.InnerException;
+                if (cause is IOException && cause.Message == "Stream closed")
+                {
+                    // expected on the second time that _testDataProvider.writeOutAndReadBack(SXSSFWorkbook) is called
+                    // if the test makes it this far, then we know that XSSFName sheet indices are updated when sheet
+                    // order is changed, which is the purpose of this test. Therefore, consider this a passing test.
+                }
+                else
+                {
+                    throw e;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes issue #931. In practice, I've encountered it too when I tried to change sheet order after setting PrintArea in each sheets.

Referenced POI source code version: POI 5.2.3

----

POI Bug Tracker issue:

https://bz.apache.org/bugzilla/show_bug.cgi?id=60197

Tracked POI changes:

- bug 60197: Workbook#setSheetOrder should update named range sheet indices 

  https://svn.apache.org/repos/asf/poi/trunk@1763939

- sonar fixes - use assert in junit tests

  https://svn.apache.org/repos/asf/poi/trunk@1872397

- #65026 - Migrate tests to Junit 5

  https://svn.apache.org/repos/asf/poi/trunk@1884783

(comment: Actual logic fix was only in first revision, rests were test code adjustments.)
