### PR TITLE
fix #1055 Unexpected ROUNDDOWN function Result

### DIFF
--- a/main/SS/Formula/Eval/TwoOperandNumeric/MultiplyEval.cs
+++ b/main/SS/Formula/Eval/TwoOperandNumeric/MultiplyEval.cs
@@ -25,7 +25,10 @@ namespace NPOI.SS.Formula.Eval
     {
         public override double Evaluate(double d0, double d1)
         {
-            return d0 * d1;
+            decimal dec0 = (decimal)d0;
+            decimal dec1 = (decimal)d1;
+
+            return decimal.ToDouble(dec0 * dec1);
         }
     }
 }

--- a/solution/NPOI.Core.Test.sln
+++ b/solution/NPOI.Core.Test.sln
@@ -26,7 +26,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.c
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NPOI.Benchmarks", "..\benchmarks\NPOI.Benchmarks\NPOI.Benchmarks.csproj", "{3DA1149D-46F8-4181-9976-E002BF2BFB76}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPOI.Pack", "NPOI.Pack.csproj", "{6D7A6E15-C914-4FCA-B8E4-FF5C7437C2E0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NPOI.Pack", "NPOI.Pack.csproj", "{6D7A6E15-C914-4FCA-B8E4-FF5C7437C2E0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -62,6 +62,10 @@ Global
 		{DA2CA3BD-1CAC-470C-9FA2-611A5768A76A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DA2CA3BD-1CAC-470C-9FA2-611A5768A76A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DA2CA3BD-1CAC-470C-9FA2-611A5768A76A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/solution/NPOI.Core.Test.sln
+++ b/solution/NPOI.Core.Test.sln
@@ -26,7 +26,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.c
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NPOI.Benchmarks", "..\benchmarks\NPOI.Benchmarks\NPOI.Benchmarks.csproj", "{3DA1149D-46F8-4181-9976-E002BF2BFB76}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NPOI.Pack", "NPOI.Pack.csproj", "{6D7A6E15-C914-4FCA-B8E4-FF5C7437C2E0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPOI.Pack", "NPOI.Pack.csproj", "{6D7A6E15-C914-4FCA-B8E4-FF5C7437C2E0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -62,10 +62,6 @@ Global
 		{DA2CA3BD-1CAC-470C-9FA2-611A5768A76A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DA2CA3BD-1CAC-470C-9FA2-611A5768A76A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DA2CA3BD-1CAC-470C-9FA2-611A5768A76A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{94B18BCF-84E8-401F-BAAB-0496AA136628}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3DA1149D-46F8-4181-9976-E002BF2BFB76}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/testcases/main/SS/Formula/Eval/TestMultiplyEval.cs
+++ b/testcases/main/SS/Formula/Eval/TestMultiplyEval.cs
@@ -1,0 +1,55 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for Additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+namespace TestCases.SS.Formula.Eval
+{
+
+    using NUnit.Framework;
+    using NPOI.SS.Formula.Eval;
+    using TestCases.SS.Formula.Functions;
+
+    /**
+     *  Test for multiply operator Evaluator.
+     *  
+     *  
+     */
+    [TestFixture]
+    public class TestMultiplyEval
+    {
+
+        private static void Confirm(ValueEval arg0, ValueEval arg1, double expectedResult)
+        {
+            ValueEval[] args = {
+			    arg0, arg1,
+		    };
+
+            double result = NumericFunctionInvoker.Invoke(EvalInstances.Multiply, args, 0, 0);
+
+            Assert.AreEqual(expectedResult, result, 0);
+        }
+        [Test]
+        public void TestBasic()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
+
+            // issue #1055, use decimal to handle precision issue like (20000 * 0.000027 = 0.539999 in double)
+            Confirm(new NumberEval(20000), new NumberEval(0.000027), 0.54);            
+        }
+        
+    }
+
+}

--- a/testcases/main/SS/Formula/PTG/TestExternalNameReference.cs
+++ b/testcases/main/SS/Formula/PTG/TestExternalNameReference.cs
@@ -120,7 +120,8 @@ namespace TestCases.SS.Formula.PTG
             Evaluator.EvaluateFormulaCell(ccell);
             Evaluator.EvaluateFormulaCell(tccell);
             Assert.AreEqual(NEW_PART_COST, uccell.NumericCellValue);
-            Assert.AreEqual(NEW_PART_COST * NEW_QUANT, ccell.NumericCellValue);
+            double ctotal = decimal.ToDouble((decimal)NEW_PART_COST * (decimal)NEW_QUANT);
+            Assert.AreEqual(ctotal, ccell.NumericCellValue);
             Assert.AreEqual(NEW_PART_COST * NEW_QUANT * MARKUP_COST_2, tccell.NumericCellValue);
         }
     }


### PR DESCRIPTION
this closes #1055 

1. use decimal to replace double on precision issue
2. add a unit test file to track the issue 
![image](https://github.com/nissl-lab/npoi/assets/11364500/28dc433b-fcfd-4b90-8af7-525be65fcaab)
