### PR TITLE
Adding unit tests: TestRemoveSheetMethod and TestRemoveSheetAtMethod

### DIFF
--- a/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
@@ -1196,5 +1196,56 @@ namespace TestCases.XSSF.UserModel
             wb.Close();
         }
 
+        [Test]
+        public void TestRemoveSheetMethod()
+        {
+            byte[] contents;
+            {
+                XSSFWorkbook wb = new XSSFWorkbook();
+                var sheet1 = wb.CreateSheet("Sheet1");
+                var sheet2 = wb.CreateSheet("Sheet2");
+                Assert.True(wb.Remove(sheet2));
+                Assert.AreEqual(1, wb.NumberOfSheets);
+                Assert.AreEqual("Sheet1", wb.GetSheetName(0));
+                Assert.AreEqual(sheet1, wb.GetSheet("Sheet1"));
+                var stream = new MemoryStream();
+                wb.Write(stream);
+                contents = stream.ToArray();
+                wb.Close();
+            }
+
+            {
+                XSSFWorkbook wb = new XSSFWorkbook(new MemoryStream(contents, false));
+                Assert.AreEqual(1, wb.NumberOfSheets);
+                Assert.AreEqual("Sheet1", wb.GetSheetName(0));
+                wb.Close();
+            }
+        }
+
+        [Test]
+        public void TestRemoveSheetAtMethod()
+        {
+            byte[] contents;
+            {
+                XSSFWorkbook wb = new XSSFWorkbook();
+                var sheet1 = wb.CreateSheet("Sheet1");
+                var sheet2 = wb.CreateSheet("Sheet2");
+                wb.RemoveSheetAt(1);
+                Assert.AreEqual(1, wb.NumberOfSheets);
+                Assert.AreEqual("Sheet1", wb.GetSheetName(0));
+                Assert.AreEqual(sheet1, wb.GetSheet("Sheet1"));
+                var stream = new MemoryStream();
+                wb.Write(stream);
+                contents = stream.ToArray();
+                wb.Close();
+            }
+
+            {
+                XSSFWorkbook wb = new XSSFWorkbook(new MemoryStream(contents, false));
+                Assert.AreEqual(1, wb.NumberOfSheets);
+                Assert.AreEqual("Sheet1", wb.GetSheetName(0));
+                wb.Close();
+            }
+        }
     }
 }


### PR DESCRIPTION
#1146

```
 TestRemoveSheetMethod
   Source: TestXSSFWorkbook.cs line 1200
   Duration: 98 ms

  Message: 
  Expected: 1
  But was:  2


  Stack Trace: 
TestXSSFWorkbook.TestRemoveSheetMethod() line 1219
1)    場所 TestCases.XSSF.UserModel.TestXSSFWorkbook.TestRemoveSheetMethod() 場所 V:\npoi\testcases\ooxml\XSSF\UserModel\TestXSSFWorkbook.cs:行 1219
```

`XSSFWorkbook.RemoveSheetAt` method works well already.
`XSSFWorkbook.Remove` method has issue.