### PR TITLE
Reduce string allocations when writing documents

### DIFF
--- a/OpenXmlFormats/CustomXmlSchemaProperties.cs
+++ b/OpenXmlFormats/CustomXmlSchemaProperties.cs
@@ -71,7 +71,7 @@ namespace NPOI.OpenXmlFormats
             XmlHelper.WriteAttribute(sw, "w:manifestLocation", this.manifestLocation);
             XmlHelper.WriteAttribute(sw, "w:schemaLocation", this.schemaLocation);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_Schema()

--- a/OpenXmlFormats/Drawing/WordprocessingDrawing.cs
+++ b/OpenXmlFormats/Drawing/WordprocessingDrawing.cs
@@ -64,7 +64,7 @@ namespace NPOI.OpenXmlFormats.Dml.WordProcessing
                     x.Write(sw, "inline");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         List<CT_Anchor> anchorField;

--- a/OpenXmlFormats/Spreadsheet/Document/CalcChainDocument.cs
+++ b/OpenXmlFormats/Spreadsheet/Document/CalcChainDocument.cs
@@ -57,15 +57,27 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             foreach (CT_CalcCell cc in calcChain.c)
             {
                 sw.Write("<c");
-                sw.Write(" r=\""+cc.r+"\"");
-                if(cc.i>0)
-                    sw.Write(" i=\"" + cc.i + "\"");
-                if(cc.s)
-                    sw.Write(" s=\"" + (cc.s?1:0) + "\"");
+                sw.WriteAttribute("r", cc.r);
+
+                if (cc.i > 0)
+                {
+                    sw.WriteAttribute("i", cc.i);
+                }
+
+                if (cc.s)
+                {
+                    sw.WriteBooleanAttribute("s", cc.s);
+                }
+
                 if (cc.t)
-                    sw.Write(" t=\"" + (cc.t?1:0) + "\"");
+                {
+                    sw.WriteBooleanAttribute("t", cc.t);
+                }
+
                 if (cc.l)
-                    sw.Write(" l=\"" + (cc.l?1:0) + "\"");
+                {
+                    sw.WriteBooleanAttribute("l", cc.l);
+                }
                 sw.Write("/>");
 
             }

--- a/OpenXmlFormats/Spreadsheet/Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet.cs
@@ -2688,7 +2688,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
+            sw.Write("<");
+            sw.Write(nodeName);
             if (this.t != ST_CellFormulaType.normal)
                 XmlHelper.WriteAttribute(sw, "t", this.t.ToString());
             XmlHelper.WriteAttribute(sw, "aca", this.aca, false);
@@ -2707,7 +2708,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             {
                 sw.Write(">");
                 sw.Write(XmlHelper.EncodeXml(this.valueField).Replace("&quot;", "\""));
-                sw.Write(string.Format("</{0}>", nodeName));
+                sw.Write("</");
+                sw.Write(nodeName);
+                sw.Write(">");
             }
             else
             {

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Cell.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Cell.cs
@@ -65,7 +65,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
+            sw.Write("<");
+            sw.Write(nodeName);
 
             XmlHelper.WriteAttribute(sw, "r", this.r);
             XmlHelper.WriteAttribute(sw, "s", this.s);
@@ -87,14 +88,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 if (this.f != null)
                     this.f.Write(sw, "f");
                 if (!string.IsNullOrEmpty(this.v))
-                    sw.Write(string.Format("<v>{0}</v>", XmlHelper.EncodeXml(this.v)));
+                    sw.WriteElementAndContent("v", XmlHelper.EncodeXml(this.v));
                 else
                     sw.Write("<v/>");
                 if (this.@is != null)
                     this.@is.Write(sw, "is");
                 if (this.extLst != null)
                     this.extLst.Write(sw, "extLst");
-                sw.Write(string.Format("</{0}>", nodeName));
+                sw.WriteEndElement(nodeName);
             }
         }
 

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Row.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Row.cs
@@ -82,7 +82,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<{0}", nodeName));
+            sw.Write("<");
+            sw.Write(nodeName);
             XmlHelper.WriteAttribute(sw, "r", this.r);
             XmlHelper.WriteAttribute(sw, "spans", this.spans);
             XmlHelper.WriteAttribute(sw, "s", this.s);
@@ -107,7 +108,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                     x.Write(sw, "c");
                 }
             }
-            sw.Write(string.Format("</{0}>", nodeName));
+            sw.WriteEndElement(nodeName);
         }
 
 

