### PR TITLE
Fix some warnings in test projects

### DIFF
--- a/openxml4Net/OPC/Internal/ZipHelper.cs
+++ b/openxml4Net/OPC/Internal/ZipHelper.cs
@@ -183,10 +183,6 @@ namespace NPOI.OpenXml4Net.OPC.Internal
             {
                 stream.Reset();
             }
-            else if (stream is FileStream)
-            {
-                // File open check, about to be closed, nothing to do
-            }
             else
             {
                 // Oh dear... I hope you know what you're doing!

--- a/test.runsettings
+++ b/test.runsettings
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <RunSettings>
   <RunConfiguration>
-      <ResultsDirectory>.\TestResults</ResultsDirectory>
+      <ResultsDirectory>./TestResults</ResultsDirectory>
    </RunConfiguration>
 
   <TestRunParameters>
     <Parameter name="loggername" value="TestCases.Util.DummyPOILogger,NPOI.TestCases"/>
-    <Parameter name="HSSF.testdata.path" value="..\..\..\testcases\test-data\hssf"/>
-    <Parameter name="POIFS.testdata.path" value="..\..\..\testcases\test-data\poifs"/>
-    <Parameter name="POI.testdata.path" value="..\..\..\testcases\test-data"/>
-    <Parameter name="java.io.tmpdir" value="..\..\..\testcases\test-data"/>
-    <Parameter name="poi.keep.tmp.files" value="..\..\..\testcases\test-data\"/>
-    <Parameter name="font.metrics.filename" value="..\..\..\testcases\test-data\font_metrics.properties"/>
-    <Parameter name="escher.data.path" value="..\..\..\testcases\test-data\ddf\"/>
+    <Parameter name="HSSF.testdata.path" value="../../../testcases/test-data/hssf"/>
+	<Parameter name="POIFS.testdata.path" value="../../../testcases/test-data/poifs"/>
+	<Parameter name="POI.testdata.path" value="../../../testcases/test-data"/>
+	<Parameter name="java.io.tmpdir" value="../../../testcases/test-data"/>
+	<Parameter name="poi.keep.tmp.files" value="../../../testcases/test-data/"/>
+	<Parameter name="font.metrics.filename" value="../../../testcases/test-data/font_metrics.properties"/>
+	<Parameter name="escher.data.path" value="../../../testcases/test-data/ddf/"/>
   </TestRunParameters>
 </RunSettings>

--- a/testcases/main/HSSF/Model/TestFormulaParser.cs
+++ b/testcases/main/HSSF/Model/TestFormulaParser.cs
@@ -805,14 +805,14 @@ namespace TestCases.HSSF.Model
 
             Type[] expClss;
 
-            expClss = new Type[] { 
-                typeof(RefPtg), 
+            expClss = new Type[] {
+                typeof(RefPtg),
                 typeof(AttrPtg), // tAttrIf
-                typeof(MissingArgPtg), 
+                typeof(MissingArgPtg),
                 typeof(AttrPtg), // tAttrSkip
                 typeof(RefPtg),
                 typeof(AttrPtg), // tAttrSkip
-                typeof(FuncVarPtg), 
+                typeof(FuncVarPtg),
         };
 
             ConfirmTokenClasses("if(A1, ,C1)", expClss);
@@ -868,7 +868,7 @@ namespace TestCases.HSSF.Model
                 {
                     Assert.Fail("Identified bug 28754a");
                 }
-                throw e;
+                throw;
             }
             Assert.AreEqual("test\"ing", sp.Value);
 
@@ -1240,8 +1240,8 @@ namespace TestCases.HSSF.Model
 
             ArrayPtg aptg = (ArrayPtg)ptgs[0];
             Object[,] values = aptg.GetTokenArrayValues();
-            Assert.AreEqual(ErrorConstant.ValueOf(FormulaError.REF.Code), values[0,3]);
-            Assert.AreEqual(false, values[1,0]);
+            Assert.AreEqual(ErrorConstant.ValueOf(FormulaError.REF.Code), values[0, 3]);
+            Assert.AreEqual(false, values[1, 0]);
         }
         [Test]
         public void TestParseStringElementInArray()
@@ -1249,7 +1249,7 @@ namespace TestCases.HSSF.Model
             Ptg[] ptgs;
             ptgs = ParseFormula("MAX({\"5\"},3)");
             ConfirmTokenClasses(ptgs, typeof(ArrayPtg), typeof(IntPtg), typeof(FuncVarPtg));
-            object element = ((ArrayPtg)ptgs[0]).GetTokenArrayValues()[0,0];
+            object element = ((ArrayPtg)ptgs[0]).GetTokenArrayValues()[0, 0];
             if (element is UnicodeString)
             {
                 // this would cause ClassCastException below
@@ -1290,14 +1290,14 @@ namespace TestCases.HSSF.Model
                 throw e;
             }
             ConfirmTokenClasses(ptgs, typeof(ArrayPtg));
-            Object element = ((ArrayPtg)ptgs[0]).GetTokenArrayValues()[0,0];
+            Object element = ((ArrayPtg)ptgs[0]).GetTokenArrayValues()[0, 0];
 
             Assert.AreEqual(-42.0, (Double)element, 0.0);
 
             // Should be able to handle whitespace between unary minus and digits (Excel
             // accepts this formula after presenting the user with a Confirmation dialog).
             ptgs = ParseFormula("{- 5}");
-            element = ((ArrayPtg)ptgs[0]).GetTokenArrayValues()[0,0];
+            element = ((ArrayPtg)ptgs[0]).GetTokenArrayValues()[0, 0];
             Assert.AreEqual(-5.0, (Double)element, 0.0);
         }
         [Test]
@@ -1378,7 +1378,7 @@ namespace TestCases.HSSF.Model
             Ptg[] ptgs = FormulaParser.Parse(formula, HSSFEvaluationWorkbook.Create(wb), FormulaType.Cell, -1, -1);
 
             ConfirmTokenClasses(ptgs,
-                // TODO - AttrPtg), // Excel prepends this
+                    // TODO - AttrPtg), // Excel prepends this
                     typeof(MemFuncPtg),
                     typeof(Area3DPtg),
                     typeof(Area3DPtg),
@@ -1406,7 +1406,7 @@ namespace TestCases.HSSF.Model
             wb.CreateSheet("Sheet1");
             Ptg[] ptgs = FormulaParser.Parse(formula, HSSFEvaluationWorkbook.Create(wb), FormulaType.Cell, -1);
             ConfirmTokenClasses(ptgs,
-                    // TODO - AttrPtg.class, // Excel prepends this
+                // TODO - AttrPtg.class, // Excel prepends this
                 typeof(MemFuncPtg),
                 typeof(Area3DPtg),
                 typeof(Area3DPtg),
@@ -1456,7 +1456,7 @@ namespace TestCases.HSSF.Model
                     typeof(ParenthesisPtg)
                 );
         }
-    
+
 
         /** Named ranges with backslashes, e.g. 'POI\\2009' */
         [Test]
@@ -1520,7 +1520,7 @@ namespace TestCases.HSSF.Model
                     Assert.Fail("Identified bug 46951");
                 }
                 wb.Close();
-                throw e;
+                throw;
             }
             ConfirmTokenClasses(ptgs,
                 typeof(MemFuncPtg), // [len=23]
@@ -1627,7 +1627,7 @@ namespace TestCases.HSSF.Model
 
             ptgs = ParseFormula("SUM(A1:B2:C3:D4)");
             ConfirmTokenClasses(ptgs,
-                // AttrPtg), // [volatile ] // POI doesn't do this yet (Apr 2009)
+                    // AttrPtg), // [volatile ] // POI doesn't do this yet (Apr 2009)
                     typeof(MemAreaPtg), // len 19
                     typeof(AreaPtg), // [A1:B2]
                     typeof(AreaPtg), // [C3:D4]

--- a/testcases/main/HSSF/Model/TestLinkTable.cs
+++ b/testcases/main/HSSF/Model/TestLinkTable.cs
@@ -60,7 +60,7 @@ namespace TestCases.HSSF.Model
                 {
                     throw new AssertionException("Identified bug 45046 b");
                 }
-                throw e;
+                throw;
             }
             // some other sanity Checks
             Assert.AreEqual(3, wb.NumberOfSheets);
@@ -90,7 +90,7 @@ namespace TestCases.HSSF.Model
                 {
                     throw new AssertionException("Identified bug 45698");
                 }
-                throw e;
+                throw;
             }
             // some other sanity Checks
             Assert.AreEqual(7, wb.NumberOfSheets);
@@ -169,7 +169,7 @@ namespace TestCases.HSSF.Model
                     throw new AssertionException("Identified bug 47001b");
                 }
 
-                throw e;
+                throw;
             }
             Assert.IsNotNull(lt);
         }

--- a/testcases/main/HSSF/Model/TestSheet.cs
+++ b/testcases/main/HSSF/Model/TestSheet.cs
@@ -74,15 +74,18 @@ namespace TestCases.HSSF.Model
             Assert.IsTrue(outRecs[pos++] is EOFRecord);
         }
 
