### PR TITLE
Remove reflections in unused (or not working) classes

### DIFF
--- a/main/HSSF/UserModel/OperationEvaluatorFactory.cs
+++ b/main/HSSF/UserModel/OperationEvaluatorFactory.cs
@@ -21,9 +21,10 @@ namespace NPOI.HSSF.UserModel
     using NPOI.SS.Formula.Eval;
 
     using System.Collections;
-    using System.Reflection;
     using NPOI.SS.Formula.PTG;
 
+
+    // REMOVE-REFLECTION: This class won't work as intended, and not used elsewhere in NPOI. Obsolete and remove.
 
     /**
      * This class Creates <c>OperationEval</c> instances to help evaluate <c>OperationPtg</c>
@@ -85,44 +86,39 @@ namespace NPOI.HSSF.UserModel
                 throw new Exception("Eval class must not be abstract");
             }
 
-            ConstructorInfo constructor;
+            /*ConstructorInfo constructor;
             constructor = evalClass.GetConstructor(OPERATION_CONSTRUCTOR_CLASS_ARRAY);
             if (!constructor.IsPublic)
             {
                 throw new Exception("Eval constructor must be public");
             }
-            m[ptgClass] = constructor;
+            m[ptgClass] = constructor;*/
         }
 
         /**
          * returns the OperationEval concrete impl instance corresponding
          * to the supplied operationPtg
          */
+        [Obsolete]
         public static OperationEval Create(OperationPtg ptg)
         {
+            throw new NotSupportedException();
+
             if (ptg == null)
             {
                 throw new ArgumentException("ptg must not be null");
             }
 
-            Type ptgClass = ptg.GetType();
+            // (original comment)
+            // ExpPtg Is used for array formulas and shared formulas.
+            // it Is currently Unsupported, and may not even Get implemented here
 
-            ConstructorInfo constructor = (ConstructorInfo)_constructorsByPtgClass[ptgClass];
-            if (constructor == null)
-            {
-                if (ptgClass == typeof(ExpPtg))
-                {
-                    // ExpPtg Is used for array formulas and shared formulas.
-                    // it Is currently Unsupported, and may not even Get implemented here
-                    throw new Exception("ExpPtg currently not supported");
-                }
-                throw new Exception("Unexpected operation ptg class (" + ptgClass.Name + ")");
-            }
+            /*Type ptgClass = ptg.GetType();
 
             Object result;
             Object[] initargs = { ptg };
             result = constructor.Invoke(initargs);
-            return (OperationEval)result;
+            return (OperationEval)result;*/
         }
     }
 }

--- a/main/POIFS/NIO/FileBackedDataSource.cs
+++ b/main/POIFS/NIO/FileBackedDataSource.cs
@@ -20,7 +20,6 @@ using System;
 using NPOI.Util;
 using System.Collections.Generic;
 using System.Security;
-using System.Reflection;
 //using System.IO.MemoryMappedFiles;
 namespace NPOI.POIFS.NIO
 {
@@ -209,38 +208,7 @@ namespace NPOI.POIFS.NIO
         // but we at least have unit-tests which will indicate this when run on Windows
         private static void unmap(ByteBuffer bb)
         {
-            //TODO: try add clean method for ByteBuffer class.
-            //Type fcClass = bb.GetType();
-            //try
-            //{
-            //    // invoke bb.cleaner().clean(), but do not depend on sun.nio
-            //    // interfaces
-            //    MethodInfo cleanerMethod = fcClass.GetMethod("cleaner");
-            //    //cleanerMethod.setAccessible(true);
-            //    Object cleaner = cleanerMethod.Invoke(bb, null);
-            //    MethodInfo cleanMethod = cleaner.GetType().GetMethod("clean");
-            //    cleanMethod.Invoke(cleaner, null);
-            //}
-            //catch (NotSupportedException e)
-            //{
-            //    // e.printStackTrace();
-            //}
-            //catch (SecurityException e)
-            //{
-            //    // e.printStackTrace();
-            //}
-            //catch (MethodAccessException e)
-            //{
-            //    // e.printStackTrace();
-            //}
-            //catch (ArgumentException e)
-            //{
-            //    // e.printStackTrace();
-            //}
-            //catch (TargetException e)
-            //{
-            //    // e.printStackTrace();
-            //}
+            // REMOVE-REFLECTION: This method is Java-specific.
         }
     }
 