--- a/OpenXmlFormats/StreamWriterExtensions.cs
+++ b/OpenXmlFormats/StreamWriterExtensions.cs
@@ -1,0 +1,65 @@
+﻿using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace NPOI.OpenXmlFormats;
+
+internal static class StreamWriterExtensions
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void WriteAttribute(this StreamWriter sw, string name, string value)
+    {
+        sw.Write(" ");
+        sw.Write(name);
+        sw.Write("=\"");
+        sw.Write(value);
+        sw.Write("\"");
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void WriteAttribute(this StreamWriter sw, string name, int value)
+    {
+        sw.Write(" ");
+        sw.Write(name);
+        sw.Write("=\"");
+        sw.Write(value);
+        sw.Write("\"");
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void WriteBooleanAttribute(this StreamWriter sw, string name, bool value)
+    {
+        sw.Write(" ");
+        sw.Write(name);
+        sw.Write("=\"");
+        sw.Write(value ? 1 : 0);
+        sw.Write("\"");
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void WriteElementAndContent(this StreamWriter sw, string name, string value)
+    {
+        sw.Write("<");
+        sw.Write(name);
+        sw.Write(">");
+        sw.Write(value);
+        sw.Write("</");
+        sw.Write(name);
+        sw.Write(">");
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void WriteEndElement(this StreamWriter sw, string name)
+    {
+        sw.Write("</");
+        sw.Write(name);
+        sw.Write(">");
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void WriteEndW(this StreamWriter sw, string nodeName)
+    {
+        sw.Write("</w:");
+        sw.Write(nodeName);
+        sw.Write(">");
+    }
+}

--- a/OpenXmlFormats/Vml/WordprocessingDrawing.cs
+++ b/OpenXmlFormats/Vml/WordprocessingDrawing.cs
@@ -44,7 +44,7 @@ namespace NPOI.OpenXmlFormats.Vml.Wordprocessing
             XmlHelper.WriteAttribute(sw, "width", this.width);
             NPOI.OpenXmlFormats.Util.XmlHelper.WriteAttribute(sw, "shadow", this.shadow);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute]
@@ -260,7 +260,7 @@ namespace NPOI.OpenXmlFormats.Vml.Wordprocessing
             XmlHelper.WriteAttribute(sw, "anchorx", this.anchorx.ToString());
             XmlHelper.WriteAttribute(sw, "anchory", this.anchory.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute]

--- a/OpenXmlFormats/Wordprocessing/BaseTypes.cs
+++ b/OpenXmlFormats/Wordprocessing/BaseTypes.cs
@@ -365,7 +365,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -484,7 +484,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
         private string valField;
         /// <summary>
@@ -616,7 +616,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         private string valField;

--- a/OpenXmlFormats/Wordprocessing/CustomXml.cs
+++ b/OpenXmlFormats/Wordprocessing/CustomXml.cs
@@ -258,7 +258,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_CustomXmlRow)
                     ((CT_CustomXmlRow)o).Write(sw, "customXml");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -404,7 +404,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "attr");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -467,7 +467,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:name", this.name);
             XmlHelper.WriteAttribute(sw, "w:val", this.val);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -1067,7 +1067,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_OMathPara)
                     ((CT_OMathPara)o).Write(sw, "oMathPara");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
     }
@@ -1559,7 +1559,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_Markup)
                     ((CT_Markup)o).Write(sw, "customXmlMoveToRangeEnd");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
     }
@@ -1932,7 +1932,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_OMathPara)
                     ((CT_OMathPara)o).Write(sw, "oMathPara");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("oMath", typeof(CT_OMath), Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/math", Order = 1)]
@@ -2363,7 +2363,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_Markup)
                     ((CT_Markup)o).Write(sw, "customXmlInsRangeEnd");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]

--- a/OpenXmlFormats/Wordprocessing/Document.cs
+++ b/OpenXmlFormats/Wordprocessing/Document.cs
@@ -401,7 +401,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             }
             if (this.sectPr != null)
                 this.sectPr.Write(sw, "sectPr");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_SectPr AddNewSectPr()

--- a/OpenXmlFormats/Wordprocessing/FormField.cs
+++ b/OpenXmlFormats/Wordprocessing/FormField.cs
@@ -206,7 +206,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 {
                     this.numberingChangeField.Write(sw, "numberingChange");
                 }
-                sw.Write(string.Format("</w:{0}>", nodeName));
+                sw.WriteEndW(nodeName);
             }
         }
 