-       private class MergedCellListener:RecordVisitor 
-       {
+        private class MergedCellListener : RecordVisitor
+        {
 
             private int _count;
-            public MergedCellListener() {
+            public MergedCellListener()
+            {
                 _count = 0;
             }
-            public void VisitRecord(Record r) {
-                if (r is MergeCellsRecord) {
+            public void VisitRecord(Record r)
+            {
+                if (r is MergeCellsRecord)
+                {
                     _count++;
                 }
             }
@@ -115,7 +118,7 @@ namespace TestCases.HSSF.Model
             //test that the regions were spread out over the appropriate number of records
             MergedCellListener mcListener = new MergedCellListener();
             sheet.VisitContainedRecords(mcListener, 0);
-            int recordsAdded = mcListener.Count; 
+            int recordsAdded = mcListener.Count;
             int recordsExpected = regionsToAdd / 1027;
             if ((regionsToAdd % 1027) != 0)
                 recordsExpected++;
@@ -149,7 +152,7 @@ namespace TestCases.HSSF.Model
             int regionsToAdd = 4096;
 
             for (int n = 0; n < regionsToAdd; n++)
-                sheet.AddMergedRegion(0, 0, 1,1);
+                sheet.AddMergedRegion(0, 0, 1, 1);
 
             int nSheetRecords = sheet.Records.Count;
 
@@ -158,7 +161,7 @@ namespace TestCases.HSSF.Model
             {
                 sheet.RemoveMergedRegion(0);
                 //assert they have been deleted
-                Assert.AreEqual(sheet.NumMergedRegions,regionsToAdd - n - 1, "Num of regions should be " + (regionsToAdd - n - 1) + " not " + sheet.NumMergedRegions);
+                Assert.AreEqual(sheet.NumMergedRegions, regionsToAdd - n - 1, "Num of regions should be " + (regionsToAdd - n - 1) + " not " + sheet.NumMergedRegions);
             }
 
             // merge records are removed from within the MergedCellsTable, 
@@ -211,12 +214,12 @@ namespace TestCases.HSSF.Model
         private static Record CreateWindow2Record()
         {
             WindowTwoRecord result = new WindowTwoRecord();
-            result.Options=((short)0x6b6);
-            result.TopRow=((short)0);
-            result.LeftCol=((short)0);
-            result.HeaderColor=(0x40);
-            result.PageBreakZoom=((short)0);
-            result.NormalZoom=((short)0);
+            result.Options = ((short)0x6b6);
+            result.TopRow = ((short)0);
+            result.LeftCol = ((short)0);
+            result.HeaderColor = (0x40);
+            result.PageBreakZoom = ((short)0);
+            result.NormalZoom = ((short)0);
             return result;
         }
 
@@ -284,10 +287,14 @@ namespace TestCases.HSSF.Model
             for (int i = 0; i < rowBreaks.Length; i++)
             {
                 int main = rowBreaks[i];
-                if (main != 0 && main != 10 && main != 11) Assert.Fail("Invalid page break");
-                if (main == 0) is0 = true;
-                if (main == 10) is10 = true;
-                if (main == 11) is11 = true;
+                if (main != 0 && main != 10 && main != 11)
+                    Assert.Fail("Invalid page break");
+                if (main == 0)
+                    is0 = true;
+                if (main == 10)
+                    is10 = true;
+                if (main == 11)
+                    is11 = true;
             }
 
             Assert.IsTrue(is0 && is10 && is11, "one of the breaks didnt make it");
@@ -344,11 +351,16 @@ namespace TestCases.HSSF.Model
             for (int i = 0; i < colBreaks.Length; i++)
             {
                 int main = colBreaks[i];
-                if (main != 0 && main != 1 && main != 10 && main != 15) Assert.Fail("Invalid page break");
-                if (main == 0) is0 = true;
-                if (main == 1) is1 = true;
-                if (main == 10) is10 = true;
-                if (main == 15) is15 = true;
+                if (main != 0 && main != 1 && main != 10 && main != 15)
+                    Assert.Fail("Invalid page break");
+                if (main == 0)
+                    is0 = true;
+                if (main == 1)
+                    is1 = true;
+                if (main == 10)
+                    is10 = true;
+                if (main == 15)
+                    is15 = true;
             }
 
             Assert.IsTrue(is0 && is1 && is10 && is15, "one of the breaks didnt make it");
@@ -568,31 +580,35 @@ namespace TestCases.HSSF.Model
  * Checks for bug introduced around r682282-r683880 that caused a second GUTS records
  * which in turn got the dimensions record out of alignment
  */
-        public void TestGutsRecord_bug45640() {
+        public void TestGutsRecord_bug45640()
+        {
 
             InternalSheet sheet = InternalSheet.CreateSheet();
-        sheet.AddRow(new RowRecord(0));
-        sheet.AddRow(new RowRecord(1));
-        sheet.GroupRowRange( 0, 1, true );
-        sheet.ToString();
-        IList recs = sheet.Records;
-        int count=0;
-        for(int i=0; i< recs.Count; i++) {
-            if (recs[i] is GutsRecord) {
-                count++;
+            sheet.AddRow(new RowRecord(0));
+            sheet.AddRow(new RowRecord(1));
+            sheet.GroupRowRange(0, 1, true);
+            sheet.ToString();
+            IList recs = sheet.Records;
+            int count = 0;
+            for (int i = 0; i < recs.Count; i++)
+            {
+                if (recs[i] is GutsRecord)
+                {
+                    count++;
+                }
             }
+            if (count == 2)
+            {
+                throw new AssertionException("Identified bug 45640");
+            }
+            Assert.AreEqual(1, count);
         }
-        if (count == 2) {
-            throw new AssertionException("Identified bug 45640");
-        }
-        Assert.AreEqual(1, count);
-    }
 
         public void TestMisplacedMergedCellsRecords_bug45699()
         {
             HSSFWorkbook wb = HSSFTestDataSamples.OpenSampleWorkbook("ex45698-22488.xls");
 
-            HSSFSheet sheet =(HSSFSheet)wb.GetSheetAt(0);
+            HSSFSheet sheet = (HSSFSheet)wb.GetSheetAt(0);
             HSSFRow row = (HSSFRow)sheet.GetRow(3);
             HSSFCell cell = (HSSFCell)row.GetCell(4);
             if (cell == null)
@@ -658,7 +674,7 @@ namespace TestCases.HSSF.Model
                 {
                     throw new AssertionException("Identified bug 46206");
                 }
-                throw e;
+                throw;
             }
 
             RecordInspector.RecordCollector rv = new RecordInspector.RecordCollector();
@@ -689,7 +705,7 @@ namespace TestCases.HSSF.Model
             //Assert.AreEqual(23, sheetRecs.Count);
             Assert.AreEqual(24, sheetRecs.Count); //for SheetExtRecord
 
-            FormulaShifter shifter = FormulaShifter.CreateForRowShift(0,"", 0, 0, 1, SpreadsheetVersion.EXCEL97);
+            FormulaShifter shifter = FormulaShifter.CreateForRowShift(0, "", 0, 0, 1, SpreadsheetVersion.EXCEL97);
             sheet.UpdateFormulasAfterCellShift(shifter, 0);
             if (sheetRecs.Count == 25 && sheetRecs[22] is ConditionalFormattingTable)
             {
@@ -748,7 +764,7 @@ namespace TestCases.HSSF.Model
                 {
                     throw new AssertionException("Identified bug 46776");
                 }
-                throw e;
+                throw;
             }
 
             TestCases.HSSF.UserModel.RecordInspector.RecordCollector rc = new TestCases.HSSF.UserModel.RecordInspector.RecordCollector();

--- a/testcases/main/HSSF/Record/Aggregates/TestPageSettingsBlock.cs
+++ b/testcases/main/HSSF/Record/Aggregates/TestPageSettingsBlock.cs
@@ -72,20 +72,20 @@ namespace TestCases.HSSF.Record.Aggregates
             nr.Value = (3.0);
 
             NPOI.HSSF.Record.Record[] recs = {
-				BOFRecord.CreateSheetBOF(),
-				new HeaderRecord("&LSales Figures"),
-				new FooterRecord("&LJanuary"),
-				new HeaderFooterRecord(HexRead.ReadFromString("9C 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 C4 60 00 00 00 00 00 00 00 00")),
-				new DimensionsRecord(),
-				new WindowTwoRecord(),
-				new UserSViewBegin(HexRead.ReadFromString("ED 77 3B 86 BC 3F 37 4C A9 58 60 23 43 68 54 4B 01 00 00 00 64 00 00 00 40 00 00 00 02 00 00 00 3D 80 04 00 00 00 00 00 00 00 0C 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 F0 3F FF FF 01 00")),
-				new HeaderRecord("&LSales Figures"),
-				new FooterRecord("&LJanuary"),
-				new HeaderFooterRecord(HexRead.ReadFromString("9C 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 C4 60 00 00 00 00 00 00 00 00")),
-				new UserSViewEnd(HexRead.ReadFromString("01, 00")),
+                BOFRecord.CreateSheetBOF(),
+                new HeaderRecord("&LSales Figures"),
+                new FooterRecord("&LJanuary"),
+                new HeaderFooterRecord(HexRead.ReadFromString("9C 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 C4 60 00 00 00 00 00 00 00 00")),
+                new DimensionsRecord(),
+                new WindowTwoRecord(),
+                new UserSViewBegin(HexRead.ReadFromString("ED 77 3B 86 BC 3F 37 4C A9 58 60 23 43 68 54 4B 01 00 00 00 64 00 00 00 40 00 00 00 02 00 00 00 3D 80 04 00 00 00 00 00 00 00 0C 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 F0 3F FF FF 01 00")),
+                new HeaderRecord("&LSales Figures"),
+                new FooterRecord("&LJanuary"),
+                new HeaderFooterRecord(HexRead.ReadFromString("9C 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 C4 60 00 00 00 00 00 00 00 00")),
+                new UserSViewEnd(HexRead.ReadFromString("01, 00")),
 
-				EOFRecord.instance,
-		};
+                EOFRecord.instance,
+        };
             RecordStream rs = new RecordStream(Arrays.AsList(recs), 0);
             InternalSheet sheet;
             try
@@ -98,7 +98,7 @@ namespace TestCases.HSSF.Record.Aggregates
                 {
                     throw new AssertionException("Identified bug 46480");
                 }
-                throw e;
+                throw;
             }
 
             TestCases.HSSF.UserModel.RecordInspector.RecordCollector rv = new TestCases.HSSF.UserModel.RecordInspector.RecordCollector();
@@ -122,14 +122,14 @@ namespace TestCases.HSSF.Record.Aggregates
             nr.Value = (3.0);
 
             NPOI.HSSF.Record.Record[] recs = {
-				BOFRecord.CreateSheetBOF(),
-				new HeaderRecord("&LSales Figures"),
-				new FooterRecord("&LJanuary"),
-				new DimensionsRecord(),
-				new WindowTwoRecord(),
-				new HeaderFooterRecord(HexRead.ReadFromString("9C 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 C4 60 00 00 00 00 00 00 00 00")),
-				EOFRecord.instance,
-		};
+                BOFRecord.CreateSheetBOF(),
+                new HeaderRecord("&LSales Figures"),
+                new FooterRecord("&LJanuary"),
+                new DimensionsRecord(),
+                new WindowTwoRecord(),
+                new HeaderFooterRecord(HexRead.ReadFromString("9C 08 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 C4 60 00 00 00 00 00 00 00 00")),
+                EOFRecord.instance,
+        };
             RecordStream rs = new RecordStream(Arrays.AsList(recs), 0);
             InternalSheet sheet = InternalSheet.CreateSheet(rs);
 
@@ -168,14 +168,14 @@ namespace TestCases.HSSF.Record.Aggregates
         {
 
             NPOI.HSSF.Record.Record[] recs = {
-				BOFRecord.CreateSheetBOF(),
-				new HeaderRecord("&LSales Figures"),
-				new FooterRecord("&LJanuary"),
-				new DimensionsRecord(),
-				CreateBottomMargin(0.787F),
-				new WindowTwoRecord(),
-				EOFRecord.instance,
-		};
+                BOFRecord.CreateSheetBOF(),
+                new HeaderRecord("&LSales Figures"),
+                new FooterRecord("&LJanuary"),
+                new DimensionsRecord(),
+                CreateBottomMargin(0.787F),
+                new WindowTwoRecord(),
+                EOFRecord.instance,
+        };
             RecordStream rs = new RecordStream(Arrays.AsList(recs), 0);
 
             InternalSheet sheet;
@@ -189,7 +189,7 @@ namespace TestCases.HSSF.Record.Aggregates
                 {
                     throw new AssertionException("Identified bug 47199a - failed to process late margings records");
                 }
-                throw e;
+                throw;
             }
 
             TestCases.HSSF.UserModel.RecordInspector.RecordCollector rv = new TestCases.HSSF.UserModel.RecordInspector.RecordCollector();
@@ -223,9 +223,9 @@ namespace TestCases.HSSF.Record.Aggregates
 
             // Hypothetical Setup of PSB records which should cause POI to crash
             NPOI.HSSF.Record.Record[] recs = {
-				new HeaderRecord("&LSales Figures"),
-				new HeaderRecord("&LInventory"),
-		};
+                new HeaderRecord("&LSales Figures"),
+                new HeaderRecord("&LInventory"),
+        };
             RecordStream rs = new RecordStream(Arrays.AsList(recs), 0);
 
             try
@@ -261,9 +261,9 @@ namespace TestCases.HSSF.Record.Aggregates
         {
             // Initialise PSB with some records, but not the header / footer
             NPOI.HSSF.Record.Record[] recs = {
-				new HCenterRecord(),
-				new VCenterRecord(),
-		};
+                new HCenterRecord(),
+                new VCenterRecord(),
+        };
             RecordStream rs = new RecordStream(Arrays.AsList(recs), 0);
             PageSettingsBlock psb = new PageSettingsBlock(rs);
 
@@ -306,12 +306,12 @@ namespace TestCases.HSSF.Record.Aggregates
             NPOI.HSSF.Record.Record contB1 = new ContinueRecord(HexRead.ReadFromString("FE ED"));
             NPOI.HSSF.Record.Record contB2 = new ContinueRecord(HexRead.ReadFromString("FA CE"));
             NPOI.HSSF.Record.Record[] recs = {
-				new HeaderRecord("&LSales Figures"),
-				new FooterRecord("&LInventory"),
-				new HCenterRecord(),
-				new VCenterRecord(),
-				plsA,
-				plsB, contB1, contB2, // make sure continuing PLS is still OK
+                new HeaderRecord("&LSales Figures"),
+                new FooterRecord("&LInventory"),
+                new HCenterRecord(),
+                new VCenterRecord(),
+                plsA,
+                plsB, contB1, contB2, // make sure continuing PLS is still OK
 		};
             RecordStream rs = new RecordStream(Arrays.AsList(recs), 0);
             PageSettingsBlock psb;
@@ -375,7 +375,7 @@ namespace TestCases.HSSF.Record.Aggregates
                 {
                     throw new AssertionException("Identified bug 48026");
                 }
-                throw e;
+                throw;
             }
 
             RecordInspector.RecordCollector rv = new RecordInspector.RecordCollector();

--- a/testcases/main/HSSF/Record/Chart/TestSeriesToChartGroupRecord.cs
+++ b/testcases/main/HSSF/Record/Chart/TestSeriesToChartGroupRecord.cs
@@ -34,10 +34,11 @@ namespace TestCases.HSSF.Record.Chart
      * @author Andrew C. Oliver (acoliver at apache.org)
      */
     [TestFixture]
+    [Obsolete]
     public class TestSeriesToChartGroupRecord
     {
         byte[] data = new byte[] {
-	        (byte)0x0, (byte)0x0
+            (byte)0x0, (byte)0x0
         };
 
         public TestSeriesToChartGroupRecord()

--- a/testcases/main/HSSF/Record/TestRecordFactory.cs
+++ b/testcases/main/HSSF/Record/TestRecordFactory.cs
@@ -171,14 +171,14 @@ namespace TestCases.HSSF.Record
              *  Taken from a real test sample file 39512.xls. See Bug 39512 for details.
              */
             String dump =
-                //OBJ
+                    //OBJ
                     "5D 00 48 00 15 00 12 00 0C 00 3C 00 11 00 A0 2E 03 01 CC 42 " +
                     "CF 00 00 00 00 00 0A 00 0C 00 00 00 00 00 00 00 00 00 00 00 " +
                     "03 00 0B 00 06 00 28 01 03 01 00 00 12 00 08 00 00 00 00 00 " +
                     "00 00 03 00 11 00 04 00 3D 00 00 00 00 00 00 00 " +
-                //MSODRAWING
+                    //MSODRAWING
                     "EC 00 08 00 00 00 0D F0 00 00 00 00 " +
-                //TXO (and 2 trailing CONTINUE records)
+                    //TXO (and 2 trailing CONTINUE records)
                     //"B6 01 12 00 22 02 00 00 00 00 00 00 00 00 10 00 10 00 00 00 " +
                     //"00 00 3C 00 21 00 01 4F 00 70 00 74 00 69 00 6F 00 6E 00 20 " +
                     //"00 42 00 75 00 74 00 74 00 6F 00 6E 00 20 00 33 00 39 00 3C " +
@@ -186,7 +186,7 @@ namespace TestCases.HSSF.Record
                     "B6 01 12 00 22 02 00 00 00 00 00 00 00 00 10 00 10 00 00 00 00 00 " +
                     "3C 00 11 00 00 4F 70 74 69 6F 6E 20 42 75 74 74 6F 6E 20 33 39 " +
                     "3C 00 10 00 00 00 05 00 00 00 00 00 10 00 00 00 00 00 00 00 " +
-                // another CONTINUE
+                    // another CONTINUE
                     "3C 00 7E 00 0F 00 04 F0 7E 00 00 00 92 0C 0A F0 08 00 00 00 " +
                     "3D 04 00 00 00 0A 00 00 A3 00 0B F0 3C 00 00 00 7F 00 00 01 " +
                     "00 01 80 00 8C 01 03 01 85 00 01 00 00 00 8B 00 02 00 00 00 " +
@@ -194,7 +194,7 @@ namespace TestCases.HSSF.Record
                     "00 00 10 00 C0 01 40 00 00 08 FF 01 00 00 08 00 00 00 10 F0 " +
                     "12 00 00 00 02 00 02 00 A0 03 18 00 B5 00 04 00 30 02 1A 00 " +
                     "00 00 00 00 11 F0 00 00 00 00 " +
-                //OBJ
+                    //OBJ
                     "5D 00 48 00 15 00 12 00 0C 00 3D 00 11 00 8C 01 03 01 C8 59 CF 00 00 " +
                     "00 00 00 0A 00 0C 00 00 00 00 00 00 00 00 00 00 00 03 00 0B 00 06 00 " +
                     "7C 16 03 01 00 00 12 00 08 00 00 00 00 00 00 00 03 00 11 00 04 00 01 " +
@@ -211,7 +211,7 @@ namespace TestCases.HSSF.Record
 
             //Serialize and verify that the Serialized data is1 the same as the original
             MemoryStream out1 = new MemoryStream();
-            for (IEnumerator it = records.GetEnumerator(); it.MoveNext(); )
+            for (IEnumerator it = records.GetEnumerator(); it.MoveNext();)
             {
                 Record rec = (Record)it.Current;
                 byte[] serialdata = rec.Serialize();
@@ -226,17 +226,17 @@ namespace TestCases.HSSF.Record
         public void TestNonZeroPadding_bug46987()
         {
             Record[] recs = {
-			    new BOFRecord(),
-			    new WriteAccessRecord(), // need *something* between BOF and EOF
+                new BOFRecord(),
+                new WriteAccessRecord(), // need *something* between BOF and EOF
 			    EOFRecord.instance,
-			    BOFRecord.CreateSheetBOF(),
-			    EOFRecord.instance,
-		    };
+                BOFRecord.CreateSheetBOF(),
+                EOFRecord.instance,
+            };
             MemoryStream baos = new MemoryStream();
             for (int i = 0; i < recs.Length; i++)
             {
                 byte[] data = recs[i].Serialize();
-                baos.Write(data,0,data.Length);
+                baos.Write(data, 0, data.Length);
             }
             //simulate the bad padding at the end of the workbook stream in attachment 23483 of bug 46987
             baos.WriteByte(0x00);
@@ -266,7 +266,7 @@ namespace TestCases.HSSF.Record
                 {
                     throw new AssertionException("Identified bug 46987");
                 }
-                throw e;
+                throw;
             }
             Assert.AreEqual(5, outRecs.Count);
         }

--- a/testcases/main/HSSF/UserModel/TestBugs.cs
+++ b/testcases/main/HSSF/UserModel/TestBugs.cs
@@ -222,7 +222,8 @@ namespace TestCases.HSSF.UserModel
         [Ignore("this test was not found in poi 3.8beta4")]
         public void Test22568()
         {
-            int r = 2000; int c = 3;
+            int r = 2000;
+            int c = 3;
 
             HSSFWorkbook wb = new HSSFWorkbook();
             ISheet sheet = wb.CreateSheet("ExcelTest");
@@ -1241,7 +1242,7 @@ namespace TestCases.HSSF.UserModel
             Assert.AreEqual(4, wb.NumberOfFonts);
 
             IFont f1 = wb.GetFontAt((short)0);
-            Assert.AreEqual(400, f1.Boldweight);
+            Assert.IsFalse(f1.IsBold);
 
             // Check that asking for the same font
             //  multiple times gives you the same thing.
@@ -1264,7 +1265,7 @@ namespace TestCases.HSSF.UserModel
             //  yet to Add
             Assert.IsNull(
                 wb.FindFont(
-                    (short)11, (short)123, (short)22,
+                    true, (short)123, (short)22,
                     "Thingy", false, true, FontSuperScript.Sub, FontUnderlineType.Double
                 )
             );
@@ -1275,7 +1276,7 @@ namespace TestCases.HSSF.UserModel
             Assert.AreEqual(5, nf.Index);
             Assert.AreEqual(nf, wb.GetFontAt((short)5));
 
-            nf.Boldweight = ((short)11);
+            nf.IsBold = true;
             nf.Color = ((short)123);
             nf.FontHeight = ((short)22);
             nf.FontName = ("Thingy");
@@ -1290,20 +1291,20 @@ namespace TestCases.HSSF.UserModel
             // Find it now
             Assert.IsNotNull(
                 wb.FindFont(
-                    (short)11, (short)123, (short)22,
+                    true, (short)123, (short)22,
                     "Thingy", false, true, FontSuperScript.Sub, FontUnderlineType.Double
                 )
             );
             Assert.AreEqual(
                 5,
                 wb.FindFont(
-                       (short)11, (short)123, (short)22,
+                       true, (short)123, (short)22,
                        "Thingy", false, true, FontSuperScript.Sub, FontUnderlineType.Double
                    ).Index
             );
             Assert.AreEqual(nf,
                    wb.FindFont(
-                       (short)11, (short)123, (short)22,
+                       true, (short)123, (short)22,
                        "Thingy", false, true, FontSuperScript.Sub, FontUnderlineType.Double
                    )
             );
@@ -1558,7 +1559,8 @@ namespace TestCases.HSSF.UserModel
         {
             HSSFWorkbook wb = OpenSample("44958.xls");
             ISheet sh = wb.GetSheetAt(0);
-            for (short i = 0; i < 30; i++) sh.AutoSizeColumn(i);
+            for (short i = 0; i < 30; i++)
+                sh.AutoSizeColumn(i);
         }
 
         /**

--- a/testcases/main/HSSF/UserModel/TestBugs.cs
+++ b/testcases/main/HSSF/UserModel/TestBugs.cs
@@ -3401,7 +3401,7 @@ namespace TestCases.HSSF.UserModel
                 Assert.IsNull(cell.CellFormula);
                 Assert.Fail("Should throw an exception here");
             }
-            catch (InvalidOperationException e)
+            catch
             {
                 // expected here
             }
@@ -3490,11 +3490,13 @@ namespace TestCases.HSSF.UserModel
         [Test]
         public void Test52447()
         {
-            IWorkbook wb=null;
+            IWorkbook wb = null;
             try
             {
                 wb = HSSFTestDataSamples.OpenSampleWorkbook("52447.xls");
-            } catch { 
+            }
+            catch
+            {
                 Assert.IsNotNull(wb);
             }
         }

--- a/testcases/main/HSSF/UserModel/TestCellStyle.cs
+++ b/testcases/main/HSSF/UserModel/TestCellStyle.cs
@@ -15,7 +15,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-        
+
 
 /*
  * TestCellStyle.java
@@ -67,82 +67,82 @@ namespace TestCases.HSSF.UserModel
          */
         [Test]
         public void TestWriteSheetFont()
-    {
-        string             filepath = TempFile.GetTempFilePath("TestWriteSheetFont",
-                                                    ".xls");
-        FileStream out1  = new FileStream(filepath,FileMode.OpenOrCreate);
-        HSSFWorkbook     wb   = new HSSFWorkbook();
-        NPOI.SS.UserModel.ISheet        s    = wb.CreateSheet();
-        IRow          r    = null;
-        ICell         c    = null;
-        IFont         fnt  = wb.CreateFont();
-        NPOI.SS.UserModel.ICellStyle    cs   = wb.CreateCellStyle();
-
-        fnt.Color=(HSSFColor.Red.Index);
-        fnt.Boldweight= (short)FontBoldWeight.Bold;
-        cs.SetFont(fnt);
-        for (short rownum = ( short ) 0; rownum < 100; rownum++)
         {
-            r = s.CreateRow(rownum);
+            string filepath = TempFile.GetTempFilePath("TestWriteSheetFont",
+                                                        ".xls");
+            FileStream out1 = new FileStream(filepath, FileMode.OpenOrCreate);
+            HSSFWorkbook wb = new HSSFWorkbook();
+            NPOI.SS.UserModel.ISheet s = wb.CreateSheet();
+            IRow r = null;
+            ICell c = null;
+            IFont fnt = wb.CreateFont();
+            NPOI.SS.UserModel.ICellStyle cs = wb.CreateCellStyle();
 
-            // r.SetRowNum(( short ) rownum);
-            for (short cellnum = ( short ) 0; cellnum < 50; cellnum += 2)
+            fnt.Color = (HSSFColor.Red.Index);
+            fnt.IsBold = true;
+            cs.SetFont(fnt);
+            for (short rownum = (short)0; rownum < 100; rownum++)
             {
-                c = r.CreateCell(cellnum);
-                c.SetCellValue(rownum * 10000 + cellnum
-                               + ((( double ) rownum / 1000)
-                                  + (( double ) cellnum / 10000)));
-                c = r.CreateCell(cellnum + 1);
-                c.SetCellValue("TEST");
-                c.CellStyle = (cs);
-            }
-        }
-        wb.Write(out1);
-        out1.Close();
-        SanityChecker sanityChecker = new SanityChecker();
-        sanityChecker.CheckHSSFWorkbook(wb);
-        Assert.AreEqual(99, s.LastRowNum, "LAST ROW == 99");
-        Assert.AreEqual(0, s.FirstRowNum, "FIRST ROW == 0");
+                r = s.CreateRow(rownum);
 
-        // assert((s.LastRowNum == 99));
-    }
+                // r.SetRowNum(( short ) rownum);
+                for (short cellnum = (short)0; cellnum < 50; cellnum += 2)
+                {
+                    c = r.CreateCell(cellnum);
+                    c.SetCellValue(rownum * 10000 + cellnum
+                                   + (((double)rownum / 1000)
+                                      + ((double)cellnum / 10000)));
+                    c = r.CreateCell(cellnum + 1);
+                    c.SetCellValue("TEST");
+                    c.CellStyle = (cs);
+                }
+            }
+            wb.Write(out1);
+            out1.Close();
+            SanityChecker sanityChecker = new SanityChecker();
+            sanityChecker.CheckHSSFWorkbook(wb);
+            Assert.AreEqual(99, s.LastRowNum, "LAST ROW == 99");
+            Assert.AreEqual(0, s.FirstRowNum, "FIRST ROW == 0");
+
+            // assert((s.LastRowNum == 99));
+        }
 
         /**
          * Tests that is creating a file with a date or an calendar works correctly.
          */
         [Test]
         public void TestDataStyle()
