### PR TITLE
Fix warnings on comparing value types to null

### DIFF
--- a/main/SS/Formula/Functions/EDate.cs
+++ b/main/SS/Formula/Functions/EDate.cs
@@ -59,11 +59,16 @@ namespace NPOI.SS.Formula.Functions
                 int offsetInMonthAsNumber = (int)GetValue(args[1]);
 
                 // resolve the arguments
-                DateTime startDate = DateUtil.GetJavaDate(startDateAsNumber);
-                if (startDate == null)
+                DateTime startDate;
+                try
+                {
+                    startDate = DateUtil.GetJavaDate(startDateAsNumber);
+                }
+                catch (ArgumentException)
                 {
                     return ErrorEval.VALUE_INVALID;
                 }
+
                 DateTime resultDate = startDate.AddMonths(offsetInMonthAsNumber);
                 result = DateUtil.GetExcelDate(resultDate);
                     

--- a/main/Util/StringUtil.cs
+++ b/main/Util/StringUtil.cs
@@ -510,8 +510,8 @@ namespace NPOI.Util
             {
 
                 int msCodepoint = char.ConvertToUtf32(string1, offset);//codePointAt(stringChars, offset, string1.Length);
-                int uniCodepoint = msCodepointToUnicode[(msCodepoint)];
-                sb.Append(Char.ConvertFromUtf32(uniCodepoint == null ? msCodepoint : uniCodepoint));
+
+                sb.Append(Char.ConvertFromUtf32(msCodepointToUnicode.TryGetValue(msCodepoint, out var uniCodepoint) ? uniCodepoint : msCodepoint));
                 offset += CharCount(msCodepoint);
             }
 

--- a/openxml4Net/OPC/Internal/PackagePropertiesPart.cs
+++ b/openxml4Net/OPC/Internal/PackagePropertiesPart.cs
@@ -309,7 +309,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal
          * @return A string representation of the modified date.
          */
         public String GetModifiedPropertyString() {
-            if (modified.Value == null)
+            if (modified == null)
                 return GetDateValue(new Nullable<DateTime>(new DateTime()));
             else
                 return GetDateValue(modified);
@@ -570,10 +570,12 @@ namespace NPOI.OpenXml4Net.OPC.Internal
                 {
                     SimpleDateFormat df = new SimpleDateFormat(fStr);
                     df.TimeZone = TimeZoneInfo.Utc;
-                    DateTime d = df.Parse(dateTzStr);
-                    if (d != null)
+                    try
                     {
-                        return new DateTime?(d);
+                        return df.Parse(dateTzStr);
+                    }
+                    catch (FormatException)
+                    {
                     }
                 }
             }
@@ -582,10 +584,12 @@ namespace NPOI.OpenXml4Net.OPC.Internal
             {
                 SimpleDateFormat df = new SimpleDateFormat(fStr);
                 df.TimeZone = TimeZoneInfo.Utc;
-                DateTime d = df.Parse(dateTzStr).ToUniversalTime();
-                if (d != null)
+                try
                 {
-                    return new DateTime?(d);
+                    return df.Parse(dateTzStr).ToUniversalTime();
+                }
+                catch (FormatException)
+                {
                 }
             }
             //if you're here, no pattern matched, throw exception


### PR DESCRIPTION
RT

looks like incorrect porting from Java to C# / from Hashtable to Dictionary.