### PR TITLE
Update SearchFind.cs to not throw an unhandled exception 

### DIFF
--- a/main/SS/Formula/Functions/Text/SearchFind.cs
+++ b/main/SS/Formula/Functions/Text/SearchFind.cs
@@ -47,6 +47,11 @@ namespace NPOI.SS.Formula.Functions
         }
         private ValueEval Eval(String haystack, String needle, int startIndex)
         {
+            if (startIndex >= haystack.Length)
+            {
+                return ErrorEval.VALUE_INVALID;
+            }
+            
             int result;
             if (_isCaseSensitive)
             {


### PR DESCRIPTION
Update SearchFind.cs to not throw an unhandled exception when startIndex is >= to length of string to search in