### PR TITLE
fix issue #983 INT(1.99) doesn't return correct rounded value

### DIFF
--- a/main/SS/Formula/Functions/Int.cs
+++ b/main/SS/Formula/Functions/Int.cs
@@ -31,10 +31,7 @@ namespace NPOI.SS.Formula.Functions
 
         public override double Evaluate(double d)
         {
-            if (d > 0)
-                return Math.Round(d - 0.49);
-            else
-                return Math.Round(d - 0.5);
+            return Math.Floor(d);            
         }
 
     }


### PR DESCRIPTION
This closes #983 

Since in excel INT function definition is "Rounds a number down to the nearest integer", change the function from Math.Round to Math.Floor