### PR TITLE
fix `Ambiguous project name` error while restoring NuGet packages.

### DIFF
--- a/OpenXmlFormats/NPOI.OpenXmlFormats.csproj
+++ b/OpenXmlFormats/NPOI.OpenXmlFormats.csproj
@@ -34,7 +34,6 @@
     </TargetFrameworkProfile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>npoi.snk</AssemblyOriginatorKeyFile>
-    <PackageId>NPOI</PackageId>
     <RepositoryUrl>https://github.com/tonyqus/npoi</RepositoryUrl>
     <LangVersion>default</LangVersion>
   </PropertyGroup>

--- a/main/NPOI.Core.csproj
+++ b/main/NPOI.Core.csproj
@@ -7,7 +7,6 @@
     <RootNamespace>NPOI</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>npoi.snk</AssemblyOriginatorKeyFile>
-    <PackageId>NPOI</PackageId>
     <RepositoryUrl>https://github.com/tonyqus/npoi</RepositoryUrl>
     <OutputPath></OutputPath>
   </PropertyGroup>

--- a/main/NPOI.csproj
+++ b/main/NPOI.csproj
@@ -33,7 +33,6 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <PackageId>NPOI</PackageId>
     <RepositoryUrl>https://github.com/tonyqus/npoi</RepositoryUrl>
     <TargetFrameworkProfile />
     <LangVersion>default</LangVersion>

--- a/ooxml/NPOI.OOXML.csproj
+++ b/ooxml/NPOI.OOXML.csproj
@@ -34,7 +34,6 @@
     </TargetFrameworkProfile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\main\npoi.snk</AssemblyOriginatorKeyFile>
-    <PackageId>NPOI</PackageId>
     <RepositoryUrl>https://github.com/tonyqus/npoi</RepositoryUrl>
     <LangVersion>default</LangVersion>
   </PropertyGroup>

--- a/openxml4Net/NPOI.OpenXml4Net.csproj
+++ b/openxml4Net/NPOI.OpenXml4Net.csproj
@@ -34,7 +34,6 @@
     </TargetFrameworkProfile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>npoi.snk</AssemblyOriginatorKeyFile>
-    <PackageId>NPOI</PackageId>
     <RepositoryUrl>https://github.com/tonyqus/npoi</RepositoryUrl>
     <LangVersion>default</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
When I had tried to build NPOI.sln with VS2022, I always got `Ambiguous project name 'NPOI'` error while restoring NuGet packages. Therefore, I was able able to test only NPOI.Core build until recently.

After some search I found https://github.com/NuGet/Home/issues/7372 that says all csproj files should have unique or empty PackageId.

So I removed all `<PackageId>NPOI</PackageId>` settings from csproj files to resolve the ambiguous project name error.