@@ -416,7 +416,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     (this.itemsField[i] as CT_FFTextInput).Write(sw, "textInput");
             }
 
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
         private void AddNewObject(object obj, FFDataItemsType type)
         {
@@ -642,7 +642,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else
                     (this.itemField as CT_HpsMeasure).Write(sw, "size");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
     }
 
@@ -742,7 +742,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             {
                 str.Write(sw, "listEntry");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
     }
 
@@ -1034,7 +1034,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             if (this.maxLengthField != null)
                 this.maxLengthField.Write(sw, "maxLength");
             
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
     }
 

--- a/OpenXmlFormats/Wordprocessing/Frame.cs
+++ b/OpenXmlFormats/Wordprocessing/Frame.cs
@@ -491,7 +491,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:hRule", this.hRule.ToString());
             XmlHelper.WriteAttribute(sw, "w:anchorLock", this.anchorLock.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 

--- a/OpenXmlFormats/Wordprocessing/HdrFtr.cs
+++ b/OpenXmlFormats/Wordprocessing/HdrFtr.cs
@@ -262,7 +262,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_Markup)
                     ((CT_Markup)o).Write(sw, "customXmlInsRangeEnd");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public ArrayList Items
@@ -648,7 +648,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.numStart.Write(sw, "numStart");
             if (this.numRestart != null)
                 this.numRestart.Write(sw, "numRestart");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -728,7 +728,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         private ST_FtnPos valField;
@@ -1098,7 +1098,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     ((CT_CustomXmlBlock)o).Write(sw, "customXml");
                 i++;
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -1523,7 +1523,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "footnote");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("footnote", Order = 0)]
@@ -1635,7 +1635,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.numStart.Write(sw, "numStart");
             if (this.numRestart != null)
                 this.numRestart.Write(sw, "numRestart");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -1715,7 +1715,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         private ST_EdnPos valField;
@@ -1797,7 +1797,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "endnote");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         private List<CT_FtnEdnSepRef> endnoteField;
@@ -1857,7 +1857,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:customMarkFollows", this.customMarkFollows.ToString());
             XmlHelper.WriteAttribute(sw, "w:id", this.id);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]

--- a/OpenXmlFormats/Wordprocessing/Markup.cs
+++ b/OpenXmlFormats/Wordprocessing/Markup.cs
@@ -503,7 +503,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_MarkupRange)
                     ((CT_MarkupRange)o).Write(sw, "moveFromRangeEnd");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [System.Xml.Serialization.XmlElementAttribute("oMath", typeof(CT_OMath), Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/math", Order = 0)]

--- a/OpenXmlFormats/Wordprocessing/Numbering.cs
+++ b/OpenXmlFormats/Wordprocessing/Numbering.cs
@@ -58,7 +58,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "lvlOverride");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -166,7 +166,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.startOverride.Write(sw, "startOverride");
             if (this.lvl != null)
                 this.lvl.Write(sw, "lvl");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -459,7 +459,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.pict != null)
                 this.pict.Write(sw, "pict");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -722,7 +722,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         private ST_RestartNumber valField;
@@ -811,7 +811,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.numberingChange.Write(sw, "numberingChange");
             if (this.ins != null)
                 this.ins.Write(sw, "ins");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_DecimalNumber AddNewIlvl()
@@ -908,7 +908,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:font", this.font);
             XmlHelper.WriteAttribute(sw, "w:char", this.@char);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -1162,7 +1162,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "lvl");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -1369,7 +1369,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.pPr.Write(sw, "pPr");
             if (this.rPr != null)
                 this.rPr.Write(sw, "rPr");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -1750,7 +1750,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:legacySpace", this.legacySpace);
             XmlHelper.WriteAttribute(sw, "w:legacyIndent", this.legacyIndent);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 

--- a/OpenXmlFormats/Wordprocessing/PageSetup.cs
+++ b/OpenXmlFormats/Wordprocessing/PageSetup.cs
@@ -330,7 +330,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:first", this.first);
             XmlHelper.WriteAttribute(sw, "w:other", this.other);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified, DataType = "integer")]
@@ -437,7 +437,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.bottom.Write(sw, "bottom");
             if (this.right != null)
                 this.right.Write(sw, "right");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -765,7 +765,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -857,7 +857,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:distance", this.distance);
             XmlHelper.WriteAttribute(sw, "w:restart", this.restart.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified, DataType = "integer")]