-            
-    {
-        string             filepath = TempFile.GetTempFilePath("TestWriteSheetStyleDate",
-                                                    ".xls");
-        FileStream out1  = new FileStream(filepath,FileMode.OpenOrCreate);
-        HSSFWorkbook     wb   = new HSSFWorkbook();
-        NPOI.SS.UserModel.ISheet        s    = wb.CreateSheet();
-        NPOI.SS.UserModel.ICellStyle    cs   = wb.CreateCellStyle();
-        IRow row = s.CreateRow(0);
 
-        // with Date:
-        ICell cell = row.CreateCell(1);
-        cs.DataFormat=(HSSFDataFormat.GetBuiltinFormat("m/d/yy"));
-        cell.CellStyle = (cs);
-        cell.SetCellValue(DateTime.Now);
+        {
+            string filepath = TempFile.GetTempFilePath("TestWriteSheetStyleDate",
+                                                        ".xls");
+            FileStream out1 = new FileStream(filepath, FileMode.OpenOrCreate);
+            HSSFWorkbook wb = new HSSFWorkbook();
+            NPOI.SS.UserModel.ISheet s = wb.CreateSheet();
+            NPOI.SS.UserModel.ICellStyle cs = wb.CreateCellStyle();
+            IRow row = s.CreateRow(0);
 
-        // with Calendar:
-        cell = row.CreateCell(2);
-        cs.DataFormat=(HSSFDataFormat.GetBuiltinFormat("m/d/yy"));
-        cell.CellStyle = (cs);
-        cell.SetCellValue(DateTime.Now);
+            // with Date:
+            ICell cell = row.CreateCell(1);
+            cs.DataFormat = (HSSFDataFormat.GetBuiltinFormat("m/d/yy"));
+            cell.CellStyle = (cs);
+            cell.SetCellValue(DateTime.Now);
 
-        wb.Write(out1);
-        out1.Close();
-        SanityChecker sanityChecker = new SanityChecker();
-        sanityChecker.CheckHSSFWorkbook(wb);
+            // with Calendar:
+            cell = row.CreateCell(2);
+            cs.DataFormat = (HSSFDataFormat.GetBuiltinFormat("m/d/yy"));
+            cell.CellStyle = (cs);
+            cell.SetCellValue(DateTime.Now);
 
-        Assert.AreEqual(0, s.LastRowNum, "LAST ROW ");
-        Assert.AreEqual(0, s.FirstRowNum,"FIRST ROW ");
+            wb.Write(out1);
+            out1.Close();
+            SanityChecker sanityChecker = new SanityChecker();
+            sanityChecker.CheckHSSFWorkbook(wb);
 
-    }
+            Assert.AreEqual(0, s.LastRowNum, "LAST ROW ");
+            Assert.AreEqual(0, s.FirstRowNum, "FIRST ROW ");
+
+        }
         [Test]
         public void TestHashEquals()
         {
@@ -188,55 +188,55 @@ namespace TestCases.HSSF.UserModel
          */
         [Test]
         public void TestWriteSheetStyle()
-    {
-        string             filepath = TempFile.GetTempFilePath("TestWriteSheetStyle",
-                                                    ".xls");
-        FileStream out1  = new FileStream(filepath,FileMode.OpenOrCreate);
-        HSSFWorkbook     wb   = new HSSFWorkbook();
-        NPOI.SS.UserModel.ISheet        s    = wb.CreateSheet();
-        IRow          r    = null;
-        ICell         c    = null;
-        IFont         fnt  = wb.CreateFont();
-        NPOI.SS.UserModel.ICellStyle cs = wb.CreateCellStyle();
-        NPOI.SS.UserModel.ICellStyle cs2 = wb.CreateCellStyle();
-
-        cs.BorderBottom= (BorderStyle.Thin);
-        cs.BorderLeft= (BorderStyle.Thin);
-        cs.BorderRight= (BorderStyle.Thin);
-        cs.BorderTop= (BorderStyle.Thin);
-        cs.FillForegroundColor= ( short ) 0xA;
-        cs.FillPattern = FillPattern.SolidForeground;
-        fnt.Color= ( short ) 0xf;
-        fnt.IsItalic= (true);
-        cs2.FillForegroundColor= ( short ) 0x0;
-        cs2.FillPattern= FillPattern.SolidForeground;
-        cs2.SetFont(fnt);
-        for (short rownum = ( short ) 0; rownum < 100; rownum++)
         {
-            r = s.CreateRow(rownum);
+            string filepath = TempFile.GetTempFilePath("TestWriteSheetStyle",
+                                                        ".xls");
+            FileStream out1 = new FileStream(filepath, FileMode.OpenOrCreate);
+            HSSFWorkbook wb = new HSSFWorkbook();
+            NPOI.SS.UserModel.ISheet s = wb.CreateSheet();
+            IRow r = null;
+            ICell c = null;
+            IFont fnt = wb.CreateFont();
+            NPOI.SS.UserModel.ICellStyle cs = wb.CreateCellStyle();
+            NPOI.SS.UserModel.ICellStyle cs2 = wb.CreateCellStyle();
 
-            // r.SetRowNum(( short ) rownum);
-            for (short cellnum = ( short ) 0; cellnum < 50; cellnum += 2)
+            cs.BorderBottom = (BorderStyle.Thin);
+            cs.BorderLeft = (BorderStyle.Thin);
+            cs.BorderRight = (BorderStyle.Thin);
+            cs.BorderTop = (BorderStyle.Thin);
+            cs.FillForegroundColor = (short)0xA;
+            cs.FillPattern = FillPattern.SolidForeground;
+            fnt.Color = (short)0xf;
+            fnt.IsItalic = (true);
+            cs2.FillForegroundColor = (short)0x0;
+            cs2.FillPattern = FillPattern.SolidForeground;
+            cs2.SetFont(fnt);
+            for (short rownum = (short)0; rownum < 100; rownum++)
             {
-                c = r.CreateCell(cellnum);
-                c.SetCellValue(rownum * 10000 + cellnum
-                               + ((( double ) rownum / 1000)
-                                  + (( double ) cellnum / 10000)));
-                c.CellStyle = (cs);
-                c = r.CreateCell(cellnum + 1);
-                c.SetCellValue("TEST");
-                c.CellStyle = (cs2);
-            }
-        }
-        wb.Write(out1);
-        out1.Close();
-        SanityChecker sanityChecker = new SanityChecker();
-        sanityChecker.CheckHSSFWorkbook(wb);
-        Assert.AreEqual(99, s.LastRowNum, "LAST ROW == 99");
-        Assert.AreEqual(0, s.FirstRowNum, "FIRST ROW == 0");
+                r = s.CreateRow(rownum);
 
-        // assert((s.LastRowNum == 99));
-    }
+                // r.SetRowNum(( short ) rownum);
+                for (short cellnum = (short)0; cellnum < 50; cellnum += 2)
+                {
+                    c = r.CreateCell(cellnum);
+                    c.SetCellValue(rownum * 10000 + cellnum
+                                   + (((double)rownum / 1000)
+                                      + ((double)cellnum / 10000)));
+                    c.CellStyle = (cs);
+                    c = r.CreateCell(cellnum + 1);
+                    c.SetCellValue("TEST");
+                    c.CellStyle = (cs2);
+                }
+            }
+            wb.Write(out1);
+            out1.Close();
+            SanityChecker sanityChecker = new SanityChecker();
+            sanityChecker.CheckHSSFWorkbook(wb);
+            Assert.AreEqual(99, s.LastRowNum, "LAST ROW == 99");
+            Assert.AreEqual(0, s.FirstRowNum, "FIRST ROW == 0");
+
+            // assert((s.LastRowNum == 99));
+        }
 
         /**
          * Cloning one NPOI.SS.UserModel.CellType onto Another, same
@@ -247,20 +247,20 @@ namespace TestCases.HSSF.UserModel
         {
             HSSFWorkbook wb = new HSSFWorkbook();
             IFont fnt = wb.CreateFont();
-            fnt.FontName=("TestingFont");
+            fnt.FontName = ("TestingFont");
             Assert.AreEqual(5, wb.NumberOfFonts);
 
             NPOI.SS.UserModel.ICellStyle orig = wb.CreateCellStyle();
-            orig.Alignment=(HorizontalAlignment.Right);
+            orig.Alignment = (HorizontalAlignment.Right);
             orig.SetFont(fnt);
-            orig.DataFormat=((short)18);
+            orig.DataFormat = ((short)18);
 
-            Assert.AreEqual(HorizontalAlignment.Right,orig.Alignment);
-            Assert.AreEqual(fnt,orig.GetFont(wb));
-            Assert.AreEqual(18,orig.DataFormat);
+            Assert.AreEqual(HorizontalAlignment.Right, orig.Alignment);
+            Assert.AreEqual(fnt, orig.GetFont(wb));
+            Assert.AreEqual(18, orig.DataFormat);
 
             NPOI.SS.UserModel.ICellStyle clone = wb.CreateCellStyle();
-            Assert.AreNotEqual(HorizontalAlignment.Right , clone.Alignment);
+            Assert.AreNotEqual(HorizontalAlignment.Right, clone.Alignment);
             Assert.AreNotEqual(fnt, clone.GetFont(wb));
             Assert.AreNotEqual(18, clone.DataFormat);
 
@@ -284,7 +284,7 @@ namespace TestCases.HSSF.UserModel
             HSSFWorkbook wbOrig = new HSSFWorkbook();
 
             IFont fnt = wbOrig.CreateFont();
-            fnt.FontName=("TestingFont");
+            fnt.FontName = ("TestingFont");
             Assert.AreEqual(5, wbOrig.NumberOfFonts);
 
             IDataFormat fmt = wbOrig.CreateDataFormat();
@@ -294,11 +294,11 @@ namespace TestCases.HSSF.UserModel
             NPOI.SS.UserModel.ICellStyle orig = wbOrig.CreateCellStyle();
             orig.Alignment = (HorizontalAlignment.Right);
             orig.SetFont(fnt);
-            orig.DataFormat=(fmt.GetFormat("Test##"));
+            orig.DataFormat = (fmt.GetFormat("Test##"));
 
             Assert.AreEqual(HorizontalAlignment.Right, orig.Alignment);
-            Assert.AreEqual(fnt,orig.GetFont(wbOrig));
-            Assert.AreEqual(fmt.GetFormat("Test##") , orig.DataFormat);
+            Assert.AreEqual(fnt, orig.GetFont(wbOrig));
+            Assert.AreEqual(fmt.GetFormat("Test##"), orig.DataFormat);
 
             // Now a style on another workbook
             HSSFWorkbook wbClone = new HSSFWorkbook();
@@ -308,14 +308,14 @@ namespace TestCases.HSSF.UserModel
             NPOI.SS.UserModel.ICellStyle clone = wbClone.CreateCellStyle();
             Assert.AreEqual(4, wbClone.NumberOfFonts);
 
-            Assert.AreNotEqual(HorizontalAlignment.Right,clone.Alignment);
+            Assert.AreNotEqual(HorizontalAlignment.Right, clone.Alignment);
             Assert.AreNotEqual("TestingFont", clone.GetFont(wbClone).FontName);
 
             clone.CloneStyleFrom(orig);
             Assert.AreEqual(HorizontalAlignment.Right, clone.Alignment);
-            Assert.AreEqual("TestingFont" ,clone.GetFont(wbClone).FontName);
-            Assert.AreEqual(fmtClone.GetFormat("Test##"),clone.DataFormat);
-            Assert.AreNotEqual(fmtClone.GetFormat("Test##") , fmt.GetFormat("Test##"));
+            Assert.AreEqual("TestingFont", clone.GetFont(wbClone).FontName);
+            Assert.AreEqual(fmtClone.GetFormat("Test##"), clone.DataFormat);
+            Assert.AreNotEqual(fmtClone.GetFormat("Test##"), fmt.GetFormat("Test##"));
             Assert.AreEqual(5, wbClone.NumberOfFonts);
         }
         [Test]
@@ -521,6 +521,6 @@ namespace TestCases.HSSF.UserModel
 
             wb.Close();
         }
-        
+
     }
 }

--- a/testcases/main/HSSF/UserModel/TestHSSFCell.cs
+++ b/testcases/main/HSSF/UserModel/TestHSSFCell.cs
@@ -142,7 +142,7 @@ namespace TestCases.HSSF.UserModel
             // string to error code
             cell.SetCellValue("abc");
             ConfirmStringRecord(sheet, true);
-            cell.SetCellErrorValue(FormulaError.REF.Code);
+            cell.SetCellErrorValue(FormulaError.REF);
             ConfirmStringRecord(sheet, false);
 
             // string to boolean

--- a/testcases/main/HSSF/UserModel/TestHSSFFormulaEvaluator.cs
+++ b/testcases/main/HSSF/UserModel/TestHSSFFormulaEvaluator.cs
@@ -146,7 +146,7 @@ namespace TestCases.HSSF.UserModel
                 {
                     Assert.Fail("Identified bug 47048a");
                 }
-                throw e;
+                throw;
             }
             finally
             {

--- a/testcases/main/HSSF/UserModel/TestHSSFName.cs
+++ b/testcases/main/HSSF/UserModel/TestHSSFName.cs
@@ -43,7 +43,7 @@ namespace TestCases.HSSF.UserModel
         public TestHSSFName()
             : base(HSSFITestDataProvider.Instance)
         {
-            
+
         }
 
         /**
@@ -56,7 +56,7 @@ namespace TestCases.HSSF.UserModel
         {
 
             FieldInfo f;
-            f = typeof(HSSFName).GetField("_definedNameRec",BindingFlags.Instance|BindingFlags.NonPublic);
+            f = typeof(HSSFName).GetField("_definedNameRec", BindingFlags.Instance | BindingFlags.NonPublic);
             //f.SetAccessible(true);
             return (NameRecord)f.GetValue(definedName);
         }
@@ -204,6 +204,7 @@ namespace TestCases.HSSF.UserModel
         }
 
         [Test]
+        [Obsolete]
         public void TestDeletedReference()
         {
             HSSFWorkbook wb = HSSFTestDataSamples.OpenSampleWorkbook("24207.xls");

--- a/testcases/main/HSSF/UserModel/TestHSSFSheet.cs
+++ b/testcases/main/HSSF/UserModel/TestHSSFSheet.cs
@@ -567,7 +567,9 @@ namespace TestCases.HSSF.UserModel
 
             workbook.Close();
         }
+
         [Test]
+        [Obsolete]
         public void TestZoom()
         {
             HSSFWorkbook wb = new HSSFWorkbook();
@@ -734,7 +736,8 @@ namespace TestCases.HSSF.UserModel
             HSSFWorkbook wb2 = HSSFTestDataSamples.OpenSampleWorkbook("Simple.xls");
 
             sheet = wb2.GetSheetAt(0);
-            for (int i = 3; i < 10; i++) sheet.CreateRow(i);
+            for (int i = 3; i < 10; i++)
+                sheet.CreateRow(i);
 
             HSSFTestDataSamples.WriteOutAndReadBack(wb2).Close();
 

--- a/testcases/main/HSSF/UserModel/TestHSSFSheet.cs
+++ b/testcases/main/HSSF/UserModel/TestHSSFSheet.cs
@@ -449,7 +449,7 @@ namespace TestCases.HSSF.UserModel
             Assert.IsTrue(hssfSheet.ObjectProtect);
             Assert.AreEqual(expectedHashA, hssfSheet.Password);
             Assert.AreEqual(expectedHashA, hssfSheet.Sheet.ProtectionBlock.PasswordHash);
-            
+
 
             // Clone the sheet, and make sure the password hash is preserved
             HSSFSheet sheet2 = (HSSFSheet)workbook.CloneSheet(0);
@@ -1132,7 +1132,7 @@ namespace TestCases.HSSF.UserModel
             Assert.AreEqual(11 * 20, bs.GetFont(wbSimple).FontHeight);
             Assert.AreEqual(8, bs.GetFont(wbSimple).Color);
             Assert.IsFalse(bs.GetFont(wbSimple).IsItalic);
-            Assert.AreEqual((int)FontBoldWeight.Normal, bs.GetFont(wbSimple).Boldweight);
+            Assert.IsFalse(bs.GetFont(wbSimple).IsBold);
 
 
             ICellStyle cs = wbComplex.GetSheetAt(0).GetColumnStyle(1);
@@ -1142,7 +1142,7 @@ namespace TestCases.HSSF.UserModel
             Assert.AreEqual(8 * 20, cs.GetFont(wbComplex).FontHeight);
             Assert.AreEqual(10, cs.GetFont(wbComplex).Color);
             Assert.IsFalse(cs.GetFont(wbComplex).IsItalic);
-            Assert.AreEqual((int)FontBoldWeight.Bold, cs.GetFont(wbComplex).Boldweight);
+            Assert.IsTrue(cs.GetFont(wbComplex).IsBold);
 
             wbComplex.Close();
             wbSimple.Close();

--- a/testcases/main/HSSF/UserModel/TestHSSFWorkbook.cs
+++ b/testcases/main/HSSF/UserModel/TestHSSFWorkbook.cs
@@ -49,7 +49,8 @@ namespace TestCases.HSSF.UserModel
     {
         public TestHSSFWorkbook()
             : base(HSSFITestDataProvider.Instance)
-        { }
+        {
+        }
         /**
      * gives test code access to the {@link InternalWorkbook} within {@link HSSFWorkbook}
      */
@@ -178,7 +179,7 @@ namespace TestCases.HSSF.UserModel
             Assert.AreEqual(1, b.ActiveSheetIndex);
             Assert.AreEqual(1, b.FirstVisibleTab);
         }
-        
+
         [Test]
         public void ReadWriteWithCharts()
         {
@@ -636,7 +637,7 @@ namespace TestCases.HSSF.UserModel
                     // there was a problem in the code which locates the existing print titles name record 
                     throw new Exception("Identified bug 45720b");
                 }
-                throw e;
+                throw;
             }
             HSSFWorkbook wb2 = HSSFTestDataSamples.WriteOutAndReadBack(wb1);
             wb1.Close();

--- a/testcases/main/HSSF/UserModel/TestLinkTable.cs
+++ b/testcases/main/HSSF/UserModel/TestLinkTable.cs
@@ -36,7 +36,7 @@ namespace TestCases.HSSF.UserModel
                 {
                     throw new AssertionException("Identified bug 45046 b");
                 }
-                throw e;
+                throw;
             }
             // some other sanity Checks
             Assert.AreEqual(3, wb.NumberOfSheets);
@@ -66,7 +66,7 @@ namespace TestCases.HSSF.UserModel
                 {
                     throw new AssertionException("Identified bug 45698");
                 }
-                throw e;
+                throw;
             }
             // some other sanity Checks
             Assert.AreEqual(7, wb.NumberOfSheets);

