### PR TITLE
Remove reflections in `POIFS.Crypt`

### DIFF
--- a/main/POIFS/Crypt/EncryptionInfo.cs
+++ b/main/POIFS/Crypt/EncryptionInfo.cs
@@ -22,7 +22,8 @@ using NPOI.Util;
 namespace NPOI.POIFS.Crypt
 {
     using System;
-    using System.Reflection;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Net.Security;
 
     public class EncryptionInfo
     {
@@ -292,23 +293,49 @@ namespace NPOI.POIFS.Crypt
             _encryptor = eib.GetEncryptor();
         }
 
+        // REMOVE-REFLECTION: Remove reflections here will prevent NPOI from creating custom encryptors.
+        // Is it OK? Remove reflection-related code for now.
+        // It might be better to move Agile classes definition into this library. Now it's defined in NPOI.OOXML.Core.
         protected static IEncryptionInfoBuilder GetBuilder(EncryptionMode encryptionMode)
         {
-            Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            Type t = null;
-            foreach (Assembly assembly in assemblies)
+            switch (encryptionMode.Builder)
             {
-                t = assembly.GetType(encryptionMode.Builder);
-                if (t != null)
+                case EncryptionMode.BuilderNameBinaryRC4:
+                    return new BinaryRC4.BinaryRC4EncryptionInfoBuilder();
+                case EncryptionMode.BuilderNameCryptoAPI:
+                    return new CryptoAPI.CryptoAPIEncryptionInfoBuilder();
+                case EncryptionMode.BuilderNameStandard:
+                    return new Standard.StandardEncryptionInfoBuilder();
+                case EncryptionMode.BuilderNameAgile:
+                    // return new Agile.AgileEncryptionInfoBuilder();
+                    // TODO
+                    IEncryptionInfoBuilder instance = CreateAgileInstanceFallback();
+                    if (instance is not null)
+                        return instance;
                     break;
             }
-            if (t == null)
+
+            throw new EncryptedDocumentException("Not found type " + encryptionMode.Builder);
+        }
+
+        private static Type AgileEncrpytionInfo;
+
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Agile must be dynamically loaded from NPOI.OOXML. TODO.")]
+#endif
+        private static IEncryptionInfoBuilder CreateAgileInstanceFallback()
+        {
+            if (AgileEncrpytionInfo is null)
             {
-                throw new EncryptedDocumentException("Not found type " + encryptionMode.Builder);
+                foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+                    if ((AgileEncrpytionInfo = assembly.GetType(EncryptionMode.BuilderNameAgile)) != null)
+                        break;
             }
-            IEncryptionInfoBuilder eib = null;
-            eib = (IEncryptionInfoBuilder)t.Assembly.CreateInstance(encryptionMode.Builder);
-            return eib;
+
+            if (AgileEncrpytionInfo is null)
+                return null;
+
+            return (IEncryptionInfoBuilder)Activator.CreateInstance(AgileEncrpytionInfo);
         }
 
         private int _versionMajor;

--- a/main/POIFS/Crypt/EncryptionMode.cs
+++ b/main/POIFS/Crypt/EncryptionMode.cs
@@ -27,14 +27,19 @@ namespace NPOI.POIFS.Crypt
      */
     public class EncryptionMode
     {
+        public const string BuilderNameBinaryRC4 = "NPOI.POIFS.Crypt.BinaryRC4.BinaryRC4EncryptionInfoBuilder";
+        public const string BuilderNameCryptoAPI = "NPOI.POIFS.Crypt.CryptoAPI.CryptoAPIEncryptionInfoBuilder";
+        public const string BuilderNameStandard = "NPOI.POIFS.Crypt.Standard.StandardEncryptionInfoBuilder";
+        public const string BuilderNameAgile = "NPOI.POIFS.Crypt.Agile.AgileEncryptionInfoBuilder";
+
         /* @see <a href="http://msdn.microsoft.com/en-us/library/dd907466(v=office.12).aspx">2.3.6 Office Binary Document RC4 Encryption</a> */
-        public static readonly EncryptionMode BinaryRC4 = new EncryptionMode("NPOI.POIFS.Crypt.BinaryRC4.BinaryRC4EncryptionInfoBuilder", 1, 1, 0x0);
+        public static readonly EncryptionMode BinaryRC4 = new EncryptionMode(BuilderNameBinaryRC4, 1, 1, 0x0);
         /* @see <a href="http://msdn.microsoft.com/en-us/library/dd905225(v=office.12).aspx">2.3.5 Office Binary Document RC4 CryptoAPI Encryption</a> */
-        public static readonly EncryptionMode CryptoAPI = new EncryptionMode("NPOI.POIFS.Crypt.CryptoAPI.CryptoAPIEncryptionInfoBuilder", 4, 2, 0x04);
+        public static readonly EncryptionMode CryptoAPI = new EncryptionMode(BuilderNameCryptoAPI, 4, 2, 0x04);
         /* @see <a href="http://msdn.microsoft.com/en-us/library/dd906097(v=office.12).aspx">2.3.4.5 \EncryptionInfo Stream (Standard Encryption)</a> */
-        public static readonly EncryptionMode Standard = new EncryptionMode("NPOI.POIFS.Crypt.Standard.StandardEncryptionInfoBuilder", 4, 2, 0x24);
+        public static readonly EncryptionMode Standard = new EncryptionMode(BuilderNameStandard, 4, 2, 0x24);
         /* @see <a href="http://msdn.microsoft.com/en-us/library/dd925810(v=office.12).aspx">2.3.4.10 \EncryptionInfo Stream (Agile Encryption)</a> */
-        public static readonly EncryptionMode Agile = new EncryptionMode("NPOI.POIFS.Crypt.Agile.AgileEncryptionInfoBuilder", 4, 4, 0x40);
+        public static readonly EncryptionMode Agile = new EncryptionMode(BuilderNameAgile, 4, 4, 0x40);
 
 
         public string Builder { get; private set; }


### PR DESCRIPTION
TODO: The encrpytion `Agile` is defined in `NPOI.OOXML` and dynamically loaded from `NPOI`. This might not be done under AOT. Consider moving the class into `NPOI`.