--- a/main/SS/Formula/Eval/Forked/ForkedEvaluator.cs
+++ b/main/SS/Formula/Eval/Forked/ForkedEvaluator.cs
@@ -16,7 +16,6 @@
 ==================================================================== */
 
 using System;
-using System.Reflection;
 using NPOI.HSSF.UserModel;
 using NPOI.SS.Formula;
 using NPOI.SS.Formula.Eval;
@@ -36,6 +35,9 @@ namespace NPOI.SS.Formula.Eval.Forked
      *
      * @author Josh Micich
      */
+
+    // REMOVE-REFLECTION: This class doesn't work from the beginning because of typo.
+    // And no elsewhere in NPOI uses this class. Consider removing it.
     public class ForkedEvaluator
     {
 
@@ -58,10 +60,15 @@ namespace NPOI.SS.Formula.Eval.Forked
                 try
                 {
                     // TODO: check if this is Java 9 compatible ...
-                    Type evalWB = Type.GetType("NPOI.XSSF.UserModel.XSSFEvaluationWorkbook");
-                    Type xssfWB = Type.GetType("NPOI.XSSF.UserMode.XSSFWorkbook");
-                    MethodInfo createM = evalWB.GetMethod("create", new Type[] { xssfWB });
-                    return (IEvaluationWorkbook)createM.Invoke(null, new object[] { wb });
+                    /*Type evalWB = Type.GetType("NPOI.XSSF.UserModel.XSSFEvaluationWorkbook");
+                    Type xssfWB = Type.GetType("NPOI.XSSF.UserMode.XSSFWorkbook");*/
+
+                    // REMOVE-REFLECTION: The code is Java-specific and different from the current NPOI object model
+
+                    /*var createM = evalWB.GetMethod("create", new Type[] { xssfWB });
+                    return (IEvaluationWorkbook)createM.Invoke(null, new object[] { wb });*/
+
+                    throw new NotSupportedException();
                 }
                 catch (Exception e)
                 {

--- a/openxml4Net/Util/ZipSecureFile.cs
+++ b/openxml4Net/Util/ZipSecureFile.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 
 namespace NPOI.OpenXml4Net.Util
@@ -110,6 +109,9 @@ namespace NPOI.OpenXml4Net.Util
 
         public static ThresholdInputStream AddThreshold(Stream zipIS)
         {
+            // REMOVE-REFLCETION: Meaningless reflection is used here as the type FilterInputStream doesn't have a field named "in".
+            // And obviously this stub does nothing.
+            // There needs to be another way of handling ZIP bombs.
 
             ThresholdInputStream newInner = null;
             if (zipIS is InflaterInputStream)
@@ -117,11 +119,7 @@ namespace NPOI.OpenXml4Net.Util
                 //replace inner stream of zipIS by using a ThresholdInputStream instance??
                 try
                 {
-                    FieldInfo f = typeof(FilterInputStream).GetField("in");
-                    //f.SetAccessible(true);
-                    //InputStream oldInner = (InputStream)f.Get(zipIS);
-                    //newInner = new ThresholdInputStream(oldInner, null);
-                    //f.Set(zipIS, newInner);
+                    // REMOVE-REFLECTION: Java-specific code
                 } catch (Exception ex) {
                     //logger.Log(POILogger.WARN, "SecurityManager doesn't allow manipulation via reflection for zipbomb detection - continue with original input stream", ex);
                     newInner = null;


### PR DESCRIPTION
These 4 classes use reflection codes but don't work due to various reasons (such as wrong porting from Java to NET).
Besides they are not used elsewhere in NPOI.