### PR TITLE
Fix XSSFCellStyle.CloneStyleFrom

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Styles/CT_Xf.cs
+++ b/OpenXmlFormats/Spreadsheet/Styles/CT_Xf.cs
@@ -46,8 +46,12 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         public CT_Xf Copy()
         {
-            CT_Xf obj = new CT_Xf();
-            if (this.alignment!=null)
+            return CopyTo(new CT_Xf());
+        }
+
+        public CT_Xf CopyTo(CT_Xf obj)
+        {
+            if (this.alignment != null)
                 obj.alignment = this.alignment.Copy();
             obj.protection = this.protection;
             obj.extLstField = null == extLstField ? null : this.extLstField.Copy();
@@ -69,6 +73,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             obj.pivotButtonField = this.pivotButtonField;
             obj.quotePrefixField = this.quotePrefixField;
             obj.xfIdField = this.xfIdField;
+            obj.xfIdSpecifiedField = this.xfIdSpecifiedField;
             return obj;
         }
 
@@ -187,6 +192,13 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             // first guess:
             return IsSetProtection() &&  (protectionField.locked == true);
         }
+
+        public void UnsetXfId()
+        {
+            this.xfIdField = 0;
+            this.xfIdSpecifiedField = false;
+        }
+
         public CT_CellProtection AddNewProtection()
         {
             this.protectionField = new CT_CellProtection();
@@ -295,11 +307,17 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 this.xfIdSpecifiedField = true;
             }
         }
+
         [XmlIgnore]
         public bool xfIdSpecified
         {
             get { return xfIdSpecifiedField; }
-            set { xfIdSpecifiedField = value; }
+            set 
+            {
+                xfIdSpecifiedField = value;
+                if (xfIdSpecifiedField)
+                    xfIdField = 0;
+            }
         }
 
         [XmlAttribute]

--- a/OpenXmlFormats/Spreadsheet/Styles/CT_Xf.cs
+++ b/OpenXmlFormats/Spreadsheet/Styles/CT_Xf.cs
@@ -193,12 +193,6 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             return IsSetProtection() &&  (protectionField.locked == true);
         }
 