--- a/OpenXmlFormats/Wordprocessing/Paragraph.cs
+++ b/OpenXmlFormats/Wordprocessing/Paragraph.cs
@@ -331,7 +331,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     ((CT_Rel)o).Write(sw, "subDoc");
                 i++;
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("oMath", typeof(CT_OMath), Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/math", Order = 1)]
@@ -1116,7 +1116,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             if (this.cnfStyle != null)
                 this.cnfStyle.Write(sw, "cnfStyle");
 
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -2053,7 +2053,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.oMath.Write(sw, "oMath");
             if (this.rPrChange != null)
                 this.rPrChange.Write(sw, "rPrChange");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -2102,7 +2102,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.sectPr != null)
                 this.sectPr.Write(sw, "sectPr");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -2277,7 +2277,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.docGrid.Write(sw, "docGrid");
             if (this.printerSettings != null)
                 this.printerSettings.Write(sw, "printerSettings");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -3179,7 +3179,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.printerSettings.Write(sw, "printerSettings");
             if (this.sectPrChange != null)
                 this.sectPrChange.Write(sw, "sectPrChange");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -3248,7 +3248,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.between.Write(sw, "between");
             if (this.bar != null)
                 this.bar.Write(sw, "bar");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -4161,7 +4161,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.oMath.Write(sw, "oMath");
             if (this.rPrChange != null)
                 this.rPrChange.Write(sw, "rPrChange");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
         public CT_String AddNewRStyle()
         {
@@ -5813,7 +5813,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "w");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
     }
@@ -5983,7 +5983,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.pPr != null)
                 this.pPr.Write(sw, "pPr");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -6284,7 +6284,7 @@ cnfStyleField == null;
             if (this.cnfStyle != null)
                 this.cnfStyle.Write(sw, "cnfStyle");
 
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -6875,7 +6875,7 @@ cnfStyleField == null;
             sw.Write(">");
             if (this.rPr != null)
                 this.rPr.Write(sw, "rPr");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -7586,7 +7586,7 @@ cnfStyleField == null;
                     x.Write(sw, "imprint");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
     }
@@ -7636,7 +7636,7 @@ cnfStyleField == null;
             XmlHelper.WriteAttribute(sw, "w:type", this.type.ToString());
             XmlHelper.WriteAttribute(sw, "w:clear", this.clear.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -7788,7 +7788,7 @@ cnfStyleField == null;
                 this.trPr.Write(sw, "trPr");
             if (this.tcPr != null)
                 this.tcPr.Write(sw, "tcPr");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_TblStylePr()

--- a/OpenXmlFormats/Wordprocessing/Picture.cs
+++ b/OpenXmlFormats/Wordprocessing/Picture.cs
@@ -220,7 +220,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     ((CT_Shapetype)childnode).Write(sw, "shapetype");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
     }
 
@@ -451,7 +451,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.control != null)
                 this.control.Write(sw, "control");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
     }
@@ -482,7 +482,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:shapeid", this.shapeid);
             XmlHelper.WriteAttribute(sw, "r:id", this.id);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 

--- a/OpenXmlFormats/Wordprocessing/RangePermission.cs
+++ b/OpenXmlFormats/Wordprocessing/RangePermission.cs
@@ -56,11 +56,12 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<w:{0}", nodeName));
+            sw.Write("<w:");
+            sw.Write(nodeName);
             XmlHelper.WriteAttribute(sw, "r:id", this.id);
             XmlHelper.WriteAttribute(sw, "w:displacedByCustomXml", this.displacedByCustomXml.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified, Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships")]
@@ -213,7 +214,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:id", this.id);
             XmlHelper.WriteAttribute(sw, "w:displacedByCustomXml", this.displacedByCustomXml.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
     }

--- a/OpenXmlFormats/Wordprocessing/Run.cs
+++ b/OpenXmlFormats/Wordprocessing/Run.cs
@@ -794,7 +794,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             {
                 this.alternateContent.Write(sw, "AlternateContent");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
     }
 
@@ -927,7 +927,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -1039,7 +1039,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.lid.Write(sw, "lid");
             if (this.dirty != null)
                 this.dirty.Write(sw, "dirty");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -1394,7 +1394,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     ((CT_R)o).Write(sw, "r");
                 i++;
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
     }
@@ -1535,7 +1535,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.rt.Write(sw, "rt");
             if (this.rubyBase != null)
                 this.rubyBase.Write(sw, "rubyBase");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -1813,7 +1813,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         private ST_TextboxTightWrap valField;
