### PR TITLE
Include all projects in NuGet package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,22 +1,13 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 
-    <!-- SourceLink related properties https://github.com/dotnet/SourceLink#using-sourcelink -->
-    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-     
-    <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    
-    <!-- Optional: Include the PDB in the built .nupkg -->
-    <!-- <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder> -->
-    
-    <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
     <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-
-    <RunSettingsFilePath>$(MSBuildThisFileDirectory)\test.runsettings</RunSettingsFilePath>
+    <DebugType>portable</DebugType>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
     <VersionPrefix>2.6.1</VersionPrefix>
     <Title>NPOI</Title>
@@ -34,6 +25,10 @@
     <PackageTags>xlsx xls Excel Word docx office ole</PackageTags>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\LICENSE" Pack="true" Visible="false" PackagePath="" />
     <None Include="..\Read Me.txt" Pack="true" Visible="false" PackagePath="" />
@@ -45,6 +40,10 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NuGetizer" Version="1.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -45,8 +45,17 @@ partial class Build : NukeBuild
         .Before(Restore)
         .Executes(() =>
         {
-            SourceDirectory.GlobDirectories("**/bin", "**/obj").ForEach(x => x.DeleteDirectory());
+            DeleteCompilationArtifacts();
+            ArtifactsDirectory.CreateOrCleanDirectory();
         });
+
+    static void DeleteCompilationArtifacts()
+    {
+        var solutionDirectory = RootDirectory / "solution";
+        solutionDirectory.GlobDirectories("**/bin", "**/obj").ForEach(x => x.DeleteDirectory());
+        (solutionDirectory / "Debug").DeleteDirectory();
+        (solutionDirectory / "Release").DeleteDirectory();
+    }
 
     Target Restore => _ => _
         .Executes(() =>
@@ -68,9 +77,12 @@ partial class Build : NukeBuild
                 .SetVerbosity(DotNetVerbosity.Minimal)
                 // obsolete missing XML documentation comment, XML comment on not valid language element, XML comment has badly formed XML, no matching tag in XML comment
                 // need to use escaped separator in order for this to work
-                .AddProperty("NoWarn", string.Join("%3B", new [] { 618, 1591, 1587, 1570, 1572, 1573 }))
+                .AddProperty("NoWarn", string.Join("%3B", new [] { 169, 612, 618, 1591, 1587, 1570, 1572, 1573, 1574 }))
                 .SetProjectFile(Solution)
             );
+
+            // copy files from projects in order to get them to be part of pack
+
         });
 
     Target Test => _ => _
@@ -92,6 +104,11 @@ partial class Build : NukeBuild
         .Produces(ArtifactsDirectory / "**")
         .Executes(() =>
         {
+            // make sure we make fresh build
+            DeleteCompilationArtifacts();
+
+            var packTarget = Solution.GetProject("NPOI.Pack");
+
             DotNetPack(_ =>_
                 .SetConfiguration(Configuration)
                 .SetOutputDirectory(ArtifactsDirectory)
@@ -99,8 +116,9 @@ partial class Build : NukeBuild
                 .SetContinuousIntegrationBuild(IsServerBuild)
                 // obsolete missing XML documentation comment, XML comment on not valid language element, XML comment has badly formed XML, no matching tag in XML comment
                 // need to use escaped separator in order for this to work
-                .AddProperty("NoWarn", string.Join("%3B", new [] { 618, 1591, 1587, 1570, 1572, 1573 }))
-                .SetProject(Solution.GetProject("NPOI.Core"))
+                .AddProperty("NoWarn", string.Join("%3B", new [] { 169, 612, 618, 1591, 1587, 1570, 1572, 1573, 1574 }))
+                .SetProperty("EnablePackageValidation", "false")
+                .SetProject(packTarget)
             );
         });
 }

--- a/main/NPOI.Core.csproj
+++ b/main/NPOI.Core.csproj
@@ -2,16 +2,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <AssemblyName>NPOI</AssemblyName>
     <RootNamespace>NPOI</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\npoi.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\solution\$(Configuration)\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,7 +21,14 @@
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.0-beta19" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <Reference Include="System.Configuration" />
   </ItemGroup>
 
 </Project>

