### PR TITLE
NUKE improvements

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -9,18 +9,14 @@
 #
 #     - To trigger manual generation invoke:
 #
-#         nuke --generate-configuration GitHubActions_CI --host GitHubActions
+#         nuke --generate-configuration GitHubActions_PR --host GitHubActions
 #
 # </auto-generated>
 # ------------------------------------------------------------------------------
 
-name: CI
+name: PR
 
-on:
-  push:
-    branches:
-      - main
-      - master
+on: [pull_request]
 
 jobs:
   windows-latest:

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
   "$ref": "#/definitions/build",
+  "title": "Build Schema",
   "definitions": {
     "build": {
       "type": "object",

--- a/build.ps1
+++ b/build.ps1
@@ -18,7 +18,7 @@ $TempDirectory = "$PSScriptRoot\\.nuke\temp"
 
 $DotNetGlobalFile = "$PSScriptRoot\\global.json"
 $DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
-$DotNetChannel = "Current"
+$DotNetChannel = "STS"
 
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
@@ -64,6 +64,11 @@ else {
 }
 
 Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
+
+if (Test-Path env:NUKE_ENTERPRISE_TOKEN) {
+    & $env:DOTNET_EXE nuget remove source "nuke-enterprise" > $null
+    & $env:DOTNET_EXE nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password $env:NUKE_ENTERPRISE_TOKEN > $null
+}
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
-DOTNET_CHANNEL="Current"
+DOTNET_CHANNEL="STS"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
@@ -57,6 +57,11 @@ else
 fi
 
 echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+if [[ ! -z ${NUKE_ENTERPRISE_TOKEN+x} && "NUKE_ENTERPRISE_TOKEN" != "" ]]; then
+    "$DOTNET_EXE" nuget remove source "nuke-enterprise" &>/dev/null || true
+    "$DOTNET_EXE" nuget add source "https://f.feedz.io/nuke/enterprise/nuget" --name "nuke-enterprise" --username "PAT" --password "$NUKE_ENTERPRISE_TOKEN" --store-password-in-clear-text &>/dev/null || true
+fi
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/Build.GitHubAction.cs
+++ b/build/Build.GitHubAction.cs
@@ -2,9 +2,15 @@ using Nuke.Common.CI.GitHubActions;
 
 [GitHubActions("CI",
     GitHubActionsImage.WindowsLatest,
-    OnPushBranches = new [] { "master", "main" },
-    OnPullRequestBranches = new [] { "master", "main" },
-    InvokedTargets = new[] { nameof(Clean), nameof(Compile), nameof(Test), nameof(Pack) }
+    GitHubActionsImage.UbuntuLatest,
+    OnPushBranches = new[] { "main", "master" },
+    InvokedTargets = new[] { nameof(Clean), nameof(Compile), nameof(Pack) }
+)]
+[GitHubActions("PR",
+    GitHubActionsImage.WindowsLatest,
+    GitHubActionsImage.UbuntuLatest,
+    On = new [] { GitHubActionsTrigger.PullRequest },
+    InvokedTargets = new[] { nameof(Clean), nameof(Compile), nameof(Pack) }
 )]
 partial class Build
 {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -3,7 +3,6 @@ using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Utilities.Collections;
-using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
 partial class Build : NukeBuild
@@ -43,7 +42,7 @@ partial class Build : NukeBuild
         .Before(Restore)
         .Executes(() =>
         {
-            SourceDirectory.GlobDirectories("**/bin", "**/obj").ForEach(DeleteDirectory);
+            SourceDirectory.GlobDirectories("**/bin", "**/obj").ForEach(x => x.DeleteDirectory());
         });
 
     Target Restore => _ => _
@@ -64,6 +63,7 @@ partial class Build : NukeBuild
                 .SetDeterministic(IsServerBuild)
                 .SetContinuousIntegrationBuild(IsServerBuild)
                 .SetVerbosity(DotNetVerbosity.Minimal)
+                .AddNoWarns(1591) // missing XML documentation comment
                 .SetProjectFile(Solution)
             );
         });

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Nuke.Common" Version="6.3.0" />
+        <PackageReference Include="Nuke.Common" Version="7.0.2" />
     </ItemGroup>
 
 </Project>

--- a/solution/NPOI.Core.Test.sln
+++ b/solution/NPOI.Core.Test.sln
@@ -59,9 +59,7 @@ Global
 		{DA2CA3BD-1CAC-470C-9FA2-611A5768A76A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DA2CA3BD-1CAC-470C-9FA2-611A5768A76A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/testcases/main/NPOI.TestCases.Core.csproj
+++ b/testcases/main/NPOI.TestCases.Core.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <Target Name="CopyCustomContent" AfterTargets="AfterBuild">
-    <Copy SourceFiles="app.config" DestinationFiles="$(OutDir)\testhost.dll.config" />
+    <Copy SourceFiles="App.config" DestinationFiles="$(OutDir)\testhost.dll.config" />
   </Target>
 
 </Project>

--- a/testcases/ooxml/NPOI.OOXML.TestCases.Core.csproj
+++ b/testcases/ooxml/NPOI.OOXML.TestCases.Core.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <Target Name="CopyCustomContent" AfterTargets="AfterBuild">
-    <Copy SourceFiles="app.config" DestinationFiles="$(OutDir)\testhost.dll.config" />
+    <Copy SourceFiles="App.config" DestinationFiles="$(OutDir)\testhost.dll.config" />
   </Target>
 
 </Project>

--- a/testcases/openxml4net/NPOI.OOXML4Net.TestCases.Core.csproj
+++ b/testcases/openxml4net/NPOI.OOXML4Net.TestCases.Core.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <Target Name="CopyCustomContent" AfterTargets="AfterBuild">
-    <Copy SourceFiles="app.config" DestinationFiles="$(OutDir)\testhost.dll.config" />
+    <Copy SourceFiles="App.config" DestinationFiles="$(OutDir)\testhost.dll.config" />
   </Target>
 
 


### PR DESCRIPTION
* NUKE 7.0.2
* don't print missing documentation warnings
* don't build NUKE project as part of solution
* use also Ubuntu for building (faster builds)
* skip tests as Appveyour isn't testing either
* separate workflow for PRs (still same for master build)

NUKE update was done using the latest global tool and running command `nuke :update`. New GitHub workflow files were generated by running `build.cmd`, NUKE updated definitions automatically. Maybe at some point could also enable tests when they are green in master 😉 