@@ -1879,7 +1879,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 

--- a/OpenXmlFormats/Wordprocessing/Sdt.cs
+++ b/OpenXmlFormats/Wordprocessing/Sdt.cs
@@ -258,7 +258,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_MarkupRange)
                     ((CT_MarkupRange)o).Write(sw, "commentRangeEnd");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("oMath", typeof(CT_OMath), Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/math", Order = 0)]
@@ -463,7 +463,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             }
             if (this.sdtContent != null)
                 this.sdtContent.Write(sw, "sdtContent");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -583,7 +583,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "sdtEndPr");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -682,7 +682,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "sdtEndPr");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -761,7 +761,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "listItem");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         private List<CT_SdtListItem> listItemField;
@@ -849,7 +849,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.docPartCategory.Write(sw, "docPartCategory");
             if (this.docPartUnique != null)
                 this.docPartUnique.Write(sw, "docPartUnique");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -944,7 +944,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "listItem");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("listItem", Order = 0)]
@@ -1211,7 +1211,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_Tbl)
                     ((CT_Tbl)o).Write(sw, "tbl");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("oMath", typeof(CT_OMath), Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/math", Order = 0)]
@@ -1705,7 +1705,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_Row)
                     ((CT_Row)o).Write(sw, "tr");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("oMath", typeof(CT_OMath), Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/math", Order = 0)]
@@ -1998,7 +1998,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     ((CT_DataBinding)o).Write(sw, "dataBinding");
                 
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_DecimalNumber AddNewId()
@@ -2485,7 +2485,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_MarkupRange)
                     ((CT_MarkupRange)o).Write(sw, "bookmarkEnd");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("oMath", typeof(CT_OMath), Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/math", Order = 0)]
@@ -2789,7 +2789,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:displayText", this.displayText);
             XmlHelper.WriteAttribute(sw, "w:value", this.value);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -2847,7 +2847,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -2922,7 +2922,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -3052,7 +3052,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.storeMappedDataAs.Write(sw, "storeMappedDataAs");
             if (this.calendar != null)
                 this.calendar.Write(sw, "calendar");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -3188,7 +3188,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "sdtEndPr");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -3258,7 +3258,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:multiLine", this.multiLine.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -3311,7 +3311,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         private ST_Lock valField;

--- a/OpenXmlFormats/Wordprocessing/Settings.cs
+++ b/OpenXmlFormats/Wordprocessing/Settings.cs
@@ -2196,7 +2196,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:hash", this.hash);
             XmlHelper.WriteAttribute(sw, "w:salt", this.salt);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -2480,7 +2480,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -2670,7 +2670,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:checkStyle", this.checkStyle.ToString());
             XmlHelper.WriteAttribute(sw, "w:appName", this.appName);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -2800,7 +2800,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:spelling", this.spelling.ToString());
             XmlHelper.WriteAttribute(sw, "w:grammar", this.grammar.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -2895,7 +2895,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -3048,7 +3048,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.checkErrors.Write(sw, "checkErrors");
             if (this.odso != null)
                 this.odso.Write(sw, "odso");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_MailMerge()
@@ -3306,7 +3306,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -3374,7 +3374,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -3442,7 +3442,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -3574,7 +3574,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "recipientData");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -3709,7 +3709,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -3820,7 +3820,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.lid.Write(sw, "lid");
             if (this.dynamicAddress != null)
                 this.dynamicAddress.Write(sw, "dynamicAddress");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_OdsoFieldMapData()
@@ -3938,7 +3938,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -4027,7 +4027,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:formatting", this.formatting.ToString());
             XmlHelper.WriteAttribute(sw, "w:inkAnnotations", this.inkAnnotations.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -4649,7 +4649,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:lang", this.lang);
             XmlHelper.WriteAttribute(sw, "w:val", this.val);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -4708,7 +4708,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "r:id", this.id);
             XmlHelper.WriteAttribute(sw, "w:solutionID", this.solutionID);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified, Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/relationships")]
@@ -5152,7 +5152,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.useAnsiKerningPairs.Write(sw, "useAnsiKerningPairs");
             if (this.cachedColBalance != null)
                 this.cachedColBalance.Write(sw, "cachedColBalance");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_Compat()
