### PR TITLE
Fix XSSFSheet.RemoveHyperlink method.

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -1436,24 +1436,27 @@ namespace NPOI.XSSF.UserModel
             }
 
             // Now re-generate our CT_Hyperlinks, if needed
-            if (worksheet.hyperlinks == null)
+            if (hyperlinks.Count > 0)
             {
-                worksheet.AddNewHyperlinks();
-            }
+                if (worksheet.hyperlinks == null)
+                {
+                    worksheet.AddNewHyperlinks();
+                }
 
-            CT_Hyperlink[] ctHls
-                = new CT_Hyperlink[hyperlinks.Count];
-            for (int i = 0; i < ctHls.Length; i++)
-            {
-                // If our sheet has hyperlinks, have them add
-                //  any relationships that they might need
-                XSSFHyperlink hyperlink = hyperlinks[i];
-                hyperlink.GenerateRelationIfNeeded(GetPackagePart());
-                // Now grab their underling object
-                ctHls[i] = hyperlink.GetCTHyperlink();
-            }
+                CT_Hyperlink[] ctHls
+                    = new CT_Hyperlink[hyperlinks.Count];
+                for (int i = 0; i < ctHls.Length; i++)
+                {
+                    // If our sheet has hyperlinks, have them add
+                    //  any relationships that they might need
+                    XSSFHyperlink hyperlink = hyperlinks[i];
+                    hyperlink.GenerateRelationIfNeeded(GetPackagePart());
+                    // Now grab their underling object
+                    ctHls[i] = hyperlink.GetCTHyperlink();
+                }
 
-            worksheet.hyperlinks.SetHyperlinkArray(ctHls);
+                worksheet.hyperlinks.SetHyperlinkArray(ctHls);
+            }
 
             foreach (XSSFRow row in _rows.Values)
             {
@@ -3011,6 +3014,7 @@ namespace NPOI.XSSF.UserModel
                 XSSFHyperlink hyperlink = hyperlinks[index];
                 if (hyperlink.CellRef.Equals(ref1))
                 {
+                    worksheet.hyperlinks.hyperlink.Remove(hyperlink.GetCTHyperlink());
                     hyperlinks.RemoveAt(index);
                     return;
                 }

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -3014,7 +3014,14 @@ namespace NPOI.XSSF.UserModel
                 XSSFHyperlink hyperlink = hyperlinks[index];
                 if (hyperlink.CellRef.Equals(ref1))
                 {
-                    worksheet.hyperlinks.hyperlink.Remove(hyperlink.GetCTHyperlink());
+                    if (worksheet != null
+                        && worksheet.hyperlinks != null
+                        && worksheet.hyperlinks.hyperlink != null
+                        && worksheet.hyperlinks.hyperlink.Contains(hyperlink.GetCTHyperlink()))
+                    {
+                        worksheet.hyperlinks.hyperlink.Remove(hyperlink.GetCTHyperlink());
+                    }
+
                     hyperlinks.RemoveAt(index);
                     return;
                 }

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFBugs.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFBugs.cs
@@ -3391,34 +3391,44 @@ namespace TestCases.XSSF.UserModel
             {
                 XSSFSheet sheet = workbook.CreateSheet() as XSSFSheet;
                 XSSFCreationHelper creationHelper = workbook.GetCreationHelper() as XSSFCreationHelper;
-                XSSFHyperlink hyperlink;
 
-                hyperlink = creationHelper.CreateHyperlink(HyperlinkType.Url) as XSSFHyperlink;
-                sheet.AddHyperlink(hyperlink);
+                XSSFHyperlink hyperlink1 = creationHelper.CreateHyperlink(HyperlinkType.Url) as XSSFHyperlink;
+                sheet.AddHyperlink(hyperlink1);
+                string address1 = "http://myurl1";
+                hyperlink1.Address = address1;
+                hyperlink1.SetCellReference("A1");
 
-                string address = "http://myurl";
-                hyperlink.Address = address;
-                hyperlink.SetCellReference("A1");
+                XSSFHyperlink hyperlink2 = creationHelper.CreateHyperlink(HyperlinkType.Url) as XSSFHyperlink;
+                sheet.AddHyperlink(hyperlink2);
+                string address2 = "http://myurl2";
+                hyperlink2.Address = address2;
+                hyperlink2.SetCellReference("B2");
 
-                var cellAddress = new CellAddress("A1");
+                XSSFHyperlink hyperlink3 = creationHelper.CreateHyperlink(HyperlinkType.Url) as XSSFHyperlink;
+                sheet.AddHyperlink(hyperlink3);
+                string address3 = "http://myurl3";
+                hyperlink3.Address = address3;
+                hyperlink3.SetCellReference("C3");
 
-                var comment = sheet.GetHyperlink(cellAddress);
+                var cellAddressToRemoveHL = new CellAddress("B2");
+
+                var comment = sheet.GetHyperlink(cellAddressToRemoveHL);
                 Assert.IsNotNull(comment);
-                Assert.IsTrue(comment.Address.Equals(address));
+                Assert.IsTrue(comment.Address.Equals(address2));
 
                 using (var wbCopy = XSSFTestDataSamples.WriteOutAndReadBack(workbook))
                 {
                     sheet = wbCopy.GetSheetAt(0) as XSSFSheet;
-                    var comment2 = sheet.GetHyperlink(cellAddress);
+                    var comment2 = sheet.GetHyperlink(cellAddressToRemoveHL);
                     Assert.IsNotNull(comment2);
-                    Assert.IsTrue(comment2.Address.Equals(address));
+                    Assert.IsTrue(comment2.Address.Equals(address2));
 
-                    sheet.RemoveHyperlink(cellAddress.Row, cellAddress.Column);
+                    sheet.RemoveHyperlink(cellAddressToRemoveHL.Row, cellAddressToRemoveHL.Column);
 
                     using (var wbCopy2 = XSSFTestDataSamples.WriteOutAndReadBack(wbCopy))
                     {
                         sheet = wbCopy2.GetSheetAt(0) as XSSFSheet;
-                        var comment3 = sheet.GetHyperlink(cellAddress);
+                        var comment3 = sheet.GetHyperlink(cellAddressToRemoveHL);
                         Assert.IsNull(comment3);
                     }
                 }


### PR DESCRIPTION
The method wasn't removing the hyperlinks from CT_Hyperlinks array, only from a list in the hyperlinks property. Now it removes the hyperlink in both places.

Related to #1128

Updated the test for #690 to make sure the correct link is removed by the method.