### PR TITLE
Add benchmarks project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,5 @@ $RECYCLE.BIN/
 examples/packages
 examples/.vs/
 /artifacts
+
+BenchmarkDotNet.Artifacts

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,7 @@
 <Project>
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+
     <!-- SourceLink related properties https://github.com/dotnet/SourceLink#using-sourcelink -->
     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/benchmarks/NPOI.Benchmarks/LargeExcelFileBenchmark.cs
+++ b/benchmarks/NPOI.Benchmarks/LargeExcelFileBenchmark.cs
@@ -1,0 +1,58 @@
+﻿using System.Net;
+using BenchmarkDotNet.Attributes;
+using NPOI.XSSF.UserModel;
+
+namespace NPOI.Benchmarks;
+
+[ShortRunJob]
+[MemoryDiagnoser]
+public class LargeExcelFileBenchmark
+{
+    private static XSSFWorkbook _loadedWorkBook;
+    private static MemoryStream _memoryStream;
+    private string _filePath;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        // a 17MB Excel file is large so download it only when needed
+        _filePath = Path.Combine(Path.GetTempPath(), "test-performance.xlsx");
+        if (!File.Exists(_filePath))
+        {
+            Console.WriteLine("Downloading file...");
+            new WebClient().DownloadFile(
+                "https://github.com/GrapeCity/GcExcel-Java/raw/master/benchmark/files/test-performance.xlsx",
+                _filePath);
+            Console.WriteLine("File downloaded");
+        }
+
+        var copyPath = Path.Combine(Path.GetTempPath(), "test-performance-copy.xlsx");
+        if (!File.Exists(copyPath))
+        {
+            File.Copy(_filePath, copyPath);
+        }
+
+        _loadedWorkBook = new XSSFWorkbook(copyPath);
+        _memoryStream = new MemoryStream();
+    }
+
+    [Benchmark]
+    public void Load()
+    {
+        var workbook = new XSSFWorkbook(_filePath);
+        workbook.Dispose();
+    }
+
+    [Benchmark]
+    public void Write()
+    {
+        _memoryStream.Seek(0, SeekOrigin.Begin);
+        _loadedWorkBook.Write(_memoryStream, leaveOpen: true);
+    }
+
+    [Benchmark]
+    public void Evaluate()
+    {
+        _loadedWorkBook.GetCreationHelper().CreateFormulaEvaluator().EvaluateAll();
+    }
+}

--- a/benchmarks/NPOI.Benchmarks/NPOI.Benchmarks.csproj
+++ b/benchmarks/NPOI.Benchmarks/NPOI.Benchmarks.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\ooxml\NPOI.OOXML.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    </ItemGroup>
+
+</Project>

--- a/benchmarks/NPOI.Benchmarks/Program.cs
+++ b/benchmarks/NPOI.Benchmarks/Program.cs
@@ -1,0 +1,4 @@
+﻿using BenchmarkDotNet.Running;
+using NPOI.Benchmarks;
+
+BenchmarkSwitcher.FromAssembly(typeof(LargeExcelFileBenchmark).Assembly).Run();

--- a/benchmarks/NPOI.Benchmarks/RangeValuesBenchmark.cs
+++ b/benchmarks/NPOI.Benchmarks/RangeValuesBenchmark.cs
@@ -1,0 +1,140 @@
+﻿using BenchmarkDotNet.Attributes;
+using NPOI.SS.Util;
+using NPOI.XSSF.UserModel;
+
+namespace NPOI.Benchmarks;
+
+[MemoryDiagnoser]
+public class RangeValuesBenchmark
+{
+    private static readonly MemoryStream _memoryStream = new();
+
+    [Params(1_000)]
+    public int RowCount { get; set; }
+
+    [Params(30)]
+    public int ColumnCount { get; set; }
+
+    [Benchmark]
+    public void Double()
+    {
+        var workbook = new XSSFWorkbook();
+        var worksheet = workbook.CreateSheet("poi");
+
+        for (var r = 0; r < RowCount; r++)
+        {
+            var row = worksheet.CreateRow(r);
+            for (var c = 0; c < ColumnCount; c++)
+            {
+                row.CreateCell(c).SetCellValue(r + c);
+            }
+        }
+
+        for (var r = 0; r < RowCount; r++)
+        {
+            var row = worksheet.GetRow(r);
+            for (var c = 0; c < ColumnCount; c++)
+            {
+                var d = row.GetCell(c).NumericCellValue;
+            }
+        }
+
+        WriteFileAndClose(workbook);
+    }
+
+    [Benchmark]
+    public void String()
+    {
+        var workbook = new XSSFWorkbook();
+        var worksheet = workbook.CreateSheet("poi");
+
+        var random = new Random();
+        const string alphaNumericString = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        for (var r = 0; r < RowCount; r++)
+        {
+            var row = worksheet.CreateRow(r);
+            for (var c = 0; c < ColumnCount; c++)
+            {
+                row.CreateCell(c).SetCellValue(alphaNumericString[random.Next(25)].ToString());
+            }
+        }
+
+        for (var r = 0; r < RowCount; r++)
+        {
+            var row = worksheet.GetRow(r);
+            for (var c = 0; c < ColumnCount; c++)
+            {
+                var s = row.GetCell(c).StringCellValue;
+            }
+        }
+
+        WriteFileAndClose(workbook);
+    }
+
+    [Benchmark]
+    public void Date()
+    {
+        var workbook = new XSSFWorkbook();
+        var worksheet = workbook.CreateSheet("poi");
+
+        for (var r = 0; r < RowCount; r++)
+        {
+            var row = worksheet.CreateRow(r);
+            for (var c = 0; c < ColumnCount; c++)
+            {
+                row.CreateCell(c).SetCellValue(DateTime.Now);
+            }
+        }
+
+        for (var r = 0; r < RowCount; r++)
+        {
+            var row = worksheet.GetRow(r);
+            for (var c = 0; c < ColumnCount; c++)
+            {
+                var d = row.GetCell(c).DateCellValue;
+            }
+        }
+
+        WriteFileAndClose(workbook);
+    }
+
+    [Benchmark]
+    public void Formulas()
+    {
+        var workbook = new XSSFWorkbook();
+        var worksheet = workbook.CreateSheet("poi");
+
+        for (var r = 0; r < RowCount; r++)
+        {
+            var row = worksheet.CreateRow(r);
+            for (var c = 0; c < 2; c++)
+            {
+                row.CreateCell(c).SetCellValue(r + c);
+            }
+        }
+
+        for (var r = 0; r < RowCount; r++)
+        {
+            var row = worksheet.GetRow(r);
+            for (var c = 2; c < ColumnCount + 2; c++)
+            {
+                var cell = row.CreateCell(c);
+                var reference1 = new CellReference(r, c - 2);
+                var reference2 = new CellReference(r, c - 1);
+                cell.CellFormula = $"SUM({reference1.FormatAsString()}, {reference2.FormatAsString()})";
+            }
+        }
+
+        workbook.GetCreationHelper().CreateFormulaEvaluator().EvaluateAll();
+
+        WriteFileAndClose(workbook);
+    }
+
+    private static void WriteFileAndClose(XSSFWorkbook workbook)
+    {
+        _memoryStream.Seek(0, SeekOrigin.Begin);
+        workbook.Write(_memoryStream, leaveOpen: true);
+        workbook.Close();
+    }
+}

