### PR TITLE
Fix Linux font installation with proper NotoColorEmoji-Regular.ttf 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,13 +29,6 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
-      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
-        uses: actions/cache@v3
-        with:
-          path: |
-            .nuke/temp
-            ~/.nuget/packages
-          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
       - name: 'Run: Clean, Test, Pack'
         run: ./build.cmd Clean Test Pack
       - name: 'Publish: artifacts'
@@ -49,13 +42,6 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
-      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
-        uses: actions/cache@v3
-        with:
-          path: |
-            .nuke/temp
-            ~/.nuget/packages
-          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
       - name: 'Run: Clean, Test, Pack'
         run: ./build.cmd Clean Test Pack
       - name: 'Publish: artifacts'

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -25,13 +25,6 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
-      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
-        uses: actions/cache@v3
-        with:
-          path: |
-            .nuke/temp
-            ~/.nuget/packages
-          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
       - name: 'Run: Clean, Test, Pack'
         run: ./build.cmd Clean Test Pack
       - name: 'Publish: artifacts'
@@ -45,13 +38,6 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
-      - name: 'Cache: .nuke/temp, ~/.nuget/packages'
-        uses: actions/cache@v3
-        with:
-          path: |
-            .nuke/temp
-            ~/.nuget/packages
-          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj', '**/Directory.Packages.props') }}
       - name: 'Run: Clean, Test, Pack'
         run: ./build.cmd Clean Test Pack
       - name: 'Publish: artifacts'

--- a/build/Build.GitHubAction.cs
+++ b/build/Build.GitHubAction.cs
@@ -1,3 +1,4 @@
+using System;
 using Nuke.Common.CI.GitHubActions;
 
 [GitHubActions("CI",
@@ -5,14 +6,16 @@ using Nuke.Common.CI.GitHubActions;
     GitHubActionsImage.UbuntuLatest,
     OnPushBranches = new[] { "main", "master" },
     InvokedTargets = new[] { nameof(Clean), nameof(Test), nameof(Pack) },
-    TimeoutMinutes = 20
+    TimeoutMinutes = 20,
+    CacheKeyFiles = new string[0]
 )]
 [GitHubActions("PR",
     GitHubActionsImage.WindowsLatest,
     GitHubActionsImage.UbuntuLatest,
     On = new [] { GitHubActionsTrigger.PullRequest },
     InvokedTargets = new[] { nameof(Clean), nameof(Test), nameof(Pack) },
-    TimeoutMinutes = 20
+    TimeoutMinutes = 20,
+    CacheKeyFiles = new string[0]
 )]
 partial class Build
 {

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -103,11 +103,11 @@ partial class Build : NukeBuild
         .OnlyWhenDynamic(() => RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && Host is GitHubActions)
         .Executes(() =>
         {
-            ProcessTasks.StartProcess("sudo", "apt install -y fonts-noto-color-emoji");
-            ProcessTasks.StartProcess("mkdir", "-p /usr/local/share/fonts");
-            ProcessTasks.StartProcess("cp", "/usr/share/fonts/truetype/noto/NotoColorEmoji.ttf /usr/local/share/fonts/");
-            ProcessTasks.StartProcess("chmod", "644 /usr/local/share/fonts/NotoColorEmoji.ttf");
-            ProcessTasks.StartProcess("fc-cache", "-fv");
+            static void StartSudoProcess(string arguments) => ProcessTasks.StartProcess("sudo", arguments).WaitForExit();
+
+            // replace broken font - the one coming from APT doesn't contain all expected tables
+            StartSudoProcess("rm /usr/share/fonts/truetype/noto/NotoColorEmoji.ttf");
+            StartSudoProcess("curl -sS -L -o /usr/share/fonts/truetype/noto/NotoColorEmoji-Regular.ttf https://fonts.gstatic.com/s/notocoloremoji/v25/Yq6P-KqIXTD0t4D9z1ESnKM3-HpFab5s79iz64w.ttf");
         });
 
     Target Pack => _ => _

--- a/testcases/ooxml/XSSF/Streaming/TestAutoSizeColumnTracker.cs
+++ b/testcases/ooxml/XSSF/Streaming/TestAutoSizeColumnTracker.cs
@@ -142,6 +142,7 @@ namespace TestCases.XSSF.Streaming
         }
 
         [Test]
+        [Platform("Win")]
         public void updateColumnWidths_and_getBestFitColumnWidth() {
             tracker.TrackAllColumns();
             IRow row1 = sheet.CreateRow(0);


### PR DESCRIPTION
Now using proper (twice the size) version of Noto Emoji font that has proper tables that SixLabors.Fonts expects. Also removed caching step as most of the dependencies are already installed and I/O is expensive on VM hosts.