### PR TITLE
Update SheetDataWriter.cs

### DIFF
--- a/ooxml/XSSF/Streaming/SheetDataWriter.cs
+++ b/ooxml/XSSF/Streaming/SheetDataWriter.cs
@@ -228,7 +228,7 @@ namespace NPOI.XSSF.Streaming
 
             if (row.HasCustomHeight())
             {
-                WriteAsBytes(" customHeight=\"true\"  ht=\"");
+                WriteAsBytes(" customHeight=\"true\" ht=\"");
                 WriteAsBytes(row.HeightInPoints);
                 WriteAsBytes("\"");
             }


### PR DESCRIPTION
LibreOffice 7.3.4.2 has a problem with xml like
```<row r="1" customHeight="true"  ht="15">```, however this
```<row r="1" customHeight="true" ht="15">``` works well.

So I propose to remove this second space.