### PR TITLE
Remove reflections in POI Logger

### DIFF
--- a/main/Util/CustomPOILoggerFactory.cs
+++ b/main/Util/CustomPOILoggerFactory.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NPOI.Util
+{
+    /// <summary>
+    /// Helper class to circumvent Type.GetType & Activator.CreateInstance under AOT
+    /// </summary>
+    public abstract class CustomPOILoggerFactory
+    {
+        public abstract POILogger Create(string name);
+    }
+}

--- a/main/Util/POILogFactory.cs
+++ b/main/Util/POILogFactory.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Configuration;
 
 namespace NPOI.Util
@@ -50,6 +51,14 @@ namespace NPOI.Util
          *  first time we need it
          */
         private static String _loggerClassName = null;
+
+        private static readonly string BuiltInNameNullLogger = typeof(NullLogger).Name;
+        private static readonly string BuiltInNameSystemOutLogger = typeof(SystemOutLogger).Name;
+
+        private static readonly string BuiltInFullNameNullLogger = typeof(NullLogger).FullName;
+        private static readonly string BuiltInFullNameSystemOutLogger = typeof(SystemOutLogger).FullName;
+
+        public static List<CustomPOILoggerFactory> CustomFactories { get; } = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="POILogFactory"/> class.
@@ -108,8 +117,15 @@ namespace NPOI.Util
             } else {
                 try {
                     //logger=assembly.CreateInstance(_loggerClassName) as POILogger;
-                    Type loggerClass = Type.GetType(_loggerClassName);
-                    logger =  Activator.CreateInstance(loggerClass) as POILogger;
+
+                    // REMOVE-REFLECTION: I doubt if the following line would work,
+                    // because _loggerClassName is Name of the type but Type.GetType requires FullName.
+                    // It all ends up using the null logger.
+
+                    //Type loggerClass = Type.GetType(_loggerClassName);
+                    // logger =  Activator.CreateInstance(loggerClass) as POILogger;
+
+                    logger = CreateLoggerByTypeName(_loggerClassName);
                     logger.Initialize(cat);
                 } catch(Exception) {
                   // Give up and use the null logger
@@ -120,6 +136,23 @@ namespace NPOI.Util
                 _loggers[cat] = logger;
             }
             return logger;
+        }
+
+        private static POILogger CreateLoggerByTypeName(string typeName)
+        {
+            if (typeName == BuiltInNameNullLogger || typeName == BuiltInFullNameNullLogger)
+                return _nullLogger;
+
+            if (typeName == BuiltInNameSystemOutLogger || typeName == BuiltInFullNameSystemOutLogger)
+                return new SystemOutLogger();
+
+            foreach (var it in CustomFactories)
+            {
+                var logger = it.Create(typeName);
+                if (logger is not null) return logger;
+            }
+
+            return _nullLogger;
         }
     }
 }


### PR DESCRIPTION
The original impl doesn't look quite right. For example, `Type.GetType` requires `FullName` but fed with `Name`. Nevertheless, a custom factory class is now required to eliminate reflections.

This will be a breaking change if the user uses custom logger.