--- a/solution/NPOI.Core.Test.sln
+++ b/solution/NPOI.Core.Test.sln
@@ -24,6 +24,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NPOI.OOXML.TestCases.Core",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "_build", "..\build\_build.csproj", "{94B18BCF-84E8-401F-BAAB-0496AA136628}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPOI.Benchmarks", "..\benchmarks\NPOI.Benchmarks\NPOI.Benchmarks.csproj", "{3DA1149D-46F8-4181-9976-E002BF2BFB76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +62,11 @@ Global
 		{DA2CA3BD-1CAC-470C-9FA2-611A5768A76A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR adds a new benchmark project which utilizes [BenchmarkDotNet](https://benchmarkdotnet.org/) for precise and repeatable results. I adjusted test cases from [this blog post](https://www.grapecity.com/blogs/npoi-apache-poi-alternative-gcexcel-net ) to create presentation of areas.

I have diff tools that I can use to show performance changes between master and proposed optimization.

You can run the benchmarks by simply running the benchmarks project using `Release` configuration. It will as what benchmark(s) to run.

My first PR will tackle the `LargeExcelFileBenchmark.Evaluate` which is obviously the worst case at the moment as it takes over a minute to complete on my desktop.

## Current results

``` ini

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.23466.1001)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=7.0.302
  [Host]   : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2
  ShortRun : .NET 6.0.16 (6.0.1623.17311), X64 RyuJIT AVX2

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```

### NPOI.Benchmarks.LargeExcelFileBenchmark
|   Method |     Mean |    Error |   StdDev |         Gen0 |         Gen1 |      Gen2 | Allocated |
|--------- |---------:|---------:|---------:|-------------:|-------------:|----------:|----------:|
|     Load | 11.741 s | 1.1257 s | 0.0617 s |  232000.0000 |  109000.0000 | 3000.0000 |   3.65 GB |
|    Write |  3.483 s | 0.1738 s | 0.0095 s |   44000.0000 |            - |         - |   1.19 GB |
| Evaluate | 62.677 s | 4.1891 s | 0.2296 s | 4810000.0000 | 1353000.0000 |         - |  75.32 GB |

### NPOI.Benchmarks.RangeValuesBenchmark

|   Method | RowCount | ColumnCount |        Mean |     Error |   StdDev |       Gen0 |       Gen1 |      Gen2 |  Allocated |
|--------- |--------- |------------ |------------:|----------:|---------:|-----------:|-----------:|----------:|-----------:|
|   Double |     1000 |          30 |    85.46 ms |  0.367 ms | 0.343 ms |  2000.0000 |  1000.0000 |  500.0000 |   31.45 MB |
|   String |     1000 |          30 |    99.93 ms |  0.449 ms | 0.420 ms |  4400.0000 |  2000.0000 | 1000.0000 |   59.32 MB |
|     Date |     1000 |          30 |   114.71 ms |  1.603 ms | 1.499 ms |  3000.0000 |  2000.0000 | 1200.0000 |   35.73 MB |
| Formulas |     1000 |          30 | 1,064.12 ms | 10.889 ms | 9.653 ms | 94000.0000 | 27000.0000 | 4000.0000 | 1480.15 MB |