@@ -6099,7 +6099,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:name", this.name);
             XmlHelper.WriteAttribute(sw, "w:val", this.val);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -6177,7 +6177,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "rsid");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -6729,7 +6729,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "autoCaptions");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("caption", Order = 0)]
@@ -6824,7 +6824,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:numFmt", this.numFmt.ToString());
             XmlHelper.WriteAttribute(sw, "w:sep", this.sep.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -7032,7 +7032,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:name", this.name);
             XmlHelper.WriteAttribute(sw, "w:caption", this.caption);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -7100,7 +7100,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:h", this.h);
             XmlHelper.WriteAttribute(sw, "w:fontSz", this.fontSz);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -7189,7 +7189,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:name", this.name);
             XmlHelper.WriteAttribute(sw, "w:url", this.url);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]

--- a/OpenXmlFormats/Wordprocessing/Styles.cs
+++ b/OpenXmlFormats/Wordprocessing/Styles.cs
@@ -182,7 +182,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.rPrDefault.Write(sw, "rPrDefault");
             if (this.pPrDefault != null)
                 this.pPrDefault.Write(sw, "pPrDefault");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -269,7 +269,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.rPr != null)
                 this.rPr.Write(sw, "rPr");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -331,7 +331,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.pPr != null)
                 this.pPr.Write(sw, "pPr");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -431,7 +431,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "lsdException");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_LatentStyles()
@@ -811,7 +811,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "tblStylePr");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -1219,7 +1219,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -1697,7 +1697,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -1744,7 +1744,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 

--- a/OpenXmlFormats/Wordprocessing/Tab.cs
+++ b/OpenXmlFormats/Wordprocessing/Tab.cs
@@ -220,7 +220,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:relativeTo", this.relativeTo.ToString());
             XmlHelper.WriteAttribute(sw, "w:leader", this.leader.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]

--- a/OpenXmlFormats/Wordprocessing/Table.cs
+++ b/OpenXmlFormats/Wordprocessing/Table.cs
@@ -379,7 +379,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_MarkupRange)
                     ((CT_MarkupRange)o).Write(sw, "commentRangeEnd");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("bookmarkEnd", typeof(CT_MarkupRange), Order = 0)]
@@ -771,7 +771,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "tblGrid");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlArray(Order = 0)]
@@ -908,7 +908,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     x.Write(sw, "gridCol");
                 }
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -958,7 +958,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         private ST_TblOverlap valField;
@@ -1117,7 +1117,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.tblPr != null)
                 this.tblPr.Write(sw, "tblPr");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         private CT_TblPrBase tblPrField;
@@ -1272,7 +1272,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.tblCaption.Write(sw, "tblCaption");
             if (this.tblDescription != null)
                 this.tblDescription.Write(sw, "tblDescription");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -1643,7 +1643,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 XmlHelper.WriteAttribute(sw, "w:tblpYSpec", this.tblpYSpec.ToString());
             XmlHelper.WriteAttribute(sw, "w:tblpY", this.tblpY);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -2028,7 +2028,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.tblPrEx != null)
                 this.tblPrEx.Write(sw, "tblPrEx");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -2124,7 +2124,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.tblCellMar.Write(sw, "tblCellMar");
             if (this.tblLook != null)
                 this.tblLook.Write(sw, "tblLook");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_TblPrExBase()
@@ -2324,7 +2324,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.tblCellMar.Write(sw, "tblCellMar");
             if (this.tblLook != null)
                 this.tblLook.Write(sw, "tblLook");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_TblPrEx()
@@ -2408,7 +2408,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.insideH.Write(sw, "insideH");
             if (this.insideV != null)
                 this.insideV.Write(sw, "insideV");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -2660,7 +2660,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.bottom.Write(sw, "bottom");
             if (this.right != null)
                 this.right.Write(sw, "right");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_TblCellMar()
@@ -2868,7 +2868,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.tblCaption.Write(sw, "tblCaption");
             if (this.tblDescription != null)
                 this.tblDescription.Write(sw, "tblDescription");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_TblPr()
@@ -2943,7 +2943,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.trPr != null)
                 this.trPr.Write(sw, "trPr");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -3093,7 +3093,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     && this.ItemsElementName[i] == ItemsChoiceType2.wBefore)
                     ((CT_TblWidth)o).Write(sw, "wBefore");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("cantSplit", typeof(CT_OnOff), Order = 0)]
