### PR TITLE
Improve package publish logic

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,7 @@ on:
     branches:
       - main
       - master
+      - 'release*'
 
 jobs:
   windows-latest:
@@ -31,11 +32,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: 'Run: Clean, Test, Pack'
         run: ./build.cmd Clean Test Pack
-      - name: 'Publish: artifacts'
+      - name: 'Publish: publish'
         uses: actions/upload-artifact@v3
         with:
-          name: artifacts
-          path: artifacts
+          name: publish
+          path: publish
   ubuntu-latest:
     name: ubuntu-latest
     runs-on: ubuntu-latest
@@ -44,8 +45,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: 'Run: Clean, Test, Pack'
         run: ./build.cmd Clean Test Pack
-      - name: 'Publish: artifacts'
+      - name: 'Publish: publish'
         uses: actions/upload-artifact@v3
         with:
-          name: artifacts
-          path: artifacts
+          name: publish
+          path: publish

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -27,11 +27,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: 'Run: Clean, Test, Pack'
         run: ./build.cmd Clean Test Pack
-      - name: 'Publish: artifacts'
+      - name: 'Publish: publish'
         uses: actions/upload-artifact@v3
         with:
-          name: artifacts
-          path: artifacts
+          name: publish
+          path: publish
   ubuntu-latest:
     name: ubuntu-latest
     runs-on: ubuntu-latest
@@ -40,8 +40,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: 'Run: Clean, Test, Pack'
         run: ./build.cmd Clean Test Pack
-      - name: 'Publish: artifacts'
+      - name: 'Publish: publish'
         uses: actions/upload-artifact@v3
         with:
-          name: artifacts
-          path: artifacts
+          name: publish
+          path: publish

