### PR TITLE
fix EmbeddedResource access on net472

### DIFF
--- a/main/HSSF/UserModel/StaticFontMetrics.cs
+++ b/main/HSSF/UserModel/StaticFontMetrics.cs
@@ -34,11 +34,7 @@ namespace NPOI.HSSF.UserModel
      */
     class StaticFontMetrics
     {
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER || NETSTANDARD2_0
         private const String FONT_METRICS_PROPERTIES_FILE_NAME = "NPOI.Resources.font_metrics.properties";
-#else
-        private const String FONT_METRICS_PROPERTIES_FILE_NAME = "font_metrics.properties";
-#endif
         
         /** The font metrics property file we're using */
         private static Properties fontMetricsProps;

--- a/main/SS/Formula/Function/FunctionMetadataReader.cs
+++ b/main/SS/Formula/Function/FunctionMetadataReader.cs
@@ -33,11 +33,7 @@ namespace NPOI.SS.Formula.Function
      */
     class FunctionMetadataReader
     {
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER || NETSTANDARD2_0
         private const String METADATA_FILE_NAME = "NPOI.Resources.functionMetadata.txt";
-#else
-        private const String METADATA_FILE_NAME = "functionMetadata.txt";
-#endif
 
         /** plain ASCII text metadata file uses three dots for ellipsis */
         private const string ELLIPSIS = "...";

--- a/ooxml/XSSF/UserModel/XSSFBuiltinTableStyle.cs
+++ b/ooxml/XSSF/UserModel/XSSFBuiltinTableStyle.cs
@@ -301,11 +301,7 @@ namespace NPOI.XSSF.UserModel
     }
     public class XSSFBuiltinTableStyle
     {
-#if NETSTANDARD2_1 || NET6_0_OR_GREATER || NETSTANDARD2_0
         const string presetTableStylesResourceName = "NPOI.OOXML.Resources.presetTableStyles.xml";
-#else
-        const string presetTableStylesResourceName= "presetTableStyles.xml";
-#endif
 
         private static Dictionary<XSSFBuiltinTableStyleEnum, ITableStyle> styleMap = new Dictionary<XSSFBuiltinTableStyleEnum, ITableStyle>();
         public static ITableStyle GetStyle(XSSFBuiltinTableStyleEnum style)


### PR DESCRIPTION
There are three embedded resouces in NPOI.
- `functionMetadata.txt` and `font_metrics.properties` in NPOI project
- `presetTableStyles.xml` in NPOI.OOXML project

In previous, thee resource files on net472 has inconsistent settings against NET Core.

- NPOI.csproj:
	The two files had shorthand `LogicalName`s.

	```
	  <ItemGroup>
	    <EmbeddedResource Include="Resources\functionMetadata.txt">
	      <LogicalName>functionMetadata.txt</LogicalName>
	    </EmbeddedResource>
	    <EmbeddedResource Include="Resources\font_metrics.properties">
	      <LogicalName>font_metrics.properties</LogicalName>
	    </EmbeddedResource>
	  </ItemGroup>
	```

- NPOI.OOXML.csproj:
	`presetTableStyles.xml` had been properly regeistered in NPOI.OOXML.Core.csproj, but not in NPOI.OOXML.csproj as EmbeddedResource, so it had been already broken in net472.

After we migrate SDK style csproj in #1037, the default LogicalName which has assembly name + relative path in project is given to each embedded resourecs. But, the shorthand names were still used for net472 by conditional compilation, so the runtime resource loading has been failing.

This fix will significantly increase passed test numbers in net472.

net6.0: (nothing changed)
```
- NPOI.TestCases.Core           (net6.0) Fail (2484)   3 Not Run    2413 Passed    23 Failed    45 Skipped
- NPOI.OOXML.TestCases.Core     (net6.0) Fail (1426)   5 Not Run    1316 Passed    70 Failed    35 Skipped
- NPOI.OOXML4Net.TestCases.Core (net6.0) Fail   (91)   1 Not Run      78 Passed     2 Failed    10 Skipped
```

net472 (before):
<pre>
- NPOI.TestCases.Core           (net472) Fail (2484)   3 Not Run    <b>2000</b> Passed   <b>436</b> Failed    45 Skipped
- NPOI.OOXML.TestCases.Core     (net472) Fail (1426)   4 Not Run    <b>1143</b> Passed   <b>244</b> Failed    35 Skipped
- NPOI.OOXML4Net.TestCases.Core (net472) Fail   (91)   1 Not Run      78 Passed     2 Failed    10 Skipped
</pre>

net472 (after):
<pre>
- NPOI.TestCases.Core           (net472) Fail (2484)   3 Not Run    <b>2416</b> Passed    <b>20</b> Failed    45 Skipped
- NPOI.OOXML.TestCases.Core     (net472) Fail (1426)   5 Not Run    <b>1316</b> Passed    <b>70</b> Failed    35 Skipped
- NPOI.OOXML4Net.TestCases.Core (net472) Fail   (91)   1 Not Run      78 Passed     2 Failed    10 Skipped
</pre>