-        public void UnsetXfId()
-        {
-            this.xfIdField = 0;
-            this.xfIdSpecifiedField = false;
-        }
-
         public CT_CellProtection AddNewProtection()
         {
             this.protectionField = new CT_CellProtection();
@@ -312,12 +306,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         public bool xfIdSpecified
         {
             get { return xfIdSpecifiedField; }
-            set 
-            {
-                xfIdSpecifiedField = value;
-                if (xfIdSpecifiedField)
-                    xfIdField = 0;
-            }
+            set { xfIdSpecifiedField = value; }
         }
 
         [XmlAttribute]

--- a/ooxml/XSSF/Model/StylesTable.cs
+++ b/ooxml/XSSF/Model/StylesTable.cs
@@ -41,7 +41,6 @@ namespace NPOI.XSSF.Model
     public class StylesTable : POIXMLDocumentPart
     {
         private SortedDictionary<short, String> numberFormats = new SortedDictionary<short, String>();
-        private bool[] usedNumberFormats = new bool[SpreadsheetVersion.EXCEL2007.MaxCellStyles];
         private List<XSSFFont> fonts = new List<XSSFFont>();
         private List<XSSFCellFill> fills = new List<XSSFCellFill>();
         private List<XSSFCellBorder> borders = new List<XSSFCellBorder>();
@@ -886,7 +885,10 @@ namespace NPOI.XSSF.Model
             ctXf.fontId = 0;
             ctXf.fillId = 0;
             ctXf.borderId = 0;
-            ctXf.xfId = 0;
+            if (xfSize > 0)
+            {
+                ctXf.xfId = (uint)(xfSize - 1);
+            }
             
             int indexXf = PutCellXf(ctXf);
             return new XSSFCellStyle(indexXf - 1, xfSize - 1, this, theme);

--- a/ooxml/XSSF/Model/StylesTable.cs
+++ b/ooxml/XSSF/Model/StylesTable.cs
@@ -887,11 +887,11 @@ namespace NPOI.XSSF.Model
             ctXf.borderId = 0;
             if (xfSize > 0)
             {
-                ctXf.xfId = (uint)(xfSize - 1);
+                ctXf.xfId = 0; //default styleXf
             }
             
             int indexXf = PutCellXf(ctXf);
-            return new XSSFCellStyle(indexXf - 1, xfSize - 1, this, theme);
+            return new XSSFCellStyle(indexXf - 1, ctXf.xfIdSpecified ? (int)ctXf.xfId : -1, this, theme);
         }
 
         /**

--- a/ooxml/XSSF/UserModel/XSSFCellStyle.cs
+++ b/ooxml/XSSF/UserModel/XSSFCellStyle.cs
@@ -130,8 +130,18 @@ namespace NPOI.XSSF.UserModel
                 if (src._stylesSource == _stylesSource)
                 {
                     // Nice and easy
-                    _cellXf = src.GetCoreXf().Copy();
-                    _cellStyleXf = src.GetStyleXf().Copy();
+                    src.GetCoreXf().CopyTo(_cellXf);
+
+                    // There is no need to copy _cellStyleXf couse XSSFCellStyle does not modify any _cellStyleXf properties.
+                    // Just update _cellStyleXf reference
+                    if (_cellXf.xfIdSpecified)
+                    {
+                        _cellStyleXf = _stylesSource.GetCellStyleXfAt((int)_cellXf.xfId);
+                    }
+                    else
+                    {
+                        _cellStyleXf = null;
+                    }
                 }
                 else
                 {
@@ -147,11 +157,6 @@ namespace NPOI.XSSF.UserModel
 
                         // Create a new Xf with the same contents
                         _cellXf = src.GetCoreXf().Copy();
-                        if (_cellXf.applyBorder)
-                        {
-                            //CellXF is copied with existing Ids, but those are different if you're copying between two documents
-                            _cellXf.borderId = FindAddBorder(src._stylesSource.GetBorderAt((int)_cellXf.borderId).GetCTBorder());
-                        }
 
                         // bug 56295: ensure that the fills is available and set correctly
                         CT_Fill fill = CT_Fill.Parse(src.GetCTFill().ToString());
@@ -160,11 +165,6 @@ namespace NPOI.XSSF.UserModel
                         // bug 58084: set borders correctly
                         CT_Border border = CT_Border.Parse(src.GetCTBorder().ToString());
                         AddBorder(border);
-
-                        if (src._cellStyleXf.applyBorder)
-                        {
-                            _cellStyleXf.borderId = FindAddBorder(src.GetCTBorder());
-                        }
 
                         // Swap it over
                         _stylesSource.ReplaceCellXfAt(_cellXfId, _cellXf);
@@ -658,7 +658,6 @@ namespace NPOI.XSSF.UserModel
                 AddFill(ct);
             }
         }
-
 
         /**
         * Gets the font for this style
@@ -1271,6 +1270,7 @@ namespace NPOI.XSSF.UserModel
                     break;
             }
         }
+
         private int FontId
         {
             get
@@ -1279,7 +1279,13 @@ namespace NPOI.XSSF.UserModel
                 {
                     return (int)_cellXf.fontId;
                 }
-                return (int)_cellStyleXf.fontId;
+
+                if (_cellStyleXf != null && _cellStyleXf.IsSetFontId())
+                {
+                    return (int)_cellStyleXf.fontId;
+                }
+
+                return 0; //default font
             }
         }
 

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFCellStyle.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFCellStyle.cs
@@ -15,17 +15,16 @@
    limitations under the License.
 ==================================================================== */
 
-using NPOI.XSSF.Model;
-using NPOI.OpenXmlFormats.Spreadsheet;
-using NPOI.XSSF.UserModel.Extensions;
-using NUnit.Framework;
-using NPOI.SS.UserModel;
 using NPOI.HSSF.UserModel;
 using NPOI.HSSF.Util;
-using NPOI.XSSF.UserModel;
+using NPOI.OpenXmlFormats.Spreadsheet;
+using NPOI.SS.UserModel;
 using NPOI.XSSF;
+using NPOI.XSSF.Model;
+using NPOI.XSSF.UserModel;
+using NPOI.XSSF.UserModel.Extensions;
+using NUnit.Framework;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace TestCases.XSSF.UserModel
 {
@@ -808,6 +807,7 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(fnt, clone.GetFont());
             Assert.AreEqual(18, clone.DataFormat);
             Assert.AreEqual(2, wb.NumberOfFonts);
+            Assert.AreEqual(clone.GetCoreXf(), wb.GetStylesSource().GetStyleAt(clone.Index).GetCoreXf(), "Should be same CoreXF after cloning");
 
             clone.Alignment = HorizontalAlignment.Left;
             clone.DataFormat = 17;


### PR DESCRIPTION
Fix Issue #1025
XSSFCellStyle.CloneStyleFrom was breaking styles in SXSSFWorkbook because it was creating a new _cellXf while XSSFCellStyle.Index was old and referred to the old _cellXf.