--- a/testcases/main/HSSF/UserModel/TestRowStyle.cs
+++ b/testcases/main/HSSF/UserModel/TestRowStyle.cs
@@ -13,7 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
-        
+
 
 /*
  * TestRowStyle.java
@@ -68,13 +68,13 @@ namespace TestCases.HSSF.UserModel
             IFont fnt = wb.CreateFont();
             NPOI.SS.UserModel.ICellStyle cs = wb.CreateCellStyle();
 
-            fnt.Color=(NPOI.HSSF.Util.HSSFColor.Red.Index);
-            fnt.Boldweight=(short)FontBoldWeight.Bold;
+            fnt.Color = (NPOI.HSSF.Util.HSSFColor.Red.Index);
+            fnt.IsBold = true;
             cs.SetFont(fnt);
             for (short rownum = (short)0; rownum < 100; rownum++)
             {
                 r = s.CreateRow(rownum);
-                r.RowStyle=(cs);
+                r.RowStyle = (cs);
                 r.CreateCell(0);
             }
             wb = HSSFTestDataSamples.WriteOutAndReadBack(wb);
@@ -97,15 +97,15 @@ namespace TestCases.HSSF.UserModel
             IRow row = s.CreateRow((short)0);
 
             // with Date:
-            cs.DataFormat=(HSSFDataFormat.GetBuiltinFormat("m/d/yy"));
-            row.RowStyle=(cs);
+            cs.DataFormat = (HSSFDataFormat.GetBuiltinFormat("m/d/yy"));
+            row.RowStyle = (cs);
             row.CreateCell(0);
 
 
             // with Calendar:
             row = s.CreateRow((short)1);
-            cs.DataFormat= (HSSFDataFormat.GetBuiltinFormat("m/d/yy"));
-            row.RowStyle=(cs);
+            cs.DataFormat = (HSSFDataFormat.GetBuiltinFormat("m/d/yy"));
+            row.RowStyle = (cs);
             row.CreateCell(0);
 
             wb = HSSFTestDataSamples.WriteOutAndReadBack(wb);
@@ -138,28 +138,29 @@ namespace TestCases.HSSF.UserModel
             NPOI.SS.UserModel.ICellStyle cs = wb.CreateCellStyle();
             NPOI.SS.UserModel.ICellStyle cs2 = wb.CreateCellStyle();
 
-            cs.BorderBottom=(BorderStyle.Thin);
-            cs.BorderLeft=(BorderStyle.Thin);
-            cs.BorderRight=(BorderStyle.Thin);
-            cs.BorderTop=(BorderStyle.Thin);
-            cs.FillForegroundColor=((short)0xA);
+            cs.BorderBottom = (BorderStyle.Thin);
+            cs.BorderLeft = (BorderStyle.Thin);
+            cs.BorderRight = (BorderStyle.Thin);
+            cs.BorderTop = (BorderStyle.Thin);
+            cs.FillForegroundColor = ((short)0xA);
             cs.FillPattern = FillPattern.SolidForeground;
-            fnt.Color=((short)0xf);
-            fnt.IsItalic=(true);
-            cs2.FillForegroundColor=((short)0x0);
+            fnt.Color = ((short)0xf);
+            fnt.IsItalic = (true);
+            cs2.FillForegroundColor = ((short)0x0);
             cs2.FillPattern = FillPattern.SolidForeground;
             cs2.SetFont(fnt);
             for (short rownum = (short)0; rownum < 100; rownum++)
             {
                 r = s.CreateRow(rownum);
-                r.RowStyle=(cs);
+                r.RowStyle = (cs);
                 r.CreateCell(0);
 
                 rownum++;
-                if (rownum >= 100) break; // I feel too lazy to Check if this isreqd :-/ 
+                if (rownum >= 100)
+                    break; // I feel too lazy to Check if this isreqd :-/ 
 
                 r = s.CreateRow(rownum);
-                r.RowStyle=(cs2);
+                r.RowStyle = (cs2);
                 r.CreateCell(0);
             }
             wb = HSSFTestDataSamples.WriteOutAndReadBack(wb);
@@ -182,11 +183,12 @@ namespace TestCases.HSSF.UserModel
                 Assert.AreEqual(cs.BorderLeft, BorderStyle.Thin, "Left Border Style for row: ");
                 Assert.AreEqual(cs.BorderRight, BorderStyle.Thin, "Right Border Style for row: ");
                 Assert.AreEqual(cs.BorderTop, BorderStyle.Thin, "Top Border Style for row: ");
-                Assert.AreEqual(0xA, cs.FillForegroundColor,  "FillForegroundColor for row: ");
-                Assert.AreEqual((short)0x1, (short)cs.FillPattern,  "FillPattern for row: ");
+                Assert.AreEqual(0xA, cs.FillForegroundColor, "FillForegroundColor for row: ");
+                Assert.AreEqual((short)0x1, (short)cs.FillPattern, "FillPattern for row: ");
 
                 rownum++;
-                if (rownum >= 100) break; // I feel too lazy to Check if this isreqd :-/ 
+                if (rownum >= 100)
+                    break; // I feel too lazy to Check if this isreqd :-/ 
 
                 r = s.GetRow(rownum);
                 Assert.IsNotNull(r, "Row is not null");

--- a/testcases/main/HSSF/UserModel/TestSheetShiftRows.cs
+++ b/testcases/main/HSSF/UserModel/TestSheetShiftRows.cs
@@ -24,6 +24,7 @@ namespace TestCases.HSSF.UserModel
     using NUnit.Framework;
     using TestCases.HSSF;
     using NPOI.SS.UserModel;
+    using NPOI.SS.Util;
 
     /**
      * Tests row shifting capabilities.
@@ -60,11 +61,11 @@ namespace TestCases.HSSF.UserModel
             // row (in original file each row was unique)
             s = wb.GetSheetAt(0);
 
-            Assert.AreEqual(1,s.GetRow(0).PhysicalNumberOfCells);
+            Assert.AreEqual(1, s.GetRow(0).PhysicalNumberOfCells);
             ConfirmEmptyRow(s, 1);
             Assert.AreEqual(2, s.GetRow(2).PhysicalNumberOfCells);
-            Assert.AreEqual(4,s.GetRow(3).PhysicalNumberOfCells);
-            Assert.AreEqual(5,s.GetRow(4).PhysicalNumberOfCells);
+            Assert.AreEqual(4, s.GetRow(3).PhysicalNumberOfCells);
+            Assert.AreEqual(5, s.GetRow(4).PhysicalNumberOfCells);
 
             // Shift rows 1-3 down 3 in the current one.  This Tests when
             // 1 row is blank.  Write to a another temp file
@@ -76,9 +77,9 @@ namespace TestCases.HSSF.UserModel
             ConfirmEmptyRow(s, 0);
             ConfirmEmptyRow(s, 1);
             ConfirmEmptyRow(s, 2);
-            Assert.AreEqual(1,s.GetRow(3).PhysicalNumberOfCells);
+            Assert.AreEqual(1, s.GetRow(3).PhysicalNumberOfCells);
             ConfirmEmptyRow(s, 4);
-            Assert.AreEqual(2,s.GetRow(5).PhysicalNumberOfCells);
+            Assert.AreEqual(2, s.GetRow(5).PhysicalNumberOfCells);
 
             // Read the first file again
             wb = HSSFTestDataSamples.OpenSampleWorkbook("SimpleMultiCell.xls");
@@ -156,16 +157,16 @@ namespace TestCases.HSSF.UserModel
             Assert.AreEqual(3, sheet.LastRowNum);
 
             // Verify comments are in the position expected
-            Assert.IsNotNull(sheet.GetCellComment(0, 0));
-            Assert.IsNull(sheet.GetCellComment(1, 0));
-            Assert.IsNotNull(sheet.GetCellComment(2, 0));
-            Assert.IsNotNull(sheet.GetCellComment(3, 0));
+            Assert.IsNotNull(sheet.GetCellComment(new CellAddress(0, 0)));
+            Assert.IsNull(sheet.GetCellComment(new CellAddress(1, 0)));
+            Assert.IsNotNull(sheet.GetCellComment(new CellAddress(2, 0)));
+            Assert.IsNotNull(sheet.GetCellComment(new CellAddress(3, 0)));
 
-            String comment1 = sheet.GetCellComment(0, 0).String.String;
+            String comment1 = sheet.GetCellComment(new CellAddress(0, 0)).String.String;
             Assert.AreEqual(comment1, "comment top row1 (index0)\n");
-            String comment3 = sheet.GetCellComment(2, 0).String.String;
+            String comment3 = sheet.GetCellComment(new CellAddress(2, 0)).String.String;
             Assert.AreEqual(comment3, "comment top row3 (index2)\n");
-            String comment4 = sheet.GetCellComment(3, 0).String.String;
+            String comment4 = sheet.GetCellComment(new CellAddress(3, 0)).String.String;
             Assert.AreEqual(comment4, "comment top row4 (index3)\n");
 
             // Shifting all but first line down to Test comments shifting
@@ -175,17 +176,17 @@ namespace TestCases.HSSF.UserModel
 
             // Test that comments were shifted as expected
             Assert.AreEqual(4, sheet.LastRowNum);
-            Assert.IsNotNull(sheet.GetCellComment(0, 0));
-            Assert.IsNull(sheet.GetCellComment(1, 0));
-            Assert.IsNull(sheet.GetCellComment(2, 0));
-            Assert.IsNotNull(sheet.GetCellComment(3, 0));
-            Assert.IsNotNull(sheet.GetCellComment(4, 0));
+            Assert.IsNotNull(sheet.GetCellComment(new CellAddress(0, 0)));
+            Assert.IsNull(sheet.GetCellComment(new CellAddress(1, 0)));
+            Assert.IsNull(sheet.GetCellComment(new CellAddress(2, 0)));
+            Assert.IsNotNull(sheet.GetCellComment(new CellAddress(3, 0)));
+            Assert.IsNotNull(sheet.GetCellComment(new CellAddress(4, 0)));
 
-            String comment1_shifted = sheet.GetCellComment(0, 0).String.String;
+            String comment1_shifted = sheet.GetCellComment(new CellAddress(0, 0)).String.String;
             Assert.AreEqual(comment1, comment1_shifted);
-            String comment3_shifted = sheet.GetCellComment(3, 0).String.String;
+            String comment3_shifted = sheet.GetCellComment(new CellAddress(3, 0)).String.String;
             Assert.AreEqual(comment3, comment3_shifted);
-            String comment4_shifted = sheet.GetCellComment(4, 0).String.String;
+            String comment4_shifted = sheet.GetCellComment(new CellAddress(4, 0)).String.String;
             Assert.AreEqual(comment4, comment4_shifted);
 
             // Write out and read back in again
@@ -195,17 +196,17 @@ namespace TestCases.HSSF.UserModel
             Assert.AreEqual(4, sheet.LastRowNum);
 
             // Verify comments are in the position expected after the shift
-            Assert.IsNotNull(sheet.GetCellComment(0, 0));
-            Assert.IsNull(sheet.GetCellComment(1, 0));
-            Assert.IsNull(sheet.GetCellComment(2, 0));
-            Assert.IsNotNull(sheet.GetCellComment(3, 0));
-            Assert.IsNotNull(sheet.GetCellComment(4, 0));
+            Assert.IsNotNull(sheet.GetCellComment(new CellAddress(0, 0)));
+            Assert.IsNull(sheet.GetCellComment(new CellAddress(1, 0)));
+            Assert.IsNull(sheet.GetCellComment(new CellAddress(2, 0)));
+            Assert.IsNotNull(sheet.GetCellComment(new CellAddress(3, 0)));
+            Assert.IsNotNull(sheet.GetCellComment(new CellAddress(4, 0)));
 
-            comment1_shifted = sheet.GetCellComment(0, 0).String.String;
+            comment1_shifted = sheet.GetCellComment(new CellAddress(0, 0)).String.String;
             Assert.AreEqual(comment1, comment1_shifted);
-            comment3_shifted = sheet.GetCellComment(3, 0).String.String;
+            comment3_shifted = sheet.GetCellComment(new CellAddress(3, 0)).String.String;
             Assert.AreEqual(comment3, comment3_shifted);
-            comment4_shifted = sheet.GetCellComment(4, 0).String.String;
+            comment4_shifted = sheet.GetCellComment(new CellAddress(4, 0)).String.String;
             Assert.AreEqual(comment4, comment4_shifted);
         }
 

--- a/testcases/main/HSSF/Util/TestAreaReference.cs
+++ b/testcases/main/HSSF/Util/TestAreaReference.cs
@@ -34,6 +34,7 @@ namespace TestCases.HSSF.Util
     using NPOI.SS.Formula.PTG;
 
     [TestFixture]
+    [Obsolete]
     public class TestAreaReference
     {
 

--- a/testcases/main/NPOI.TestCases.Core.csproj
+++ b/testcases/main/NPOI.TestCases.Core.csproj
@@ -10,6 +10,12 @@
     <OutputPath>..\..\solution\$(Configuration)\</OutputPath>
   </PropertyGroup>
 
+	<PropertyGroup>
+		<DefineConstants>HIDE_UNREACHABLE_CODE</DefineConstants>
+		<NoWarn>1701;1702;0108;0618;618;108;0612;612;162;0162</NoWarn>
+		<WarningLevel>1</WarningLevel>
+	</PropertyGroup>
+	
   <ItemGroup>
     <Compile Remove="HSSF\UserModel\TestEscherGraphics2d.cs" />
     <Compile Remove="SS\Formula\Function\ExcelFileFormatDocFunctionExtractor.cs" />

--- a/testcases/main/NPOI.TestCases.Core.csproj
+++ b/testcases/main/NPOI.TestCases.Core.csproj
@@ -10,12 +10,6 @@
     <OutputPath>..\..\solution\$(Configuration)\</OutputPath>
   </PropertyGroup>
 
-	<PropertyGroup>
-		<DefineConstants>HIDE_UNREACHABLE_CODE</DefineConstants>
-		<NoWarn>1701;1702;0108;0618;618;108;0612;612;162;0162</NoWarn>
-		<WarningLevel>1</WarningLevel>
-	</PropertyGroup>
-	
   <ItemGroup>
     <Compile Remove="HSSF\UserModel\TestEscherGraphics2d.cs" />
     <Compile Remove="SS\Formula\Function\ExcelFileFormatDocFunctionExtractor.cs" />

--- a/testcases/main/POIFS/FileSystem/TestFileSystemBugs.cs
+++ b/testcases/main/POIFS/FileSystem/TestFileSystemBugs.cs
@@ -36,7 +36,7 @@ namespace TestCases.POIFS.FileSystem
         protected List<NPOIFSFileSystem> openedFSs;
         protected void tearDown()
         {
-            if (openedFSs != null && openedFSs.Count>0)
+            if (openedFSs != null && openedFSs.Count > 0)
             {
                 foreach (NPOIFSFileSystem fs in openedFSs)
                 {
@@ -70,21 +70,25 @@ namespace TestCases.POIFS.FileSystem
         protected DirectoryNode[] openSamples(Stream[] inps, bool oldFails)
         {
             NPOIFSFileSystem nfs = new NPOIFSFileSystem(inps[0]);
-            if (openedFSs == null) openedFSs = new List<NPOIFSFileSystem>();
+            if (openedFSs == null)
+                openedFSs = new List<NPOIFSFileSystem>();
             openedFSs.Add(nfs);
 
             OPOIFSFileSystem ofs = null;
             try
             {
                 ofs = new OPOIFSFileSystem(inps[1]);
-                if (oldFails) Assert.Fail("POIFSFileSystem should have failed but didn't");
+                if (oldFails)
+                    Assert.Fail("POIFSFileSystem should have failed but didn't");
             }
-            catch (Exception e)
+            catch
             {
-                if (!oldFails) throw e;
+                if (!oldFails)
+                    throw;
             }
 
-            if (ofs == null) return new DirectoryNode[] { nfs.Root };
+            if (ofs == null)
+                return new DirectoryNode[] { nfs.Root };
             return new DirectoryNode[] { ofs.Root, nfs.Root };
         }
 

--- a/testcases/main/POIFS/FileSystem/TestNPOIFSMiniStore.cs
+++ b/testcases/main/POIFS/FileSystem/TestNPOIFSMiniStore.cs
@@ -389,7 +389,7 @@ namespace TestCases.POIFS.FileSystem
             {
                 ministore.GetNextBlock(0);
             }
-            catch (ArgumentOutOfRangeException e) { }
+            catch { }
 
             // Write a very small new document, will populate the ministore for us
             byte[] data = new byte[8];
@@ -429,7 +429,7 @@ namespace TestCases.POIFS.FileSystem
             dis = new DocumentInputStream(entry);
             IOUtils.ReadFully(dis, rdata);
             CollectionAssert.AreEqual(data, rdata);
-            
+
             dis.Close();
 
             entry = (DocumentEntry)fs.Root.GetEntry("mini2");

--- a/testcases/main/SS/Format/CellFormatTestBase.cs
+++ b/testcases/main/SS/Format/CellFormatTestBase.cs
@@ -207,18 +207,14 @@ namespace TestCases.SS.Format
         }
 
         Color labelForeColor;
-        string labelText;
         private void tryFormat(int row, String expectedText, String desc,
                 CellValue getter, ICell cell)
         {
 
             Object value = getter.GetValue(cell);
             Color testColor = getter.GetColor(cell);
-            if (testColor == null)
-                testColor = TEST_COLOR;
 
             labelForeColor = testColor;
-            labelText = "xyzzy";
 
             logger.Log(POILogger.INFO, String.Format("Row %d: \"%s\" -> \"%s\": expected \"%s\"", row + 1,
                     value.ToString(), desc, expectedText));
@@ -256,7 +252,7 @@ namespace TestCases.SS.Format
             Color actualColor = labelForeColor;
             getter.Equivalent(expectedText, actualText, format);
             Assert.AreEqual(
-                    expectedColor, actualColor,cname == null ? "no color" : "color " + cname);
+                    expectedColor, actualColor, cname == null ? "no color" : "color " + cname);
             return actualText;
         }
         /// <summary>

--- a/testcases/main/SS/Formula/Atp/TestTextJoinFunction.cs
+++ b/testcases/main/SS/Formula/Atp/TestTextJoinFunction.cs
@@ -16,11 +16,9 @@ namespace TestCases.SS.Formula.Atp
         private IFormulaEvaluator evaluator;
         private ICell textCell1;
         private ICell textCell2;
-        private ICell textCell3;
         private ICell numericCell1;
         private ICell numericCell2;
         private ICell blankCell;
-        private ICell emptyCell;
         private ICell formulaCell;
 
         private IWorkbook InitWorkbook1()

--- a/testcases/main/SS/Formula/Eval/TestRangeEval.cs
+++ b/testcases/main/SS/Formula/Eval/TestRangeEval.cs
@@ -27,6 +27,7 @@ namespace TestCases.SS.Formula.Eval
     using NPOI.SS.UserModel;
     using NPOI.SS.Util;
     using NPOI.Util;
+    using NPOI.HSSF.Util;
 
     /**
      * Test for unary plus operator Evaluator.
@@ -40,29 +41,35 @@ namespace TestCases.SS.Formula.Eval
         public void TestPermutations()
         {
 
-            Confirm("B3", "D7", "B3:D7");
-            Confirm("B1", "B1", "B1:B1");
+            Confirm("B3", "D7", 2, 6, 1, 3);
+            Confirm("B1", "B1", 0, 0, 1, 1);
 
-            Confirm("B7", "D3", "B3:D7");
-            Confirm("D3", "B7", "B3:D7");
-            Confirm("D7", "B3", "B3:D7");
+            Confirm("B7", "D3", 2, 6, 1, 3);
+            Confirm("D3", "B7", 2, 6, 1, 3);
+            Confirm("D7", "B3", 2, 6, 1, 3);
         }
 
-        private static void Confirm(String refA, String refB, String expectedAreaRef)
+        private static void Confirm(
+            String refA,
+            String refB,
+            int firstRow,
+            int lastRow,
+            int firstColumn,
+            int lastColumn)
         {
+            ValueEval[] args =
+            {
+                CreateRefEval(refA),
+                CreateRefEval(refB),
+            };
 
-            ValueEval[] args = {
-            CreateRefEval(refA),
-            CreateRefEval(refB),
-        };
-            AreaReference ar = new AreaReference(expectedAreaRef);
             ValueEval result = EvalInstances.Range.Evaluate(args, 0, (short)0);
             Assert.IsTrue(result is AreaEval);
             AreaEval ae = (AreaEval)result;
-            Assert.AreEqual(ar.FirstCell.Row, ae.FirstRow);
-            Assert.AreEqual(ar.LastCell.Row, ae.LastRow);
-            Assert.AreEqual(ar.FirstCell.Col, ae.FirstColumn);
-            Assert.AreEqual(ar.LastCell.Col, ae.LastColumn);
+            Assert.AreEqual(firstRow, ae.FirstRow);
+            Assert.AreEqual(lastRow, ae.LastRow);
+            Assert.AreEqual(firstColumn, ae.FirstColumn);
+            Assert.AreEqual(lastColumn, ae.LastColumn);
         }
 
         private static ValueEval CreateRefEval(String refStr)

--- a/testcases/main/SS/Formula/Functions/TestIndex.cs
+++ b/testcases/main/SS/Formula/Functions/TestIndex.cs
@@ -44,13 +44,13 @@ namespace TestCases.SS.Formula.Functions
 
         private static Index FUNC_INST = new Index();
         private static double[] TEST_VALUES0 = {
-			1, 2,
-			3, 4,
-			5, 6,
-			7, 8,
-			9, 10,
-			11, 12,
-	};
+            1, 2,
+            3, 4,
+            5, 6,
+            7, 8,
+            9, 10,
+            11, 12,
+    };
 
         /**
          * For the case when the first argument to INDEX() is an area reference
@@ -115,10 +115,10 @@ namespace TestCases.SS.Formula.Functions
         public void TestMissingArg()
         {
             ValueEval[] values = {
-				new NumberEval(25.0),
-				new NumberEval(26.0),
-				new NumberEval(28.0),
-		};
+                new NumberEval(25.0),
+                new NumberEval(26.0),
+                new NumberEval(28.0),
+        };
             AreaEval arg0 = EvalFactory.CreateAreaEval("A10:C10", values);
             ValueEval[] args = new ValueEval[] { arg0, MissingArgEval.instance, new NumberEval(2), };
             ValueEval actualResult;
@@ -132,7 +132,7 @@ namespace TestCases.SS.Formula.Functions
                 {
                     throw new AssertionException("Identified bug 47048b - INDEX() should support missing-arg");
                 }
-                throw e;
+                throw;
             }
             // result should be an area eval "B10:B10"
             AreaEval ae = ConfirmAreaEval("B10:B10", actualResult);

--- a/testcases/main/SS/Formula/Functions/TestMatch.cs
+++ b/testcases/main/SS/Formula/Functions/TestMatch.cs
@@ -65,12 +65,12 @@ namespace TestCases.SS.Formula.Functions
         {
 
             ValueEval[] values = {
-			new NumberEval(4),
-			new NumberEval(5),
-			new NumberEval(10),
-			new NumberEval(10),
-			new NumberEval(25),
-		};
+            new NumberEval(4),
+            new NumberEval(5),
+            new NumberEval(10),
+            new NumberEval(10),
+            new NumberEval(25),
+        };
 
             AreaEval ae = EvalFactory.CreateAreaEval("A1:A5", values);
 
@@ -87,12 +87,12 @@ namespace TestCases.SS.Formula.Functions
         {
 
             ValueEval[] values = {
-			new NumberEval(25),
-			new NumberEval(10),
-			new NumberEval(10),
-			new NumberEval(10),
-			new NumberEval(4),
-		};
+            new NumberEval(25),
+            new NumberEval(10),
+            new NumberEval(10),
+            new NumberEval(10),
+            new NumberEval(4),
+        };
 
             AreaEval ae = EvalFactory.CreateAreaEval("A1:A5", values);
 
@@ -109,12 +109,12 @@ namespace TestCases.SS.Formula.Functions
         {
 
             ValueEval[] values = {
-			new StringEval("Albert"),
-			new StringEval("Charles"),
-			new StringEval("Ed"),
-			new StringEval("Greg"),
-			new StringEval("Ian"),
-		};
+            new StringEval("Albert"),
+            new StringEval("Charles"),
+            new StringEval("Ed"),
+            new StringEval("Greg"),
+            new StringEval("Ian"),
+        };
 
             AreaEval ae = EvalFactory.CreateAreaEval("A1:A5", values);
 
@@ -175,11 +175,11 @@ namespace TestCases.SS.Formula.Functions
         {
 
             ValueEval[] values = {
-				BoolEval.FALSE,
-				BoolEval.FALSE,
-				BoolEval.TRUE,
-				BoolEval.TRUE,
-		};
+                BoolEval.FALSE,
+                BoolEval.FALSE,
+                BoolEval.TRUE,
+                BoolEval.TRUE,
+        };
 
             AreaEval ae = EvalFactory.CreateAreaEval("A1:A4", values);
 
@@ -194,20 +194,20 @@ namespace TestCases.SS.Formula.Functions
         {
 
             ValueEval[] values = {
-				new NumberEval(4),
-				BoolEval.FALSE,
-				new NumberEval(5),
-				new StringEval("Albert"),
-				BoolEval.FALSE,
-				BoolEval.TRUE,
-				new NumberEval(10),
-				new StringEval("Charles"),
-				new StringEval("Ed"),
-				new NumberEval(10),
-				new NumberEval(25),
-				BoolEval.TRUE,
-				new StringEval("Ed"),
-		};
+                new NumberEval(4),
+                BoolEval.FALSE,
+                new NumberEval(5),
+                new StringEval("Albert"),
+                BoolEval.FALSE,
+                BoolEval.TRUE,
+                new NumberEval(10),
+                new StringEval("Charles"),
+                new StringEval("Ed"),
+                new NumberEval(10),
+                new NumberEval(25),
+                BoolEval.TRUE,
+                new StringEval("Ed"),
+        };
 
             AreaEval ae = EvalFactory.CreateAreaEval("A1:A13", values);
 
@@ -242,12 +242,12 @@ namespace TestCases.SS.Formula.Functions
         {
 
             ValueEval[] values = {
-			new NumberEval(4),
-			new NumberEval(5),
-			new NumberEval(10),
-			new NumberEval(10),
-			new NumberEval(25),
-		};
+            new NumberEval(4),
+            new NumberEval(5),
+            new NumberEval(10),
+            new NumberEval(10),
+            new NumberEval(25),
+        };
 
             AreaEval ae = EvalFactory.CreateAreaEval("A1:A5", values);
 
@@ -265,7 +265,7 @@ namespace TestCases.SS.Formula.Functions
                     Assert.Fail(e.Message);
                 }
                 // some other error ??
-                throw e;
+                throw;
             }
         }
 

--- a/testcases/main/SS/Formula/PTG/TestReferencePtg.cs
+++ b/testcases/main/SS/Formula/PTG/TestReferencePtg.cs
@@ -80,11 +80,11 @@ namespace TestCases.SS.Formula.PTG
                 {
                     throw new AssertionException("Identified bug 44921");
                 }
-                throw e;
+                throw;
             }
         }
         private static byte[] tRefN_data = {
-    	0x2C, 33, 44, 55, 66,
+        0x2C, 33, 44, 55, 66,
     };
         [Test]
         public void TestReadWrite_tRefN_bug45091()

--- a/testcases/main/SS/Formula/TestFormulaShifter.cs
+++ b/testcases/main/SS/Formula/TestFormulaShifter.cs
@@ -288,7 +288,7 @@ namespace TestCases.SS.Formula
         [Test]
         public void TestConstructor()
         {
-            Assert.IsNotNull(FormulaShifter.CreateForRowShift(1, "name", 1, 2, 2));
+            Assert.IsNotNull(FormulaShifter.CreateForRowShift(1, "name", 1, 2, 2, SpreadsheetVersion.EXCEL2007));
         }
         [Test]
         public void TestToString()

--- a/testcases/main/SS/UserModel/BaseTestCell.cs
+++ b/testcases/main/SS/UserModel/BaseTestCell.cs
@@ -247,7 +247,7 @@ namespace TestCases.SS.UserModel
             IFont f = wb.CreateFont();
             f.FontHeightInPoints = 20;
             f.Color = (HSSFColor.Red.Index);
-            f.Boldweight = (int)FontBoldWeight.Bold;
+            f.IsBold = true;
             f.FontName = "Arial Unicode MS";
             cs.FillBackgroundColor = 3;
             cs.SetFont(f);
@@ -271,7 +271,7 @@ namespace TestCases.SS.UserModel
 
             Assert.IsNotNull(cs, "Formula Cell Style");
             Assert.AreEqual(f.Index, cs.FontIndex, "Font Index Matches");
-            Assert.AreEqual(BorderStyle.Thin, cs.BorderTop , "Top Border");
+            Assert.AreEqual(BorderStyle.Thin, cs.BorderTop, "Top Border");
             Assert.AreEqual(BorderStyle.Thin, cs.BorderLeft, "Left Border");
             Assert.AreEqual(BorderStyle.Thin, cs.BorderRight, "Right Border");
             Assert.AreEqual(BorderStyle.Thin, cs.BorderBottom, "Bottom Border");
@@ -428,7 +428,7 @@ namespace TestCases.SS.UserModel
             cell.SetCellValue("TRUE");
             Assert.AreEqual(CellType.String, cell.CellType);
             // test conversion of cell from text to boolean
-            cell.SetCellType(CellType.Boolean);            
+            cell.SetCellType(CellType.Boolean);
 
             Assert.AreEqual(CellType.Boolean, cell.CellType);
             Assert.AreEqual(true, cell.BooleanCellValue);
@@ -456,7 +456,7 @@ namespace TestCases.SS.UserModel
             cell.SetCellValue(true);
             // test conversion of cell from boolean to text
             cell.SetCellType(CellType.String);
-   
+
             Assert.AreEqual("TRUE", cell.RichStringCellValue.String);
             wb.Close();
         }

--- a/testcases/main/SS/UserModel/BaseTestConditionalFormatting.cs
+++ b/testcases/main/SS/UserModel/BaseTestConditionalFormatting.cs
@@ -434,7 +434,7 @@ namespace TestCases.SS.UserModel
                 {
                     Assert.Fail("Indentified bug 45682");
                 }
-                throw e;
+                throw;
             }
             finally
             {
@@ -461,7 +461,7 @@ namespace TestCases.SS.UserModel
             IConditionalFormattingRule rule2 = sheetCF.CreateConditionalFormattingRule(
                 ComparisonOperator.Between, "SUM(A10:A15)", "1+SUM(B16:B30)");
             IBorderFormatting borderFmt = rule2.CreateBorderFormatting();
-            borderFmt.BorderDiagonal= BorderStyle.Medium;
+            borderFmt.BorderDiagonal = BorderStyle.Medium;
 
 
             CellRangeAddress[] regions = {
@@ -614,9 +614,12 @@ namespace TestCases.SS.UserModel
                 if (cf is HSSFConditionalFormatting)
                 {
                     String str = cf.ToString();
-                    if (str.Contains("[CF]")) fCF++;
-                    if (str.Contains("[CF12]")) fCF12++;
-                    if (str.Contains("[CFEX]")) fCFEX++;
+                    if (str.Contains("[CF]"))
+                        fCF++;
+                    if (str.Contains("[CF12]"))
+                        fCF12++;
+                    if (str.Contains("[CFEX]"))
+                        fCFEX++;
                 }
                 else
                 {
@@ -681,10 +684,13 @@ namespace TestCases.SS.UserModel
             //   Sets the font colour to dark red
             //   Sets the background colour to lighter red
             // TODO Should the colours be slightly different between formats?
-            if (cr is HSSFConditionalFormattingRule) {
+            if (cr is HSSFConditionalFormattingRule)
+            {
                 AssertColour("8080:0:8080", cr.FontFormatting.FontColor);
                 AssertColour("FFFF:9999:CCCC", cr.PatternFormatting.FillBackgroundColorColor);
-            } else {
+            }
+            else
+            {
                 AssertColour("9C0006", cr.FontFormatting.FontColor);
                 AssertColour("FFC7CE", cr.PatternFormatting.FillBackgroundColorColor);
             }
@@ -894,7 +900,8 @@ namespace TestCases.SS.UserModel
             Assert.AreEqual(null, cr.Formula2);
 
             // TODO Implement
-            if (cr is HSSFConditionalFormattingRule) return;
+            if (cr is HSSFConditionalFormattingRule)
+                return;
             IColorScaleFormatting color = cr.ColorScaleFormatting;
             Assert.IsNotNull(color);
             Assert.IsNotNull(color.Colors);
@@ -904,25 +911,32 @@ namespace TestCases.SS.UserModel
             Assert.AreEqual(colors.Length, color.Thresholds.Length);
 
             // Thresholds should be Min / (evenly spaced) / Max
-            int steps = 100 / (colors.Length-1);
-            for (int i=0; i<colors.Length; i++) {
+            int steps = 100 / (colors.Length - 1);
+            for (int i = 0; i < colors.Length; i++)
+            {
                 IConditionalFormattingThreshold th = color.Thresholds[i];
-                if (i == 0) {
+                if (i == 0)
+                {
                     Assert.AreEqual(RangeType.MIN, th.RangeType);
-                } else if (i == colors.Length-1) {
+                }
+                else if (i == colors.Length - 1)
+                {
                     Assert.AreEqual(RangeType.MAX, th.RangeType);
-                } else {
+                }
+                else
+                {
                     Assert.AreEqual(RangeType.PERCENTILE, th.RangeType);
-                    Assert.AreEqual(steps*i, (int)th.Value.Value);
+                    Assert.AreEqual(steps * i, (int)th.Value.Value);
                 }
                 Assert.AreEqual(null, th.Formula);
             }
 
             // Colors should match
-            for (int i=0; i<colors.Length; i++) {
+            for (int i = 0; i < colors.Length; i++)
+            {
                 AssertColour(colors[i], color.Colors[i]);
             }
-            
+
         }
         [Test]
         public void TestCreateFontFormatting()
@@ -1188,8 +1202,8 @@ namespace TestCases.SS.UserModel
             Assert.AreEqual(RangeType.PERCENT, iconFmt.Thresholds[2].RangeType);
             Assert.AreEqual(RangeType.MAX, iconFmt.Thresholds[3].RangeType);
             Assert.AreEqual(null, iconFmt.Thresholds[0].Value);
-            Assert.AreEqual(10d, iconFmt.Thresholds[1].Value, 0);
-            Assert.AreEqual(75d, iconFmt.Thresholds[2].Value, 0);
+            Assert.AreEqual(10d, iconFmt.Thresholds[1].Value);
+            Assert.AreEqual(75d, iconFmt.Thresholds[2].Value);
             Assert.AreEqual(null, iconFmt.Thresholds[3].Value);
 
             wb2.Close();
@@ -1238,7 +1252,7 @@ namespace TestCases.SS.UserModel
             Assert.AreEqual(RangeType.NUMBER, clrFmt.Thresholds[1].RangeType);
             Assert.AreEqual(RangeType.MAX, clrFmt.Thresholds[2].RangeType);
             Assert.AreEqual(null, clrFmt.Thresholds[0].Value);
-            Assert.AreEqual(10d, clrFmt.Thresholds[1].Value, 0);
+            Assert.AreEqual(10d, clrFmt.Thresholds[1].Value);
             Assert.AreEqual(null, clrFmt.Thresholds[2].Value);
 
             wb2.Close();

--- a/testcases/main/SS/UserModel/BaseTestDataValidation.cs
+++ b/testcases/main/SS/UserModel/BaseTestDataValidation.cs
@@ -42,6 +42,7 @@ namespace TestCases.SS.UserModel
             : this(HSSFITestDataProvider.Instance)
         {
         }
+
         protected BaseTestDataValidation(ITestDataProvider TestDataProvider)
         {
             _testDataProvider = TestDataProvider;
@@ -227,10 +228,7 @@ namespace TestCases.SS.UserModel
                     bool bold)
             {
                 IFont font = wb.CreateFont();
-                if (bold)
-                {
-                    font.Boldweight = (short)(/*setter*/FontBoldWeight.Bold);
-                }
+                font.IsBold = bold;
 
                 ICellStyle cellStyle = wb.CreateCellStyle();
                 cellStyle.SetFont(font);