@@ -3557,7 +3557,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_Tbl)
                     ((CT_Tbl)o).Write(sw, "tbl");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("oMath", typeof(CT_OMath), Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/math", Order = 1)]
@@ -4019,7 +4019,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                     && this.ItemsElementName[i] == ItemsChoiceType2.wBefore)
                     ((CT_TblWidth)o).Write(sw, "wBefore");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -4096,7 +4096,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.tcPr != null)
                 this.tcPr.Write(sw, "tcPr");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         private CT_TcPrInner tcPrField;
@@ -4220,7 +4220,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.vAlign.Write(sw, "vAlign");
             if (this.hideMark != null)
                 this.hideMark.Write(sw, "hideMark");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -4304,7 +4304,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:date", this.date);
             XmlHelper.WriteAttribute(sw, "r:id", this.id);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -4446,7 +4446,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.tl2br.Write(sw, "tl2br");
             if (this.tr2bl != null)
                 this.tr2bl.Write(sw, "tr2bl");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_TcBorders()
@@ -4615,7 +4615,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.bottom.Write(sw, "bottom");
             if (this.right != null)
                 this.right.Write(sw, "right");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -4769,7 +4769,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 this.vAlign.Write(sw, "vAlign");
             if (this.hideMark != null)
                 this.hideMark.Write(sw, "hideMark");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_TcPr()
@@ -5069,7 +5069,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -5212,7 +5212,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:w", this.w);
             XmlHelper.WriteAttribute(sw, "w:space", this.space);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]
@@ -5334,7 +5334,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 {
                     x.Write(sw, "col");
                 }
-                sw.Write(string.Format("</w:{0}>", nodeName));
+                sw.WriteEndW(nodeName);
             } else
             {
                 sw.Write("/>");
@@ -5724,7 +5724,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_Tc)
                     ((CT_Tc)o).Write(sw, "tc");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
         public CT_Row Copy()
         {

--- a/OpenXmlFormats/Wordprocessing/wml.cs
+++ b/OpenXmlFormats/Wordprocessing/wml.cs
@@ -229,7 +229,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.altChunkPr != null)
                 this.altChunkPr.Write(sw, "altChunkPr");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -292,7 +292,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.matchSrc != null)
                 this.matchSrc.Write(sw, "matchSrc");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement(Order = 0)]
@@ -539,7 +539,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:vert", this.vert.ToString());
             XmlHelper.WriteAttribute(sw, "w:vertCompress", this.vertCompress.ToString());
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -710,7 +710,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:val", this.val);
             XmlHelper.WriteAttribute(sw, "w:id", this.id);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -918,7 +918,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "w:val", this.val);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -980,7 +980,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(string.Format("<w:{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "r:id", this.id);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
 
@@ -1992,7 +1992,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_Markup)
                     ((CT_Markup)o).Write(sw, "customXmlInsRangeEnd");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("oMath", typeof(CT_OMath), Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/math", Order = 1)]
@@ -2262,7 +2262,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             {
                 sw.Write(XmlHelper.EncodeXml(this.valueField));
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified, Namespace = "http://www.w3.org/XML/1998/namespace")]
@@ -2579,7 +2579,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
                 else if (o is CT_Rel)
                     ((CT_Rel)o).Write(sw, "subDoc");
             }
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlElement("oMath", typeof(CT_OMath), Namespace = "http://schemas.openxmlformats.org/officeDocument/2006/math", Order = 0)]
@@ -3125,7 +3125,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             sw.Write(">");
             if (this.docPart != null)
                 this.docPart.Write(sw, "docPart");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         public CT_Placeholder()
@@ -3183,7 +3183,7 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
             XmlHelper.WriteAttribute(sw, "w:xpath", this.xpath);
             XmlHelper.WriteAttribute(sw, "w:storeItemID", this.storeItemID);
             sw.Write(">");
-            sw.Write(string.Format("</w:{0}>", nodeName));
+            sw.WriteEndW(nodeName);
         }
 
         [XmlAttribute(Form = System.Xml.Schema.XmlSchemaForm.Qualified)]

--- a/openxml4Net/Util/XmlHelper.cs
+++ b/openxml4Net/Util/XmlHelper.cs
@@ -215,7 +215,7 @@ namespace NPOI.OpenXml4Net.Util
                 return blankValue;
 
             string value = attr.Value;