--- a/build/Build.GitHubAction.cs
+++ b/build/Build.GitHubAction.cs
@@ -1,10 +1,9 @@
-using System;
 using Nuke.Common.CI.GitHubActions;
 
 [GitHubActions("CI",
     GitHubActionsImage.WindowsLatest,
     GitHubActionsImage.UbuntuLatest,
-    OnPushBranches = new[] { "main", "master" },
+    OnPushBranches = new[] { "main", "master", "release*" },
     InvokedTargets = new[] { nameof(Clean), nameof(Test), nameof(Pack) },
     TimeoutMinutes = 20,
     CacheKeyFiles = new string[0]

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,11 +1,15 @@
+using System;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Nuke.Common;
 using Nuke.Common.CI.GitHubActions;
+using Nuke.Common.Git;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
 using Nuke.Common.Utilities.Collections;
+
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
 partial class Build : NukeBuild
@@ -22,10 +26,26 @@ partial class Build : NukeBuild
     readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
 
     [Solution] Solution Solution;
+    [GitRepository] readonly GitRepository GitRepository;
 
     static AbsolutePath SourceDirectory => RootDirectory / "src";
 
-    static AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
+    static AbsolutePath ArtifactsDirectory => RootDirectory / "publish";
+
+    string TagVersion => GitRepository.Tags.SingleOrDefault(x => x.StartsWith("v"))?[1..];
+
+    string BranchVersion => GitRepository.Branch?.StartsWith("release") == true
+        ? GitRepository.Branch[7..]
+        : null;
+
+    // either from tag or branch
+    string PublishVersion => TagVersion ?? BranchVersion;
+
+    bool IsPublishBuild => !string.IsNullOrWhiteSpace(PublishVersion);
+
+    string VersionSuffix;
+
+    static bool IsRunningOnWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
     [Secret]
     [Parameter("GitHub API token")]
@@ -33,9 +53,20 @@ partial class Build : NukeBuild
 
     protected override void OnBuildInitialized()
     {
+        VersionSuffix = !IsPublishBuild
+            ? $"preview-{DateTime.UtcNow:yyyyMMdd-HHmm}"
+            : "";
+
+        if (IsLocalBuild)
+        {
+            VersionSuffix = $"dev-{DateTime.UtcNow:yyyyMMdd-HHmm}";
+        }
+
         Serilog.Log.Information("BUILD SETUP");
         Serilog.Log.Information("\tSolution: {Solution}", Solution);
         Serilog.Log.Information("\tConfiguration: {Configuration}", Configuration);
+        Serilog.Log.Information("\tVersion suffix: {VersionSuffix}", VersionSuffix);
+        Serilog.Log.Information("\tPublish version: {PublishVersion}", PublishVersion);
 
         Serilog.Log.Information("Build environment:");
         Serilog.Log.Information("\tHost: {Host}", Host.GetType());
@@ -120,16 +151,31 @@ partial class Build : NukeBuild
 
             var packTarget = Solution.GetProject("NPOI.Pack");
 
-            DotNetPack(_ =>_
-                .SetConfiguration(Configuration)
-                .SetOutputDirectory(ArtifactsDirectory)
-                .SetDeterministic(IsServerBuild)
-                .SetContinuousIntegrationBuild(IsServerBuild)
-                // obsolete missing XML documentation comment, XML comment on not valid language element, XML comment has badly formed XML, no matching tag in XML comment
-                // need to use escaped separator in order for this to work
-                .AddProperty("NoWarn", string.Join("%3B", new [] { 169, 612, 618, 1591, 1587, 1570, 1572, 1573, 1574 }))
-                .SetProperty("EnablePackageValidation", "false")
-                .SetProject(packTarget)
-            );
+            DotNetPack(_ =>
+            {
+                var packSettings = _
+                    .SetProject(packTarget)
+                    .SetConfiguration(Configuration)
+                    .SetOutputDirectory(ArtifactsDirectory)
+                    .SetDeterministic(IsServerBuild)
+                    .SetContinuousIntegrationBuild(IsServerBuild)
+                    // obsolete missing XML documentation comment, XML comment on not valid language element, XML comment has badly formed XML, no matching tag in XML comment
+                    // need to use escaped separator in order for this to work
+                    .AddProperty("NoWarn", string.Join("%3B", new[] { 169, 612, 618, 1591, 1587, 1570, 1572, 1573, 1574 }))
+                    .SetProperty("EnablePackageValidation", "false");
+
+                if (IsPublishBuild)
+                {
+                    // force version from tag/branch
+                    packSettings = packSettings
+                        .SetAssemblyVersion(PublishVersion)
+                        .SetFileVersion(PublishVersion)
+                        .SetInformationalVersion(PublishVersion)
+                        .SetVersionSuffix(VersionSuffix)
+                        .SetVersionPrefix(PublishVersion);
+                }
+
+                return packSettings;
+            });
         });
 }


### PR DESCRIPTION
* include `release*` branches
* read version from branch name if starts with `release`
* change output from artifacts to publish (artifacts will be used by NET 8 for binaries)

As i used `release1.5.1` (an imaginary version) as my branch name, you can see that the build on my fork determined this to be publish build and forced all version information from the branch name, output from ubuntu-latest run:

```
06:13:26 [INF] BUILD SETUP
06:13:26 [INF] 	Solution: /home/runner/work/npoi/npoi/solution/NPOI.Core.Test.sln
06:13:26 [INF] 	Configuration: Release
06:13:26 [INF] 	Version suffix: 
06:13:26 [INF] 	Publish version: 1.5.1
06:13:26 [INF] Build environment:
06:13:26 [INF] 	Host: Nuke.Common.CI.GitHubActions.GitHubActions
```` 

The summary has the Artifacts at the bottom https://github.com/lahma/npoi/actions/runs/5983250670 which opens a zip file containing a NuGet package versioned as 1.5.1 and passes all NuGet checks:

![image](https://github.com/nissl-lab/npoi/assets/171892/384406ef-9987-4008-a7cb-19342b91a0ad)

So with these changes you should be able to get NuGet release branch from any release branch automatically as long as branch name starts with `release`.