@@ -258,7 +256,7 @@ namespace TestCases.SS.UserModel
             {
                 IFont font = wb.CreateFont();
                 font.Color = (/*setter*/ HSSFColor.White.Index);
-                font.Boldweight = (short)(/*setter*/FontBoldWeight.Bold);
+                font.IsBold = true;
 
                 ICellStyle cellStyle = wb.CreateCellStyle();
                 cellStyle.FillForegroundColor = (/*setter*/HSSFColor.BlueGrey.Index);

--- a/testcases/main/SS/UserModel/BaseTestFont.cs
+++ b/testcases/main/SS/UserModel/BaseTestFont.cs
@@ -32,7 +32,8 @@ namespace TestCases.SS.UserModel
 
         public BaseTestFont()
             : this(TestCases.HSSF.HSSFITestDataProvider.Instance)
-        { }
+        {
+        }
         /**
          * @param testDataProvider an object that provides test data in HSSF / XSSF specific way
          */
@@ -44,19 +45,19 @@ namespace TestCases.SS.UserModel
         {
             //get default font and check against default value
             IWorkbook workbook = _testDataProvider.CreateWorkbook();
-            IFont fontFind = workbook.FindFont((short)FontBoldWeight.Normal, defaultColor, defaultSize, defaultName, false, false, FontSuperScript.None, FontUnderlineType.None);
+            IFont fontFind = workbook.FindFont(false, defaultColor, defaultSize, defaultName, false, false, FontSuperScript.None, FontUnderlineType.None);
             Assert.IsNotNull(fontFind);
 
             //get default font, then change 2 values and check against different values (height Changes)
             IFont font = workbook.CreateFont();
-            font.Boldweight = (short)(FontBoldWeight.Bold);
-            Assert.AreEqual((short)FontBoldWeight.Bold, font.Boldweight);
+            font.IsBold = true;
+            Assert.IsTrue(font.IsBold);
             font.Underline = FontUnderlineType.Double;
             Assert.AreEqual(FontUnderlineType.Double, font.Underline);
             font.FontHeightInPoints = ((short)15);
             Assert.AreEqual(15 * 20, font.FontHeight);
             Assert.AreEqual(15, font.FontHeightInPoints);
-            fontFind = workbook.FindFont((short)FontBoldWeight.Bold, defaultColor, (short)(15 * 20), defaultName, false, false, FontSuperScript.None, FontUnderlineType.Double);
+            fontFind = workbook.FindFont(true, defaultColor, (short)(15 * 20), defaultName, false, false, FontSuperScript.None, FontUnderlineType.Double);
             Assert.IsNotNull(fontFind);
         }
         [Test]
@@ -66,7 +67,7 @@ namespace TestCases.SS.UserModel
             int num0 = wb.NumberOfFonts;
 
             IFont f1 = wb.CreateFont();
-            f1.Boldweight = (short)(FontBoldWeight.Bold);
+            f1.IsBold = true;
             short idx1 = f1.Index;
             wb.CreateCellStyle().SetFont(f1);
 
@@ -81,7 +82,7 @@ namespace TestCases.SS.UserModel
             wb.CreateCellStyle().SetFont(f3);
 
             Assert.AreEqual(num0 + 3, wb.NumberOfFonts);
-            Assert.AreEqual((short)FontBoldWeight.Bold, wb.GetFontAt(idx1).Boldweight);
+            Assert.IsTrue(wb.GetFontAt(idx1).IsBold);
             Assert.AreEqual(FontUnderlineType.Double, wb.GetFontAt(idx2).Underline);
             Assert.AreEqual(23, wb.GetFontAt(idx3).FontHeightInPoints);
         }
@@ -102,7 +103,7 @@ namespace TestCases.SS.UserModel
             int num0 = wb.NumberOfFonts;
 
             IFont font = wb.CreateFont();
-            font.Boldweight = (short)(FontBoldWeight.Bold);
+            font.IsBold = true;
             font.IsStrikeout = (true);
             font.Color = (HSSFColor.Yellow.Index);
             font.FontName = ("Courier");
@@ -164,7 +165,7 @@ namespace TestCases.SS.UserModel
 
             //default font
             IFont f1 = wb.GetFontAt((short)0);