--- a/ooxml/NPOI.OOXML.Core.csproj
+++ b/ooxml/NPOI.OOXML.Core.csproj
@@ -2,19 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>NPOI.OOXML</AssemblyName>
     <RootNamespace>NPOI</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\npoi.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\solution\$(Configuration)\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/openxml4Net/NPOI.OpenXml4Net.Core.csproj
+++ b/openxml4Net/NPOI.OpenXml4Net.Core.csproj
@@ -2,16 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>NPOI.OpenXml4Net</AssemblyName>
     <RootNamespace>NPOI.OpenXml4Net</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\npoi.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\solution\$(Configuration)\</OutputPath>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/solution/NPOI.Core.Test.sln
+++ b/solution/NPOI.Core.Test.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.c
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NPOI.Benchmarks", "..\benchmarks\NPOI.Benchmarks\NPOI.Benchmarks.csproj", "{3DA1149D-46F8-4181-9976-E002BF2BFB76}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPOI.Pack", "NPOI.Pack.csproj", "{6D7A6E15-C914-4FCA-B8E4-FF5C7437C2E0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,14 +62,14 @@ Global
 		{DA2CA3BD-1CAC-470C-9FA2-611A5768A76A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DA2CA3BD-1CAC-470C-9FA2-611A5768A76A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DA2CA3BD-1CAC-470C-9FA2-611A5768A76A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D7A6E15-C914-4FCA-B8E4-FF5C7437C2E0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D7A6E15-C914-4FCA-B8E4-FF5C7437C2E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D7A6E15-C914-4FCA-B8E4-FF5C7437C2E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D7A6E15-C914-4FCA-B8E4-FF5C7437C2E0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/solution/NPOI.Pack.csproj
+++ b/solution/NPOI.Pack.csproj
@@ -1,16 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- This is an umbrella project that gathers dependencies for dotnet pack -->
+  
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
-    <AssemblyName>NPOI.OpenXmlFormats</AssemblyName>
-    <RootNamespace>NPOI.OpenXmlFormats</RootNamespace>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\npoi.snk</AssemblyOriginatorKeyFile>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <PackageId>NPOI</PackageId>
     <OutputPath>..\solution\$(Configuration)\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\main\NPOI.Core.csproj" />
+    <ProjectReference Include="..\ooxml\NPOI.OOXML.Core.csproj" />
     <ProjectReference Include="..\openxml4Net\NPOI.OpenXml4Net.Core.csproj" />
+    <ProjectReference Include="..\OpenXmlFormats\NPOI.OpenXmlFormats.Core.csproj" />
   </ItemGroup>
+
 </Project>

--- a/testcases/Directory.Build.props
+++ b/testcases/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+
+  <PropertyGroup>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)\..\..\test.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+
+</Project>

--- a/testcases/main/NPOI.TestCases.Core.csproj
+++ b/testcases/main/NPOI.TestCases.Core.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>NPOI.TestCases</AssemblyName>
     <RootNamespace>TestCases</RootNamespace>
     <SignAssembly>true</SignAssembly>

--- a/testcases/ooxml/NPOI.OOXML.TestCases.Core.csproj
+++ b/testcases/ooxml/NPOI.OOXML.TestCases.Core.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>NPOI.OOXML.TestCases</AssemblyName>
     <RootNamespace>TestCases</RootNamespace>
     <SignAssembly>true</SignAssembly>

--- a/testcases/openxml4net/NPOI.OOXML4Net.TestCases.Core.csproj
+++ b/testcases/openxml4net/NPOI.OOXML4Net.TestCases.Core.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>NPOI.OOXML4Net.TestCases</AssemblyName>
     <RootNamespace>TestCases</RootNamespace>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Adding a separate `NPOI.Pack.csproj` project that references other projects and thus creates a NuGet package that has all dependencies inside. This changes `NPOI.dll` to be `NPOI.Core.dll` (like the project actually is) in order for pack to succeed. Uses Nugetizer reference which fixes project references to be also part of NuGet package contents.

Ideally there would be separate NuGet packages for each on NuGet or as now there's build output (dll and pdb) for each dependency multiple times in package output. The package size is now 11MB which is quite big but that's the way to roll I guess with current setup where Core is/was packaging target and reverse-dependencies are needed.

With Nugetizer there's no snupkg anymore sore pdbs are part of the main NuGet package.