-            if (value == "1" || value == "-1" || value.ToLower() == "true" || value.ToLower() == "on")
+            if (value == "1" || value == "-1" || string.Equals(value, "true", StringComparison.OrdinalIgnoreCase) || string.Equals(value, "on", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -304,10 +304,24 @@ namespace NPOI.OpenXml4Net.Util
             ret.Append(t.Substring(prevIndex, t.Length - prevIndex));
             return ret.ToString();
         }
+
+        private static readonly char[] xmlEncodeCharsToReplace = { '&', '<', '>', '"' };
+
         public static string EncodeXml(string xml)
         {
-            return xml.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace("\"", "&quot;");//.Replace("'", "&apos;");
+            // quick check whether needed
+            if (xml.IndexOfAny(xmlEncodeCharsToReplace) == -1)
+            {
+                return xml;
+            }
+
+            return xml
+                .Replace("&", "&amp;")
+                .Replace("<", "&lt;")
+                .Replace(">", "&gt;")
+                .Replace("\"", "&quot;");//.Replace("'", "&apos;");
         }
+
         public static void WriteAttribute(StreamWriter sw, string attributeName, bool value)
         {
             WriteAttribute(sw, attributeName, value, true);
@@ -333,7 +347,11 @@ namespace NPOI.OpenXml4Net.Util
             if (value == 0 && !writeIfBlank)
                 return;
 
-            WriteAttribute(sw, attributeName, value.ToString(CultureInfo.InvariantCulture));
+            sw.Write(" ");
+            sw.Write(attributeName);
+            sw.Write("=\"");
+            sw.Write(value);
+            sw.Write("\"");
         }
         public static void WriteAttribute(StreamWriter sw, string attributeName, int value)
         {
@@ -344,7 +362,11 @@ namespace NPOI.OpenXml4Net.Util
             if (value == 0 && !writeIfBlank)
                 return;
 
-            WriteAttribute(sw, attributeName, value.ToString(CultureInfo.InvariantCulture));
+            sw.Write(" ");
+            sw.Write(attributeName);
+            sw.Write("=\"");
+            sw.Write(value);
+            sw.Write("\"");
         }
         public static void WriteAttribute(StreamWriter sw, string attributeName, uint value)
         {
@@ -362,7 +384,12 @@ namespace NPOI.OpenXml4Net.Util
         {
             if ((string.IsNullOrEmpty(value) || defaultValue.Equals(value)) && !writeIfBlank)
                 return;
-            sw.Write(string.Format(" {0}=\"{1}\"", attributeName, value == null ? string.Empty : EncodeXml(value)));
+
+            sw.Write(" ");
+            sw.Write(attributeName);
+            sw.Write("=\"");
+            sw.Write(value == null ? string.Empty : EncodeXml(value));
+            sw.Write("\"");
         }
         public static void WriteAttribute(StreamWriter sw, string attributeName, byte[] value)
         {


### PR DESCRIPTION
`string.Format` is a bad thing in hot paths. Changed code to call multiple `Write`s instead of string concatenation.

## NPOI.Benchmarks.LargeExcelFileBenchmark

| **Diff**|Method|Mean|Error|Allocated|
|------- |-------|-------:|-------|-------:|
| Old |Load|11.741 s|1.1257 s|3.65 GB|
| **New** |	| **11.626 s (-1%)** | **2.0913 s** | **3732.62 MB (0%)** |
| Old |Write|3.483 s|0.1738 s|1.19 GB|
| **New** |	| **3.058 s (-12%)** | **0.2296 s** | **611.83 MB (-50%)** |
| Old |Evaluate|62.677 s|4.1891 s|75.32 GB|
| **New** |	| **64.658 s (+3%)** | **24.1520 s** | **77128.7 MB (0%)** |


## NPOI.Benchmarks.RangeValuesBenchmark

| **Diff**|Method|Mean|Error|Allocated|
|------- |-------|-------:|-------|-------:|
| Old |Double|85.46 ms|0.367 ms|31.45 MB|
| **New** |	| **82.83 ms (-3%)** | **0.382 ms** | **26.98 MB (-14%)** |
| Old |String|99.93 ms|0.449 ms|59.32 MB|
| **New** |	| **91.75 ms (-8%)** | **0.803 ms** | **53.92 MB (-9%)** |
| Old |Date|114.71 ms|1.603 ms|35.73 MB|
| **New** |	| **108.22 ms (-6%)** | **0.239 ms** | **30.55 MB (-14%)** |
| Old |Formulas|1,064.12 ms|10.889 ms|1480.15 MB|
| **New** |	| **1,057.00 ms (-1%)** | **4.548 ms** | **1473.42 MB (0%)** |