-            Assert.AreEqual((short)FontBoldWeight.Normal, f1.Boldweight);
+            Assert.IsFalse(f1.IsBold);
 
             // Check that asking for the same font
             //  multiple times gives you the same thing.
@@ -175,7 +176,7 @@ namespace TestCases.SS.UserModel
             //  yet to add
             Assert.IsNull(
                 wb.FindFont(
-                    (short)FontBoldWeight.Bold, (short)123, (short)(22 * 20),
+                    true, (short)123, (short)(22 * 20),
                     "Thingy", false, true, FontSuperScript.Sub, FontUnderlineType.Double
                 )
             );
@@ -186,7 +187,7 @@ namespace TestCases.SS.UserModel
 
             Assert.AreEqual(nf, wb.GetFontAt(nfIdx));
 
-            nf.Boldweight = (short)(FontBoldWeight.Bold);
+            nf.IsBold = true;
             nf.Color = (short)123;
             nf.FontHeightInPoints = (short)22;
             nf.FontName = ("Thingy");
@@ -204,13 +205,13 @@ namespace TestCases.SS.UserModel
             // Find it now
             Assert.IsNotNull(
                 wb.FindFont(
-                    (short)FontBoldWeight.Bold, (short)123, (short)(22 * 20),
+                    true, (short)123, (short)(22 * 20),
                     "Thingy", false, true, FontSuperScript.Sub, FontUnderlineType.Double
                 )
             );
             Assert.AreSame(nf,
                    wb.FindFont(
-                       (short)FontBoldWeight.Bold, (short)123, (short)(22 * 20),
+                       true, (short)123, (short)(22 * 20),
                        "Thingy", false, true, FontSuperScript.Sub, FontUnderlineType.Double
                    )
             );

--- a/testcases/main/SS/UserModel/BaseTestNamedRange.cs
+++ b/testcases/main/SS/UserModel/BaseTestNamedRange.cs
@@ -499,7 +499,7 @@ namespace TestCases.SS.UserModel
             RangeAddress aref = new RangeAddress(aNamedCell.RefersToFormula);
             Assert.IsTrue(aref.Height == 1 && aref.Width == 1, "Should be exactly 1 cell in the named cell :'" + cellName + "'");
 
-            CellReference cref = new CellReference(aref.ToCell);
+            CellReference cref = new CellReference($"\'{aref.SheetName}\'!{aref.ToCell}");
             Assert.IsNotNull(cref);
             ISheet s = wb.GetSheet(cref.SheetName);
             Assert.IsNotNull(s);

--- a/testcases/main/SS/UserModel/BaseTestNamedRange.cs
+++ b/testcases/main/SS/UserModel/BaseTestNamedRange.cs
@@ -23,6 +23,7 @@ namespace TestCases.SS.UserModel
     using NPOI.SS.Util;
     using System.Collections.Generic;
     using NPOI.Util;
+    using NPOI.HSSF.Util;
 
     /**
      * Tests of implementations of {@link NPOI.ss.usermodel.Name}.
@@ -495,10 +496,10 @@ namespace TestCases.SS.UserModel
             Assert.IsNotNull(aNamedCell);
 
             // retrieve the cell at the named range and Test its contents
-            AreaReference aref = new AreaReference(aNamedCell.RefersToFormula);
-            Assert.IsTrue(aref.IsSingleCell, "Should be exactly 1 cell in the named cell :'" + cellName + "'");
+            RangeAddress aref = new RangeAddress(aNamedCell.RefersToFormula);
+            Assert.IsTrue(aref.Height == 1 && aref.Width == 1, "Should be exactly 1 cell in the named cell :'" + cellName + "'");
 
-            CellReference cref = aref.FirstCell;
+            CellReference cref = new CellReference(aref.ToCell);
             Assert.IsNotNull(cref);
             ISheet s = wb.GetSheet(cref.SheetName);
             Assert.IsNotNull(s);

--- a/testcases/main/SS/Util/NumberComparingSpreadsheetGenerator.cs
+++ b/testcases/main/SS/Util/NumberComparingSpreadsheetGenerator.cs
@@ -78,7 +78,7 @@ namespace TestCases.SS.Util
             IRow row = sheet.CreateRow(0);
             ICellStyle style = wb.CreateCellStyle();
             IFont font = wb.CreateFont();
-            font.Boldweight = (short)FontBoldWeight.Bold;
+            font.IsBold = true;
             style.SetFont(font);
             WriteHeaderCell(row, 0, "Raw Long Bits A", style);
             WriteHeaderCell(row, 1, "Raw Long Bits B", style);

--- a/testcases/main/SS/Util/NumberRenderingSpreadsheetGenerator.cs
+++ b/testcases/main/SS/Util/NumberRenderingSpreadsheetGenerator.cs
@@ -94,7 +94,7 @@ namespace TestCases.SS.Util
             ICellStyle style = wb.CreateCellStyle();
             IFont font = wb.CreateFont();
             WriteHeaderCell(row, 0, "Value", style);
-            font.Boldweight = (short)FontBoldWeight.Bold;
+            font.IsBold = true;
             style.SetFont(font);
             WriteHeaderCell(row, 1, "Raw Long Bits", style);
             WriteHeaderCell(row, 2, "JDK Double Rendering", style);

--- a/testcases/main/SS/Util/TestAreaReference.cs
+++ b/testcases/main/SS/Util/TestAreaReference.cs
@@ -52,6 +52,7 @@ namespace TestCases.SS.Util
         }
 
         [Test]
+        [Obsolete]
         public void TestFallbackToExcel97IfVersionNotSupplied()
         {
             Assert.IsTrue(new AreaReference("A:B").IsWholeColumnReference());

--- a/testcases/main/Util/TestULongField.cs
+++ b/testcases/main/Util/TestULongField.cs
@@ -42,11 +42,12 @@ namespace TestCases.Util
     /// </summary>
     // ULongField is declared obsolete so ommit this test class.
     [TestFixture]
+    [Obsolete]
     public class TestULongField
     {
         public TestULongField()
         {
-            _test_array =new ulong[]
+            _test_array = new ulong[]
             {
                 ulong.MinValue, 0L, 1L,168888888L, ulong.MaxValue
             };
@@ -85,7 +86,7 @@ namespace TestCases.Util
             }
             field = new ULongField(2, 0x123456789ABCDEF0L);
             Assert.AreEqual((ulong)0x123456789ABCDEF0L, field.Value);
-            byte[] array = new byte[ 10 ];
+            byte[] array = new byte[10];
 
             try
             {
@@ -99,15 +100,15 @@ namespace TestCases.Util
             }
             field = new ULongField(2, 0x123456789ABCDEF0L, array);
             Assert.AreEqual((ulong)0x123456789ABCDEF0L, field.Value);
-            Assert.AreEqual(( byte ) 0xF0, array[ 2 ]);
-            Assert.AreEqual(( byte ) 0xDE, array[ 3 ]);
-            Assert.AreEqual(( byte ) 0xBC, array[ 4 ]);
-            Assert.AreEqual(( byte ) 0x9A, array[ 5 ]);
-            Assert.AreEqual(( byte ) 0x78, array[ 6 ]);
-            Assert.AreEqual(( byte ) 0x56, array[ 7 ]);
-            Assert.AreEqual(( byte ) 0x34, array[ 8 ]);
-            Assert.AreEqual(( byte ) 0x12, array[ 9 ]);
-            array = new byte[ 9 ];
+            Assert.AreEqual((byte)0xF0, array[2]);
+            Assert.AreEqual((byte)0xDE, array[3]);
+            Assert.AreEqual((byte)0xBC, array[4]);
+            Assert.AreEqual((byte)0x9A, array[5]);
+            Assert.AreEqual((byte)0x78, array[6]);
+            Assert.AreEqual((byte)0x56, array[7]);
+            Assert.AreEqual((byte)0x34, array[8]);
+            Assert.AreEqual((byte)0x12, array[9]);
+            array = new byte[9];
             try
             {
                 new ULongField(2, 5L, array);
@@ -120,9 +121,9 @@ namespace TestCases.Util
             }
             for (int j = 0; j < _test_array.Length; j++)
             {
-                array = new byte[ 8 ];
-                new ULongField(0, _test_array[ j ], array);
-                Assert.AreEqual(_test_array[ j ], new ULongField(0, array).Value);
+                array = new byte[8];
+                new ULongField(0, _test_array[j], array);
+                Assert.AreEqual(_test_array[j], new ULongField(0, array).Value);
             }
         }
 
@@ -133,28 +134,28 @@ namespace TestCases.Util
         public void TestSet()
         {
             ULongField field = new ULongField(0);
-            byte[]    array = new byte[ 8 ];
+            byte[] array = new byte[8];
 
             for (int j = 0; j < _test_array.Length; j++)
             {
-                field.Value=_test_array[ j ];
+                field.Value = _test_array[j];
                 Assert.AreEqual(_test_array[j], field.Value, "testing _1 " + j);
                 field = new ULongField(0);
-                field.Set(_test_array[ j ],array);
-                Assert.AreEqual(_test_array[ j ], field.Value,"testing _2 ");
-                Assert.AreEqual(( byte ) (_test_array[ j ] % 256), array[ 0 ],"testing _3.0 " + _test_array[ j ]);
-                Assert.AreEqual(( byte ) ((_test_array[ j ] >> 8) % 256),
-                             array[ 1 ],"testing _3.1 " + _test_array[ j ]);
-                Assert.AreEqual(( byte ) ((_test_array[ j ] >> 16) % 256),
-                             array[ 2 ],"testing _3.2 " + _test_array[ j ]);
-                Assert.AreEqual(( byte ) ((_test_array[ j ] >> 24) % 256),
-                             array[ 3 ],"testing _3.3 " + _test_array[ j ]);
-                Assert.AreEqual(( byte ) ((_test_array[ j ] >> 32) % 256),array[ 4 ],"testing _3.4 " + _test_array[ j ]);
-                Assert.AreEqual(( byte ) ((_test_array[ j ] >> 40) % 256),
-                             array[ 5 ],"testing _3.5 " + _test_array[ j ]);
-                Assert.AreEqual(( byte ) ((_test_array[ j ] >> 48) % 256),
+                field.Set(_test_array[j], array);
+                Assert.AreEqual(_test_array[j], field.Value, "testing _2 ");
+                Assert.AreEqual((byte)(_test_array[j] % 256), array[0], "testing _3.0 " + _test_array[j]);
+                Assert.AreEqual((byte)((_test_array[j] >> 8) % 256),
+                             array[1], "testing _3.1 " + _test_array[j]);
+                Assert.AreEqual((byte)((_test_array[j] >> 16) % 256),
+                             array[2], "testing _3.2 " + _test_array[j]);
+                Assert.AreEqual((byte)((_test_array[j] >> 24) % 256),
+                             array[3], "testing _3.3 " + _test_array[j]);
+                Assert.AreEqual((byte)((_test_array[j] >> 32) % 256), array[4], "testing _3.4 " + _test_array[j]);
+                Assert.AreEqual((byte)((_test_array[j] >> 40) % 256),
+                             array[5], "testing _3.5 " + _test_array[j]);
+                Assert.AreEqual((byte)((_test_array[j] >> 48) % 256),
                              array[6], "testing _3.6 " + _test_array[j]);
-                Assert.AreEqual(( byte ) ((_test_array[ j ] >> 56) % 256),
+                Assert.AreEqual((byte)((_test_array[j] >> 56) % 256),
                              array[7], "testing _3.7 " + _test_array[j]);
             }
         }
@@ -166,7 +167,7 @@ namespace TestCases.Util
         public void TestReadFromBytes()
         {
             ULongField field = new ULongField(1);
-            byte[]    array = new byte[ 8 ];
+            byte[] array = new byte[8];
 
             try
             {
@@ -181,14 +182,14 @@ namespace TestCases.Util
             field = new ULongField(0);
             for (int j = 0; j < _test_array.Length; j++)
             {
-                array[ 0 ] = ( byte ) (_test_array[ j ] % 256);
-                array[ 1 ] = ( byte ) ((_test_array[ j ] >> 8) % 256);
-                array[ 2 ] = ( byte ) ((_test_array[ j ] >> 16) % 256);
-                array[ 3 ] = ( byte ) ((_test_array[ j ] >> 24) % 256);
-                array[ 4 ] = ( byte ) ((_test_array[ j ] >> 32) % 256);
-                array[ 5 ] = ( byte ) ((_test_array[ j ] >> 40) % 256);
-                array[ 6 ] = ( byte ) ((_test_array[ j ] >> 48) % 256);
-                array[ 7 ] = ( byte ) ((_test_array[ j ] >> 56) % 256);
+                array[0] = (byte)(_test_array[j] % 256);
+                array[1] = (byte)((_test_array[j] >> 8) % 256);
+                array[2] = (byte)((_test_array[j] >> 16) % 256);
+                array[3] = (byte)((_test_array[j] >> 24) % 256);
+                array[4] = (byte)((_test_array[j] >> 32) % 256);
+                array[5] = (byte)((_test_array[j] >> 40) % 256);
+                array[6] = (byte)((_test_array[j] >> 48) % 256);
+                array[7] = (byte)((_test_array[j] >> 56) % 256);
                 field.ReadFromBytes(array);
                 Assert.AreEqual(_test_array[j], field.Value, "testing " + j);
             }
@@ -202,19 +203,19 @@ namespace TestCases.Util
         [Test]
         public void TestReadFromStream()
         {
-            ULongField field  = new ULongField(0);
-            byte[]    buffer = new byte[ _test_array.Length * 8 ];
+            ULongField field = new ULongField(0);
+            byte[] buffer = new byte[_test_array.Length * 8];
 
             for (int j = 0; j < _test_array.Length; j++)
             {
-                buffer[ (j * 8) + 0 ] = ( byte ) (_test_array[ j ] % 256);
-                buffer[ (j * 8) + 1 ] = ( byte ) ((_test_array[ j ] >> 8) % 256);
-                buffer[ (j * 8) + 2 ] = ( byte ) ((_test_array[ j ] >> 16) % 256);
-                buffer[ (j * 8) + 3 ] = ( byte ) ((_test_array[ j ] >> 24) % 256);
-                buffer[ (j * 8) + 4 ] = ( byte ) ((_test_array[ j ] >> 32) % 256);
-                buffer[ (j * 8) + 5 ] = ( byte ) ((_test_array[ j ] >> 40) % 256);
-                buffer[ (j * 8) + 6 ] = ( byte ) ((_test_array[ j ] >> 48) % 256);
-                buffer[ (j * 8) + 7 ] = ( byte ) ((_test_array[ j ] >> 56) % 256);
+                buffer[(j * 8) + 0] = (byte)(_test_array[j] % 256);
+                buffer[(j * 8) + 1] = (byte)((_test_array[j] >> 8) % 256);
+                buffer[(j * 8) + 2] = (byte)((_test_array[j] >> 16) % 256);
+                buffer[(j * 8) + 3] = (byte)((_test_array[j] >> 24) % 256);
+                buffer[(j * 8) + 4] = (byte)((_test_array[j] >> 32) % 256);
+                buffer[(j * 8) + 5] = (byte)((_test_array[j] >> 40) % 256);
+                buffer[(j * 8) + 6] = (byte)((_test_array[j] >> 48) % 256);
+                buffer[(j * 8) + 7] = (byte)((_test_array[j] >> 56) % 256);
             }
             MemoryStream stream = new MemoryStream(buffer);
 
@@ -232,23 +233,23 @@ namespace TestCases.Util
         public void TestWriteToBytes()
         {
             ULongField field = new ULongField(0);
-            byte[]    array = new byte[ 8 ];
+            byte[] array = new byte[8];
 
             for (int j = 0; j < _test_array.Length; j++)
             {
-                field.Value=_test_array[ j ];
+                field.Value = _test_array[j];
                 field.WriteToBytes(array);
-                ulong val = (( ulong ) array[ 7 ]) << 56;
+                ulong val = ((ulong)array[7]) << 56;
 
-                val &=0xFF00000000000000L;
-                val += ((( ulong ) array[ 6 ]) << 48) & 0x00FF000000000000L;
-                val += ((( ulong ) array[ 5 ]) << 40) & 0x0000FF0000000000L;
-                val += ((( ulong ) array[ 4 ]) << 32) & 0x000000FF00000000L;
-                val += ((( ulong ) array[ 3 ]) << 24) & 0x00000000FF000000L;
-                val += ((( ulong ) array[ 2 ]) << 16) & 0x0000000000FF0000L;
-                val += ((( ulong ) array[ 1 ]) << 8) & 0x000000000000FF00L;
-                val += ((( ulong ) array[ 0 ]) & 0x00000000000000FFL);
-                Assert.AreEqual(_test_array[ j ], val,"testing ");
+                val &= 0xFF00000000000000L;
+                val += (((ulong)array[6]) << 48) & 0x00FF000000000000L;
+                val += (((ulong)array[5]) << 40) & 0x0000FF0000000000L;
+                val += (((ulong)array[4]) << 32) & 0x000000FF00000000L;
+                val += (((ulong)array[3]) << 24) & 0x00000000FF000000L;
+                val += (((ulong)array[2]) << 16) & 0x0000000000FF0000L;
+                val += (((ulong)array[1]) << 8) & 0x000000000000FF00L;
+                val += (((ulong)array[0]) & 0x00000000000000FFL);
+                Assert.AreEqual(_test_array[j], val, "testing ");
             }
         }
     }

--- a/testcases/ooxml/NPOI.OOXML.TestCases.Core.csproj
+++ b/testcases/ooxml/NPOI.OOXML.TestCases.Core.csproj
@@ -10,6 +10,12 @@
     <OutputPath>..\..\solution\$(Configuration)\</OutputPath>
   </PropertyGroup>
 
+	<PropertyGroup>
+		<DefineConstants>HIDE_UNREACHABLE_CODE</DefineConstants>
+		<NoWarn>1701;1702;0108;0618;618;108;0612;612;162;0162</NoWarn>
+		<WarningLevel>1</WarningLevel>
+	</PropertyGroup>
+	
   <ItemGroup>
     <Compile Remove="OpenXmlFormats\**" />
     <EmbeddedResource Remove="OpenXmlFormats\**" />

--- a/testcases/ooxml/NPOI.OOXML.TestCases.Core.csproj
+++ b/testcases/ooxml/NPOI.OOXML.TestCases.Core.csproj
@@ -10,12 +10,6 @@
     <OutputPath>..\..\solution\$(Configuration)\</OutputPath>
   </PropertyGroup>
 
-	<PropertyGroup>
-		<DefineConstants>HIDE_UNREACHABLE_CODE</DefineConstants>
-		<NoWarn>1701;1702;0108;0618;618;108;0612;612;162;0162</NoWarn>
-		<WarningLevel>1</WarningLevel>
-	</PropertyGroup>
-	
   <ItemGroup>
     <Compile Remove="OpenXmlFormats\**" />
     <EmbeddedResource Remove="OpenXmlFormats\**" />

--- a/testcases/ooxml/POIFS/Crypt/TestCertificateEncryption.cs
+++ b/testcases/ooxml/POIFS/Crypt/TestCertificateEncryption.cs
@@ -36,21 +36,22 @@ namespace TestCases.POIFS.Crypt
         /**
          * how many days from now the Certificate is valid for
          */
-        static int days = 1000;
+        // static int days = 1000;
         /**
          * the signing algorithm, eg "SHA1withRSA"
          */
-        static String algorithm = "SHA1withRSA";
-        static String password = "foobaa";
-        static String certAlias = "poitest";
+        // static String algorithm = "SHA1withRSA";
+        // static String password = "foobaa";
+        // static String certAlias = "poitest";
         /**
          * the X.509 Distinguished Name, eg "CN=Test, L=London, C=GB"
          */
-        static String certDN = "CN=poitest";
+        // static String certDN = "CN=poitest";
         // static File pfxFile = TempFile.CreateTempFile("poitest", ".pfx");
-        static byte[] pfxFileBytes;
+        // static byte[] pfxFileBytes;
 
-        public class CertData {
+        public class CertData
+        {
             public KeyPair keypair;
             public X509Certificate x509;
         }
@@ -106,7 +107,8 @@ namespace TestCases.POIFS.Crypt
             pfxFileBytes = bos.ToByteArray();
         } */
 
-        public CertData loadKeystore() {
+        public CertData loadKeystore()
+        {
             //KeyStore keystore = KeyStore.GetInstance("PKCS12");
 
             //// InputStream fis = new MemoryStream(pfxFileBytes);
@@ -127,7 +129,8 @@ namespace TestCases.POIFS.Crypt
         }
 
         [Test]
-        public void TestCertificateEncryption1() {
+        public void TestCertificateEncryption1()
+        {
             POIFSFileSystem fs = new POIFSFileSystem();
             EncryptionInfo info = new EncryptionInfo(EncryptionMode.Agile, CipherAlgorithm.aes128, HashAlgorithm.sha1, -1, -1, ChainingMode.cbc);
             AgileEncryptionVerifier aev = (AgileEncryptionVerifier)info.Verifier;

--- a/testcases/ooxml/POIFS/Crypt/TestSecureTempZip.cs
+++ b/testcases/ooxml/POIFS/Crypt/TestSecureTempZip.cs
@@ -65,7 +65,7 @@ namespace TestCases.POIFS.Crypt
 
             // test the source
             OPCPackage opc = OPCPackage.Open(source);
-            String expected = "This is an Encrypted Excel spreadsheet.";
+            // String expected = "This is an Encrypted Excel spreadsheet.";
 
             //XSSFEventBasedExcelExtractor extractor = new XSSFEventBasedExcelExtractor(opc);
             //extractor.IncludeSheetNames = (/*setter*/false);
@@ -177,7 +177,10 @@ namespace TestCases.POIFS.Crypt
 
             public bool IsClosed
             {
-                get { return closed; }
+                get
+                {
+                    return closed;
+                }
             }
         }
     }

--- a/testcases/ooxml/POIFS/Crypt/TestSignatureInfo.cs
+++ b/testcases/ooxml/POIFS/Crypt/TestSignatureInfo.cs
@@ -40,10 +40,10 @@ namespace TestCases.POIFS.Crypt
 
         //private static Calendar cal;
         //private KeyPair keyPair = null;
-        private X509Certificate x509 = null;
 
         [SetUp]
-        public static void InitBouncy() {
+        public static void InitBouncy()
+        {
             throw new NotImplementedException();
             //CryptoFunctions.RegisterBouncyCastle();
 
@@ -62,22 +62,27 @@ namespace TestCases.POIFS.Crypt
         }
 
         [Test]
-        public void office2007prettyPrintedRels() {
+        public void office2007prettyPrintedRels()
+        {
             OPCPackage pkg = OPCPackage.Open(testdata.GetFileInfo("office2007prettyPrintedRels.docx"), PackageAccess.READ);
-            try {
+            try
+            {
                 SignatureConfig sic = new SignatureConfig();
                 sic.SetOpcPackage(pkg);
                 SignatureInfo si = new SignatureInfo();
                 si.SetSignatureConfig(sic);
                 bool isValid = si.VerifySignature();
                 Assert.IsTrue(isValid);
-            } finally {
+            }
+            finally
+            {
                 pkg.Close();
             }
         }
 
         [Test]
-        public void GetSignerUnsigned() {
+        public void GetSignerUnsigned()
+        {
             String[] testFiles = {
                 "hello-world-unsigned.docx",
                 "hello-world-unsigned.pptx",
@@ -85,15 +90,18 @@ namespace TestCases.POIFS.Crypt
                 "hello-world-office-2010-technical-preview-unsigned.docx"
             };
 
-            foreach (String testFile in testFiles) {
+            foreach (String testFile in testFiles)
+            {
                 OPCPackage pkg = OPCPackage.Open(testdata.GetFileInfo(testFile), PackageAccess.READ);
                 SignatureConfig sic = new SignatureConfig();
                 sic.SetOpcPackage(pkg);
                 SignatureInfo si = new SignatureInfo();
                 si.SetSignatureConfig(sic);
                 List<X509Certificate> result = new List<X509Certificate>();
-                foreach (SignatureInfo.SignaturePart sp in si.GetSignatureParts()) {
-                    if (sp.Validate()) {
+                foreach (SignatureInfo.SignaturePart sp in si.GetSignatureParts())
+                {
+                    if (sp.Validate())
+                    {
                         result.Add(sp.GetSigner());
                     }
                 }
@@ -105,7 +113,8 @@ namespace TestCases.POIFS.Crypt
         }
 
         [Test]
-        public void GetSigner() {
+        public void GetSigner()
+        {
             String[] testFiles = {
                 "hyperlink-example-signed.docx",
                 "hello-world-signed.docx",
@@ -119,16 +128,20 @@ namespace TestCases.POIFS.Crypt
                 "signed.docx",
             };
 
-            foreach (String testFile in testFiles) {
+            foreach (String testFile in testFiles)
+            {
                 OPCPackage pkg = OPCPackage.Open(testdata.GetFileInfo(testFile), PackageAccess.READ);
-                try {
+                try
+                {
                     SignatureConfig sic = new SignatureConfig();
                     sic.SetOpcPackage(pkg);
                     SignatureInfo si = new SignatureInfo();
                     si.SetSignatureConfig(sic);
                     List<X509Certificate> result = new List<X509Certificate>();
-                    foreach (SignatureInfo.SignaturePart sp in si.GetSignatureParts()) {
-                        if (sp.Validate()) {
+                    foreach (SignatureInfo.SignaturePart sp in si.GetSignatureParts())
+                    {
+                        if (sp.Validate())
+                        {
                             result.Add(sp.GetSigner());
                         }
                     }
@@ -141,14 +154,17 @@ namespace TestCases.POIFS.Crypt
                     bool b = si.VerifySignature();
                     Assert.IsTrue(b, "test-file: " + testFile);
                     pkg.Revert();
-                } finally {
+                }
+                finally
+                {
                     pkg.Close();
                 }
             }
         }
 
         [Test]
-        public void GetMultiSigners() {
+        public void GetMultiSigners()
+        {
             String testFile = "hello-world-signed-twice.docx";
             OPCPackage pkg = OPCPackage.Open(testdata.GetFileInfo(testFile), PackageAccess.READ);
             //try {
@@ -189,7 +205,8 @@ namespace TestCases.POIFS.Crypt
         }
 
         [Test]
-        public void TestManipulation() {
+        public void TestManipulation()
+        {
             //// sign & validate
             //String testFile = "hello-world-unsigned.xlsx";
             //OPCPackage pkg = OPCPackage.Open(copy(testdata.GetFile(testFile)), PackageAccess.READ_WRITE);
@@ -219,7 +236,8 @@ namespace TestCases.POIFS.Crypt
         }
 
         [Test]
-        public void TestSignSpreadsheetWithSignatureInfo() {
+        public void TestSignSpreadsheetWithSignatureInfo()
+        {
             //InitKeyPair("Test", "CN=Test");
             //String testFile = "hello-world-unsigned.xlsx";
             //OPCPackage pkg = OPCPackage.Open(copy(testdata.GetFile(testFile)), PackageAccess.READ_WRITE);
@@ -243,8 +261,9 @@ namespace TestCases.POIFS.Crypt
         }
 
         [Ignore("not implemented")]
-        public void TestSignEnvelopingDocument() {
-            String testFile = "hello-world-unsigned.xlsx";
+        public void TestSignEnvelopingDocument()
+        {
+            //String testFile = "hello-world-unsigned.xlsx";
             //OPCPackage pkg = OPCPackage.Open(copy(testdata.GetFile(testFile)), PackageAccess.READ_WRITE);
 
             //InitKeyPair("Test", "CN=Test");
@@ -383,7 +402,8 @@ namespace TestCases.POIFS.Crypt
             throw new NotImplementedException();
         }
 
-        public static String GetAccessError(String destinationUrl, bool fireRequest, int timeout) {
+        public static String GetAccessError(String destinationUrl, bool fireRequest, int timeout)
+        {
             //URL url;
             //try {
             //    url = new URL(destinationUrl);
@@ -431,7 +451,8 @@ namespace TestCases.POIFS.Crypt
         }
 
         [Test]
-        public void TestCertChain() {
+        public void TestCertChain()
+        {
             //KeyStore keystore = KeyStore.GetInstance("PKCS12");
             //String password = "test";
             //InputStream is1 = testdata.OpenResourceAsStream("chaintest.pfx");
@@ -477,11 +498,12 @@ namespace TestCases.POIFS.Crypt
         }
 
         [Ignore("not implemented")]
-        public void TestNonSha1() {
-            String testFile = "hello-world-unsigned.xlsx";
-            InitKeyPair("Test", "CN=Test");
+        public void TestNonSha1()
+        {
+            //String testFile = "hello-world-unsigned.xlsx";
+            //InitKeyPair("Test", "CN=Test");
 
-            SignatureConfig signatureConfig = new SignatureConfig();
+            //SignatureConfig signatureConfig = new SignatureConfig();
             //signatureConfig.Key = (/*setter*/keyPair.Private);
             //signatureConfig.SigningCertificateChain = (/*setter*/Collections.SingletonList(x509));
 
@@ -524,7 +546,8 @@ namespace TestCases.POIFS.Crypt
 
 
         }
-        private void sign(OPCPackage pkgCopy, String alias, String signerDn, int signerCount) {
+        private void sign(OPCPackage pkgCopy, String alias, String signerDn, int signerCount)
+        {
             throw new NotImplementedException();
             //InitKeyPair(alias, signerDn);
 
@@ -568,7 +591,8 @@ namespace TestCases.POIFS.Crypt
             //Assert.AreEqual(signerCount, result.Size());
         }
 
-        private void InitKeyPair(String alias, String subjectDN) {
+        private void InitKeyPair(String alias, String subjectDN)
+        {
             throw new NotImplementedException();
             //char password[] = "test".ToCharArray();
             //File file = new File("build/test.pfx");
@@ -605,11 +629,12 @@ namespace TestCases.POIFS.Crypt
             //}
         }
 
-        private static FileInfo copy(FileInfo input) {
+        private static FileInfo copy(FileInfo input)
+        {
             String extension = input.Name.Replace(".*?(\\.[^.]+)?$", "$1");
             if (extension == null || "".Equals(extension))
                 extension = ".zip";
-            FileInfo tmpFile = new FileInfo("build" + Path.DirectorySeparatorChar+ "sigtest" + extension);
+            FileInfo tmpFile = new FileInfo("build" + Path.DirectorySeparatorChar + "sigtest" + extension);
             throw new NotImplementedException();
             //FileStream fos = tmpFile.Create();// FileOutputStream(tmpFile);
             //FileStream fis = input.Create();// new FileInputStream(input);

--- a/testcases/ooxml/XSSF/Model/TestStylesTable.cs
+++ b/testcases/ooxml/XSSF/Model/TestStylesTable.cs
@@ -30,7 +30,7 @@ namespace TestCases.XSSF.Model
     {
         private String testFile = "Formatting.xlsx";
         private static String customDataFormat = "YYYY-mm-dd";
-    
+
         [SetUp]
         public static void assumeCustomDataFormatIsNotBuiltIn()
         {
@@ -104,8 +104,8 @@ namespace TestCases.XSSF.Model
             Assert.AreEqual(2, st.GetFills().Count);
             Assert.AreEqual(1, st.GetBorders().Count);
 
-            Assert.AreEqual("yyyy/mm/dd", st.GetNumberFormatAt(165));
-            Assert.AreEqual("yy/mm/dd", st.GetNumberFormatAt(167));
+            Assert.AreEqual("yyyy/mm/dd", st.GetNumberFormatAt((short)165));
+            Assert.AreEqual("yy/mm/dd", st.GetNumberFormatAt((short)167));
 
             Assert.IsNotNull(st.GetStyleAt(0));
             Assert.IsNotNull(st.GetStyleAt(1));
@@ -143,7 +143,7 @@ namespace TestCases.XSSF.Model
             Assert.AreEqual(1, st.StyleXfsSize);
             Assert.AreEqual(2, st.NumDataFormats);
 
-            Assert.AreEqual("yyyy-mm-dd", st.GetNumberFormatAt(nf1));
+            Assert.AreEqual("yyyy-mm-dd", st.GetNumberFormatAt((short)nf1));
             Assert.AreEqual(nf1, st.PutNumberFormat("yyyy-mm-dd"));
             Assert.AreEqual(nf2, st.PutNumberFormat("yyyy-mm-DD"));
 
@@ -170,7 +170,7 @@ namespace TestCases.XSSF.Model
             Assert.AreEqual(1, st.StyleXfsSize);
             Assert.AreEqual(10, st.NumDataFormats);
 
-            Assert.AreEqual("YYYY-mm-dd", st.GetNumberFormatAt(nf1));
+            Assert.AreEqual("YYYY-mm-dd", st.GetNumberFormatAt((short)nf1));
             Assert.AreEqual(nf1, st.PutNumberFormat("YYYY-mm-dd"));
             Assert.AreEqual(nf2, st.PutNumberFormat("YYYY-mm-DD"));
 
@@ -254,7 +254,9 @@ namespace TestCases.XSSF.Model
                 // The default style shouldn't be added back to the styles source because it's built-in
                 Assert.AreEqual(0, wb.GetStylesSource().NumDataFormats);
 
-                cell = null; style = null; numberFormats = null;
+                cell = null;
+                style = null;
+                numberFormats = null;
                 wb = XSSFTestDataSamples.WriteOutCloseAndReadBack(wb);
 
                 cell = wb.GetSheet("test").GetRow(0).GetCell(0);

--- a/testcases/ooxml/XSSF/Streaming/SheetDataWriterTests.cs
+++ b/testcases/ooxml/XSSF/Streaming/SheetDataWriterTests.cs
@@ -51,7 +51,7 @@ namespace TestCases.XSSF.Streaming
                     File.Delete(_objectToTest.TemporaryFilePath());
                 }
             }
-            
+
         }
         [Test]
         public void IfCallingEmptyConstructorShouldCreateNonZippedTempFileNonDecoratedStream()
@@ -74,7 +74,7 @@ namespace TestCases.XSSF.Streaming
             var lines = File.ReadAllLines(_objectToTest.TemporaryFilePath());
 
             Assert.True(lines.Length == 2);
-            Assert.AreEqual("<row r=\"" + 1 + "\" customHeight=\"true\"  ht=\"" + row.HeightInPoints + "\">", lines[0]);
+            Assert.AreEqual("<row r=\"" + 1 + "\" customHeight=\"true\" ht=\"" + row.HeightInPoints + "\">", lines[0]);
             Assert.AreEqual("</row>", lines[1]);
 
 

--- a/testcases/ooxml/XSSF/UserModel/TestMultiSheetFormulaEvaluatorOnXSSF.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestMultiSheetFormulaEvaluatorOnXSSF.cs
@@ -118,7 +118,7 @@ namespace TestCases.XSSF.UserModel
                     Assert.AreEqual(CellType.Error, actual.CellType, msg);
                     if (false)
                     { // TODO: fix ~45 functions which are currently returning incorrect error values
-                        Assert.AreEqual(expected.ErrorCellValue, actual.ErrorValue, msg);
+                        // Assert.AreEqual(expected.ErrorCellValue, actual.ErrorValue, msg);
                     }
                     break;
                 case CellType.Formula: // will never be used, since we will call method After formula Evaluation
@@ -217,8 +217,12 @@ namespace TestCases.XSSF.UserModel
 
                         switch (ProcessFunctionRow(evaluator, targetFunctionName, targetTestName, r, expectedValueCell))
                         {
-                            case Result.ALL_EVALUATIONS_SUCCEEDED: _functionSuccessCount++; break;
-                            case Result.SOME_EVALUATIONS_FAILED: _functionFailureCount++; break;
+                            case Result.ALL_EVALUATIONS_SUCCEEDED:
+                                _functionSuccessCount++;
+                                break;
+                            case Result.SOME_EVALUATIONS_FAILED:
+                                _functionFailureCount++;
+                                break;
                             default:
                                 throw new Exception("unexpected result");
                             case Result.NO_EVALUATIONS_FOUND: // do nothing

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFChartSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFChartSheet.cs
@@ -44,9 +44,9 @@ namespace TestCases.XSSF.UserModel
         public void TestGetAccessors()
         {
             XSSFWorkbook wb = XSSFTestDataSamples.OpenSampleWorkbook("chart_sheet.xlsx");
-            XSSFChartSheet sheet = (XSSFChartSheet) wb.GetSheetAt(2);
+            XSSFChartSheet sheet = (XSSFChartSheet)wb.GetSheetAt(2);
 
-            Assert.IsFalse(sheet.GetEnumerator().MoveNext(), 
+            Assert.IsFalse(sheet.GetEnumerator().MoveNext(),
                 "Row iterator for charts sheets should return zero rows");
 
             //access to a arbitrary row
@@ -58,7 +58,7 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(0, sheet.NumMergedRegions);
             Assert.IsNull(sheet.ActiveCell);
             Assert.IsTrue(sheet.Autobreaks);
-            Assert.IsNull(sheet.GetCellComment(0, 0));
+            Assert.IsNull(sheet.GetCellComment(new CellAddress(0, 0)));
             Assert.IsNull(sheet.GetCellComment(new CellAddress(0, 0)));
             Assert.AreEqual(0, sheet.ColumnBreaks.Length);
             Assert.IsTrue(sheet.RowSumsBelow);
@@ -73,8 +73,8 @@ namespace TestCases.XSSF.UserModel
         {
             XSSFWorkbook wb = XSSFTestDataSamples.OpenSampleWorkbook("chart_sheet.xlsx");
 
-            XSSFSheet ns = (XSSFSheet) wb.GetSheetAt(0);
-            XSSFChartSheet cs = (XSSFChartSheet) wb.GetSheetAt(2);
+            XSSFSheet ns = (XSSFSheet)wb.GetSheetAt(0);
+            XSSFChartSheet cs = (XSSFChartSheet)wb.GetSheetAt(2);
 
             Assert.AreEqual(0, (ns.CreateDrawingPatriarch() as XSSFDrawing).GetCharts().Count);
             Assert.AreEqual(1, (cs.CreateDrawingPatriarch() as XSSFDrawing).GetCharts().Count);

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
@@ -30,6 +30,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using TestCases.HSSF;
 using TestCases.SS.UserModel;
 
@@ -116,7 +117,7 @@ namespace TestCases.XSSF.UserModel
 
             wb2.Close();
         }
-        
+
         [Test]
         public void TestGetAllHeadersFooters()
         {
@@ -188,7 +189,7 @@ namespace TestCases.XSSF.UserModel
             font.FontHeightInPoints = 20;
             cell.CellStyle.SetFont(font);
             row.Height = 100;
-            
+
             sheet.AutoSizeRow(row.RowNum);
 
             Assert.AreNotEqual(100, row.Height);
@@ -937,7 +938,7 @@ namespace TestCases.XSSF.UserModel
 
             comment1 = sheet1.GetCommentsTable(true);
             Assert.IsNotNull(comment1);
-            Assert.AreEqual("/xl/comments1.xml", comment1.GetPackageRelationship().TargetUri.ToString());
+            Assert.AreEqual("/xl/comments1.xml", comment1.GetPackagePart().PartName.Name);
 
             Assert.AreSame(comment1, sheet1.GetCommentsTable(true));
 
@@ -950,7 +951,7 @@ namespace TestCases.XSSF.UserModel
             Assert.IsNotNull(comment2);
 
             Assert.AreSame(comment2, sheet2.GetCommentsTable(true));
-            Assert.AreEqual("/xl/comments2.xml", comment2.GetPackageRelationship().TargetUri.ToString());
+            Assert.AreEqual("/xl/comments2.xml", comment2.GetPackagePart().PartName.Name);
 
             //comment1 and  comment2 are different objects
             Assert.AreNotSame(comment1, comment2);
@@ -961,7 +962,7 @@ namespace TestCases.XSSF.UserModel
             sheet1 = (XSSFSheet)wb2.GetSheetAt(0);
             comment1 = sheet1.GetCommentsTable(true);
             Assert.IsNotNull(comment1);
-            Assert.AreEqual("/xl/comments1.xml", comment1.GetPackageRelationship().TargetUri.ToString());
+            Assert.AreEqual("/xl/comments1.xml", comment1.GetPackagePart().PartName.Name);
             Assert.AreSame(comment1, sheet1.GetCommentsTable(true));
 
             wb2.Close();

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFTable.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFTable.cs
@@ -199,6 +199,7 @@ namespace TestCases.XSSF.UserModel
             wb.Close();
         }
         [Test]
+        [Obsolete]
         public void GetNumberOfMappedColumns()
         {
             XSSFWorkbook wb = XSSFTestDataSamples.OpenSampleWorkbook("StructuredReferences.xlsx");

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using TestCases.HSSF;
 using TestCases.SS.UserModel;
@@ -390,17 +391,17 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(2, wb.NumberOfNames);
             Assert.IsNotNull(wb.GetCalculationChain());
 
-            XSSFName nm0 = (XSSFName)wb.GetNameAt(0);
+            XSSFName nm0 = (XSSFName)wb.GetAllNames().First();
             Assert.IsTrue(nm0.GetCTName().IsSetLocalSheetId());
             Assert.AreEqual(0u, nm0.GetCTName().localSheetId);
 
-            XSSFName nm1 = (XSSFName)wb.GetNameAt(1);
+            XSSFName nm1 = (XSSFName)wb.GetAllNames().ToArray()[1];
             Assert.IsTrue(nm1.GetCTName().IsSetLocalSheetId());
             Assert.AreEqual(1u, nm1.GetCTName().localSheetId);
 
             wb.RemoveSheetAt(0);
             Assert.AreEqual(1, wb.NumberOfNames);
-            XSSFName nm2 = (XSSFName)wb.GetNameAt(0);
+            XSSFName nm2 = (XSSFName)wb.GetAllNames().First();
             Assert.IsTrue(nm2.GetCTName().IsSetLocalSheetId());
             Assert.AreEqual(0u, nm2.GetCTName().localSheetId);
             //calculation chain is Removed as well
@@ -585,7 +586,8 @@ namespace TestCases.XSSF.UserModel
             ISheet sheet = wb.GetSheetAt(0);
             sheet.ShiftRows(2, sheet.LastRowNum, 1, true, false);
             IRow newRow = sheet.GetRow(2);
-            if (newRow == null) newRow = sheet.CreateRow(2);
+            if (newRow == null)
+                newRow = sheet.CreateRow(2);
             newRow.CreateCell(0).SetCellValue(" Another Header");
             wb.CloneSheet(0);
 
@@ -1087,7 +1089,7 @@ namespace TestCases.XSSF.UserModel
                 Assert.IsTrue(!file.Exists);
             }
         }
-        
+
         [Test]
         public void CloseDoesNotModifyWorkbook()
         {
@@ -1190,8 +1192,7 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(sheet2Name, wb.GetNames("name1")[0]);
             // Check by index as well for sanity
             Assert.AreEqual(1, wb.NumberOfNames);
-            Assert.AreEqual(0, wb.GetNameIndex("name1"));
-            Assert.AreEqual(sheet2Name, wb.GetNameAt(0));
+            Assert.AreEqual(sheet2Name, wb.GetName(sheet2Name.NameName));
             wb.Close();
         }
 

--- a/testcases/ooxml/XWPF/UserModel/TestXWPFParagraph.cs
+++ b/testcases/ooxml/XWPF/UserModel/TestXWPFParagraph.cs
@@ -213,9 +213,9 @@ namespace TestCases.XWPF.UserModel
 
             CT_OnOff wordWrap = ppr.AddNewWordWrap();
             wordWrap.val = false;
-            Assert.AreEqual(false, p.IsWordWrap);
+            Assert.AreEqual(false, p.IsWordWrapped);
 
-            p.IsWordWrap = true;
+            p.IsWordWrapped = true;
             Assert.AreEqual(true, ppr.wordWrap.val);
         }
 
@@ -270,7 +270,7 @@ namespace TestCases.XWPF.UserModel
 
             p.SetNumILvl("1");
             Assert.AreEqual("1", p.GetNumIlvl());
-    
+
         }
         [Test]
         public void TestAddingRuns()
@@ -479,11 +479,11 @@ namespace TestCases.XWPF.UserModel
             p.IndentationFirstLine = (/*setter*/25);
             Assert.AreEqual(25, p.IndentationFirstLine);
 
-            Assert.IsFalse(p.IsWordWrap);
-            p.IsWordWrap = (/*setter*/true);
-            Assert.IsTrue(p.IsWordWrap);
-            p.IsWordWrap = (/*setter*/false);
-            Assert.IsFalse(p.IsWordWrap);
+            Assert.IsFalse(p.IsWordWrapped);
+            p.IsWordWrapped = (/*setter*/true);
+            Assert.IsTrue(p.IsWordWrapped);
+            p.IsWordWrapped = (/*setter*/false);
+            Assert.IsFalse(p.IsWordWrapped);
 
             Assert.IsNull(p.Style);
             p.Style = (/*setter*/"teststyle");
@@ -551,9 +551,10 @@ namespace TestCases.XWPF.UserModel
         {
             XWPFDocument doc = new XWPFDocument();
             XWPFParagraph p = doc.CreateParagraph();
+            IRunBody p1 = doc.CreateParagraph();
 
             CT_R run = new CT_R();
-            XWPFRun r = new XWPFRun(run, doc.CreateParagraph());
+            XWPFRun r = new XWPFRun(run, p1);
             p.AddRun(r);
             p.AddRun(r);
 
@@ -598,7 +599,7 @@ namespace TestCases.XWPF.UserModel
             String s = str.ToString();
             Assert.IsFalse(s.Contains("This is another Test"));
         }
-        
+
         [Test]
         public void Testpullrequest404()
         {
@@ -607,8 +608,8 @@ namespace TestCases.XWPF.UserModel
             paragraph.CreateRun().AppendText("abc");
             paragraph.CreateRun().AppendText("de");
             paragraph.CreateRun().AppendText("f");
-            paragraph.CreateRun().AppendText("g"); 
-            var result = paragraph.SearchText("cdefg",new PositionInParagraph());
+            paragraph.CreateRun().AppendText("g");
+            var result = paragraph.SearchText("cdefg", new PositionInParagraph());
             Assert.AreEqual(result.BeginRun, 0);
             Assert.AreEqual(result.EndRun, 3);
             Assert.AreEqual(result.BeginText, 0);
@@ -624,8 +625,8 @@ namespace TestCases.XWPF.UserModel
             paragraph.CreateRun().AppendText("abc");
             paragraph.CreateRun().AppendText("de");
             paragraph.CreateRun().AppendText("fg");
-            paragraph.CreateRun().AppendText("hi"); 
-            var result = paragraph.SearchText("cdefg",new PositionInParagraph());
+            paragraph.CreateRun().AppendText("hi");
+            var result = paragraph.SearchText("cdefg", new PositionInParagraph());
             Assert.AreEqual(result.BeginRun, 0);
             Assert.AreEqual(result.EndRun, 2);
             Assert.AreEqual(result.BeginText, 0);

--- a/testcases/ooxml/XWPF/UserModel/TestXWPFRun.cs
+++ b/testcases/ooxml/XWPF/UserModel/TestXWPFRun.cs
@@ -24,6 +24,7 @@ namespace TestCases.XWPF.UserModel
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
 
     /**
      * Tests for XWPF Run
@@ -33,7 +34,7 @@ namespace TestCases.XWPF.UserModel
     {
 
         public CT_R ctRun;
-        public XWPFParagraph p;
+        public IRunBody p;
         [SetUp]
         public void SetUp()
         {
@@ -132,9 +133,9 @@ namespace TestCases.XWPF.UserModel
             rpr.AddNewStrike().val = true;
 
             XWPFRun run = new XWPFRun(ctRun, p);
-            Assert.AreEqual(true, run.IsStrike);
+            Assert.IsTrue(run.IsStrikeThrough);
 
-            run.SetStrike(false);
+            run.IsStrikeThrough = false;
             Assert.AreEqual(false, rpr.strike.val);
         }
 
@@ -304,14 +305,14 @@ namespace TestCases.XWPF.UserModel
             Assert.AreEqual("This is a test document", run.ToString());
             Assert.AreEqual(false, run.IsBold);
             Assert.AreEqual(false, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
             Assert.AreEqual(null, run.GetCTR().rPr);
 
             run = p.Runs[1];
             Assert.AreEqual(".", run.ToString());
             Assert.AreEqual(false, run.IsBold);
             Assert.AreEqual(false, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
             Assert.AreEqual(null, run.GetCTR().rPr);
 
 
@@ -324,7 +325,7 @@ namespace TestCases.XWPF.UserModel
             Assert.AreEqual("This bit is in bold and italic", run.ToString());
             Assert.AreEqual(true, run.IsBold);
             Assert.AreEqual(true, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
             Assert.AreEqual(true, run.GetCTR().rPr.IsSetB());
             Assert.AreEqual(false, run.GetCTR().rPr.b.IsSetVal());
 
@@ -338,7 +339,7 @@ namespace TestCases.XWPF.UserModel
             Assert.AreEqual("Back to normal", run.ToString());
             Assert.AreEqual(false, run.IsBold);
             Assert.AreEqual(false, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
             Assert.AreEqual(null, run.GetCTR().rPr);
 
 
@@ -351,72 +352,72 @@ namespace TestCases.XWPF.UserModel
             Assert.AreEqual("This contains ", run.ToString());
             Assert.AreEqual(false, run.IsBold);
             Assert.AreEqual(false, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
             Assert.AreEqual(null, run.GetCTR().rPr);
 
             run = p.Runs[(1)];
             Assert.AreEqual("BOLD", run.ToString());
             Assert.AreEqual(true, run.IsBold);
             Assert.AreEqual(false, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
 
             run = p.Runs[2];
             Assert.AreEqual(", ", run.ToString());
             Assert.AreEqual(false, run.IsBold);
             Assert.AreEqual(false, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
             Assert.AreEqual(null, run.GetCTR().rPr);
 
             run = p.Runs[(3)];
             Assert.AreEqual("ITALIC", run.ToString());
             Assert.AreEqual(false, run.IsBold);
             Assert.AreEqual(true, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
 
             run = p.Runs[(4)];
             Assert.AreEqual(" and ", run.ToString());
             Assert.AreEqual(false, run.IsBold);
             Assert.AreEqual(false, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
             Assert.AreEqual(null, run.GetCTR().rPr);
 
             run = p.Runs[(5)];
             Assert.AreEqual("BOTH", run.ToString());
             Assert.AreEqual(true, run.IsBold);
             Assert.AreEqual(true, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
 
             run = p.Runs[(6)];
             Assert.AreEqual(", as well as ", run.ToString());
             Assert.AreEqual(false, run.IsBold);
             Assert.AreEqual(false, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
             Assert.AreEqual(null, run.GetCTR().rPr);
 
             run = p.Runs[(7)];
             Assert.AreEqual("RED", run.ToString());
             Assert.AreEqual(false, run.IsBold);
             Assert.AreEqual(false, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
 
             run = p.Runs[(8)];
             Assert.AreEqual(" and ", run.ToString());
             Assert.AreEqual(false, run.IsBold);
             Assert.AreEqual(false, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
             Assert.AreEqual(null, run.GetCTR().rPr);
 
             run = p.Runs[(9)];
             Assert.AreEqual("YELLOW", run.ToString());
             Assert.AreEqual(false, run.IsBold);
             Assert.AreEqual(false, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
 
             run = p.Runs[(10)];
             Assert.AreEqual(" text.", run.ToString());
             Assert.AreEqual(false, run.IsBold);
             Assert.AreEqual(false, run.IsItalic);
-            Assert.AreEqual(false, run.IsStrike);
+            Assert.IsFalse(run.IsStrikeThrough);
             Assert.AreEqual(null, run.GetCTR().rPr);
         }
 
@@ -452,7 +453,7 @@ namespace TestCases.XWPF.UserModel
         [Test]
         public void testSetGetHighlight()
         {
-            XWPFRun run = p.CreateRun();
+            XWPFRun run = new XWPFRun(ctRun, p);
             Assert.AreEqual(false, run.IsHighlighted);
 
             // TODO Do this using XWPFRun methods
@@ -572,7 +573,8 @@ namespace TestCases.XWPF.UserModel
             };
             MemoryStream bos = new MemoryStream();
             XWPFDocument doc = new XWPFDocument();
-            foreach (String s in text) {
+            foreach (String s in text)
+            {
                 XWPFParagraph p1 = doc.CreateParagraph();
                 XWPFRun r1 = p1.CreateRun();
                 r1.SetText(s);
@@ -602,7 +604,7 @@ namespace TestCases.XWPF.UserModel
         public void TestSetStyleId()
         {
             XWPFDocument document = XWPFTestDataSamples.OpenSampleDocument("SampleDoc.docx");
-             
+
             XWPFRun run = document.CreateParagraph().CreateRun();
 
             String styleId = "bolditalic";

--- a/testcases/openxml4net/NPOI.OOXML4Net.TestCases.Core.csproj
+++ b/testcases/openxml4net/NPOI.OOXML4Net.TestCases.Core.csproj
@@ -10,12 +10,6 @@
     <OutputPath>..\..\solution\$(Configuration)\</OutputPath>
   </PropertyGroup>
 
-	<PropertyGroup>
-		<DefineConstants>HIDE_UNREACHABLE_CODE</DefineConstants>
-		<NoWarn>1701;1702;0108;0618;618;108;0612;612;162;0162</NoWarn>
-		<WarningLevel>1</WarningLevel>
-	</PropertyGroup>
-	
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/testcases/openxml4net/NPOI.OOXML4Net.TestCases.Core.csproj
+++ b/testcases/openxml4net/NPOI.OOXML4Net.TestCases.Core.csproj
@@ -10,6 +10,12 @@
     <OutputPath>..\..\solution\$(Configuration)\</OutputPath>
   </PropertyGroup>
 
+	<PropertyGroup>
+		<DefineConstants>HIDE_UNREACHABLE_CODE</DefineConstants>
+		<NoWarn>1701;1702;0108;0618;618;108;0612;612;162;0162</NoWarn>
+		<WarningLevel>1</WarningLevel>
+	</PropertyGroup>
+	
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/testcases/openxml4net/OPC/Compliance/TestOPCCompliancePartName.cs
+++ b/testcases/openxml4net/OPC/Compliance/TestOPCCompliancePartName.cs
@@ -91,9 +91,9 @@ namespace TestCases.OpenXml4Net.OPC.Compliance
                 Uri uri = null;
                 try
                 {
-                    uri = new Uri(s,UriKind.Relative);
+                    uri = new Uri(s, UriKind.Relative);
                 }
-                catch (UriFormatException e)
+                catch
                 {
                     Assert.IsTrue(s.Equals("[Content_Types].xml"));
                     continue;
@@ -110,10 +110,10 @@ namespace TestCases.OpenXml4Net.OPC.Compliance
         public void TestValidPartNames()
         {
             String[] validNames = { "/xml/item1.xml", "/document.xml",
-				"/a/%D1%86.xml" };
+                "/a/%D1%86.xml" };
             foreach (String s in validNames)
                 Assert.IsTrue(
-                        PackagingUriHelper.IsValidPartName(new Uri(s,UriKind.RelativeOrAbsolute)),
+                        PackagingUriHelper.IsValidPartName(new Uri(s, UriKind.RelativeOrAbsolute)),
                         "This part name SHOULD be valid: " + s);
         }
 
@@ -125,7 +125,7 @@ namespace TestCases.OpenXml4Net.OPC.Compliance
         {
             try
             {
-                PackagingUriHelper.CreatePartName(new Uri("",UriKind.Relative));
+                PackagingUriHelper.CreatePartName(new Uri("", UriKind.Relative));
                 Assert.Fail("A part name shall not be empty. [M1.1]");
             }
             catch (InvalidFormatException)
@@ -145,13 +145,13 @@ namespace TestCases.OpenXml4Net.OPC.Compliance
         public void TestPartNameWithInvalidSegmentsFailure()
         {
             String[] invalidNames = { "//document.xml", "//word/document.xml",
-				"/word//document.rels", "/word//rels//document.rels",
-				"/xml./doc.xml", "/document.", "/./document.xml",
-				"/word/./doc.rels", "/%2F/document.xml" };
-                foreach (String s in invalidNames)
-                    Assert.IsFalse(
-                            PackagingUriHelper.IsValidPartName(new Uri(s,UriKind.RelativeOrAbsolute)),
-                            "A part name shall not have empty segments. [M1.3]");
+                "/word//document.rels", "/word//rels//document.rels",
+                "/xml./doc.xml", "/document.", "/./document.xml",
+                "/word/./doc.rels", "/%2F/document.xml" };
+            foreach (String s in invalidNames)
+                Assert.IsFalse(
+                        PackagingUriHelper.IsValidPartName(new Uri(s, UriKind.RelativeOrAbsolute)),
+                        "A part name shall not have empty segments. [M1.3]");
         }
 
         /**
@@ -210,7 +210,7 @@ namespace TestCases.OpenXml4Net.OPC.Compliance
                 PackagingUriHelper.CreatePartName(new Uri("document.xml", UriKind.RelativeOrAbsolute));
                 Assert.Fail("A part name shall start with a forward slash ('/') character. [M1.4]");
             }
-            catch (InvalidFormatException )
+            catch (InvalidFormatException)
             {
                 // Normal behaviour
             }


### PR DESCRIPTION
This pull request addresses some warnings that emerge on build of test projects. The warnings in the main projects are not addressed.

Namely, some warnings that are fixed:
- Warnings about exception rethrows
- Some tests for obsolete methods and members are marked as obsolete
- Use of Boldweight obsolete property (changed it to use IsBold where suitable)
- Removed (or commented out) some unused variables

No new failing tests were generated with this change.

test.runsettings file is made to use forward slash in paths, to make it usable when running unix or macos tests.