### PR TITLE
Fix DefaultColumnWidth

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet.cs
@@ -2469,10 +2469,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         private double dyDescentField;
         public CT_SheetFormatPr()
         {
-            this.baseColWidth = 8;
+            this.defaultColWidth = 8;
         }
         [XmlAttribute]
-        [DefaultValue(typeof(uint), "8")]
         public uint baseColWidth
         {
             get
@@ -2486,6 +2485,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
 
         [XmlAttribute]
+        [DefaultValue(typeof(uint), "8")]
         public double defaultColWidth
         {
             get
@@ -2599,8 +2599,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             if (node == null)
                 return null;
             CT_SheetFormatPr ctObj = new CT_SheetFormatPr();
-            ctObj.baseColWidth = XmlHelper.ReadUInt(node.Attributes["baseColWidth"],8);
-            ctObj.defaultColWidth = XmlHelper.ReadDouble(node.Attributes["defaultColWidth"]);
+            ctObj.baseColWidth = XmlHelper.ReadUInt(node.Attributes["baseColWidth"]);
+            ctObj.defaultColWidth = XmlHelper.ReadDouble(node.Attributes["defaultColWidth"], 8);
             ctObj.defaultRowHeight = XmlHelper.ReadDouble(node.Attributes["defaultRowHeight"]);
             ctObj.customHeight = XmlHelper.ReadBool(node.Attributes["customHeight"]);
             ctObj.zeroHeight = XmlHelper.ReadBool(node.Attributes["zeroHeight"]);

--- a/OpenXmlFormats/Spreadsheet/Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet.cs
@@ -2600,7 +2600,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 return null;
             CT_SheetFormatPr ctObj = new CT_SheetFormatPr();
             ctObj.baseColWidth = XmlHelper.ReadUInt(node.Attributes["baseColWidth"]);
-            ctObj.defaultColWidth = XmlHelper.ReadDouble(node.Attributes["defaultColWidth"], 8.43);
+            ctObj.defaultColWidth = XmlHelper.ReadDouble(node.Attributes["defaultColWidth"]);
             ctObj.defaultRowHeight = XmlHelper.ReadDouble(node.Attributes["defaultRowHeight"]);
             ctObj.customHeight = XmlHelper.ReadBool(node.Attributes["customHeight"]);
             ctObj.zeroHeight = XmlHelper.ReadBool(node.Attributes["zeroHeight"]);

--- a/OpenXmlFormats/Spreadsheet/Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet.cs
@@ -2469,7 +2469,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         private double dyDescentField;
         public CT_SheetFormatPr()
         {
-            this.defaultColWidth = 8;
+            this.defaultColWidth = 8.43;
         }
         [XmlAttribute]
         public uint baseColWidth
@@ -2485,7 +2485,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
 
         [XmlAttribute]
-        [DefaultValue(typeof(uint), "8")]
+        [DefaultValue(typeof(double), "8.43")]
         public double defaultColWidth
         {
             get
@@ -2600,7 +2600,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 return null;
             CT_SheetFormatPr ctObj = new CT_SheetFormatPr();
             ctObj.baseColWidth = XmlHelper.ReadUInt(node.Attributes["baseColWidth"]);
-            ctObj.defaultColWidth = XmlHelper.ReadDouble(node.Attributes["defaultColWidth"], 8);
+            ctObj.defaultColWidth = XmlHelper.ReadDouble(node.Attributes["defaultColWidth"], 8.43);
             ctObj.defaultRowHeight = XmlHelper.ReadDouble(node.Attributes["defaultRowHeight"]);
             ctObj.customHeight = XmlHelper.ReadBool(node.Attributes["customHeight"]);
             ctObj.zeroHeight = XmlHelper.ReadBool(node.Attributes["zeroHeight"]);

--- a/main/HSSF/Model/InternalSheet.cs
+++ b/main/HSSF/Model/InternalSheet.cs
@@ -1220,7 +1220,7 @@ namespace NPOI.HSSF.Model
          * @return default column width
          */
 
-        public int DefaultColumnWidth
+        public double DefaultColumnWidth
         {
             get { return defaultcolwidth.ColWidth; }
             set { defaultcolwidth.ColWidth = (short)value; }
@@ -1292,7 +1292,7 @@ namespace NPOI.HSSF.Model
          * @param column - the column number
          * @param width (in Units of 1/256th of a Char width)
          */
-        public void SetColumnWidth(int column, int width)
+        public void SetColumnWidth(int column, double width)
         {
             if (width > 255 * 256) 
                    throw new ArgumentException("The maximum column width for an individual cell is 255 characters.");
@@ -1332,12 +1332,12 @@ namespace NPOI.HSSF.Model
             SetColumn(column, (short)styleIndex, null, null, null, null);
         }
 
-        public void SetColumn(int column, int width, int level, bool hidden, bool collapsed)
+        public void SetColumn(int column, double width, int level, bool hidden, bool collapsed)
         {
             _columnInfos.SetColumn(column, 0, width, level, hidden, collapsed);
         }
 
-        public void SetColumn(int column, short? xfStyle, int? width, int? level, bool? hidden, bool? collapsed)
+        public void SetColumn(int column, short? xfStyle, double? width, int? level, bool? hidden, bool? collapsed)
         {
             _columnInfos.SetColumn(column, xfStyle, width, level, hidden, collapsed);
         }

--- a/main/HSSF/Record/Aggregates/ColumnInfoRecordsAggregate.cs
+++ b/main/HSSF/Record/Aggregates/ColumnInfoRecordsAggregate.cs
@@ -409,7 +409,7 @@ namespace NPOI.HSSF.Record.Aggregates
         /**
          * Sets all non null fields into the <c>ci</c> parameter.
          */
-        private static void SetColumnInfoFields(ColumnInfoRecord ci, short? xfStyle, int? width,
+        private static void SetColumnInfoFields(ColumnInfoRecord ci, short? xfStyle, double? width,
                     int? level, Boolean? hidden, Boolean? collapsed)
         {
             if (xfStyle != null)
@@ -517,7 +517,7 @@ namespace NPOI.HSSF.Record.Aggregates
         /// <param name="level">The level.</param>
         /// <param name="hidden">The hidden.</param>
         /// <param name="collapsed">The collapsed.</param>
-        public void SetColumn(int targetColumnIx, short? xfIndex, int? width, int? level, bool? hidden, bool? collapsed)
+        public void SetColumn(int targetColumnIx, short? xfIndex, double? width, int? level, bool? hidden, bool? collapsed)
         {
             ColumnInfoRecord ci = null;
             int k = 0;

--- a/main/HSSF/UserModel/HSSFSheet.cs
+++ b/main/HSSF/UserModel/HSSFSheet.cs
@@ -574,7 +574,7 @@ namespace NPOI.HSSF.UserModel
         /// </summary>
         /// <param name="column">the column to Set (0-based)</param>
         /// <param name="width">the width in Units of 1/256th of a Char width</param>
-        public void SetColumnWidth(int column, int width)
+        public void SetColumnWidth(int column, double width)
         {
             _sheet.SetColumnWidth(column, width);
         }
@@ -584,16 +584,16 @@ namespace NPOI.HSSF.UserModel
         /// </summary>
         /// <param name="column">the column to Set (0-based)</param>
         /// <returns>the width in Units of 1/256th of a Char width</returns>
-        public int GetColumnWidth(int column)
+        public double GetColumnWidth(int column)
         {
             return _sheet.GetColumnWidth(column);
         }
 
-        public float GetColumnWidthInPixels(int column)
+        public double GetColumnWidthInPixels(int column)
         {
-            int cw = GetColumnWidth(column);
-            int def = DefaultColumnWidth * 256;
-            float px = (cw == def ? PX_DEFAULT : PX_MODIFIED);
+            double cw = GetColumnWidth(column);
+            double def = DefaultColumnWidth * 256;
+            double px = (cw == def ? PX_DEFAULT : PX_MODIFIED);
 
             return cw / px;
         }
@@ -602,7 +602,7 @@ namespace NPOI.HSSF.UserModel
         /// Gets or sets the default width of the column.
         /// </summary>
         /// <value>The default width of the column.</value>
-        public int DefaultColumnWidth
+        public double DefaultColumnWidth
         {
             get { return _sheet.DefaultColumnWidth; }
             set { _sheet.DefaultColumnWidth = value; }

--- a/main/SS/UserModel/Sheet.cs
+++ b/main/SS/UserModel/Sheet.cs
@@ -170,14 +170,14 @@ namespace NPOI.SS.UserModel
         /// This value represents the number of characters that can be displayed
         /// in a cell that is formatted with the standard font.
         /// </remarks>
-        void SetColumnWidth(int columnIndex, int width);
+        void SetColumnWidth(int columnIndex, double width);
 
         /// <summary>
         /// get the width (in units of 1/256th of a character width )
         /// </summary>
         /// <param name="columnIndex">the column to get (0-based)</param>
         /// <returns>the width in units of 1/256th of a character width</returns>
-        int GetColumnWidth(int columnIndex);
+        double GetColumnWidth(int columnIndex);
 
         /// <summary>
         /// get the width in pixel
@@ -189,14 +189,14 @@ namespace NPOI.SS.UserModel
         /// with the default font size (Arial 10pt for .xls and Calibri 11pt for .xlsx).
         /// If the default font is changed the column width can be streched
         /// </remarks>
-        float GetColumnWidthInPixels(int columnIndex);
+        double GetColumnWidthInPixels(int columnIndex);
 
         /// <summary>
         /// Get the default column width for the sheet (if the columns do not define their own width)
         /// in characters
         /// </summary>
         /// <value>default column width measured in characters.</value>
-        int DefaultColumnWidth { get; set; }
+        double DefaultColumnWidth { get; set; }
 
         /// <summary>
         /// Get the default row height for the sheet (if the rows do not define their own height) in

--- a/ooxml/SS/Converter/ExcelToHtmlConverter.cs
+++ b/ooxml/SS/Converter/ExcelToHtmlConverter.cs
@@ -42,7 +42,7 @@ namespace NPOI.SS.Converter
             cssClassTable = htmlDocumentFacade.GetOrCreateCssClass("table", "t",
                     "border-collapse:collapse;border-spacing:0;");
         }
-        protected static int GetColumnWidth(ISheet sheet, int columnIndex)
+        protected static double GetColumnWidth(ISheet sheet, int columnIndex)
         {
             return ExcelToHtmlUtils.GetColumnWidthInPx(sheet.GetColumnWidth(columnIndex));
         }
@@ -295,7 +295,7 @@ namespace NPOI.SS.Converter
 
                 ICell cell = (ICell)row.GetCell(colIx);
 
-                int divWidthPx = 0;
+                double divWidthPx = 0;
                 if (UseDivsToSpan)
                 {
                     divWidthPx = GetColumnWidth(sheet, colIx);
@@ -481,7 +481,7 @@ namespace NPOI.SS.Converter
         }
 
         protected bool ProcessCell(ICell cell, XmlElement tableCellElement,
-                int normalWidthPx, int maxSpannedWidthPx, float normalHeightPt)
+                double normalWidthPx, double maxSpannedWidthPx, float normalHeightPt)
         {
             ICellStyle cellStyle = cell.CellStyle as ICellStyle;
 

--- a/ooxml/SS/Converter/ExcelToHtmlUtils.cs
+++ b/ooxml/SS/Converter/ExcelToHtmlUtils.cs
@@ -218,12 +218,12 @@ namespace NPOI.SS.Converter
      * "http://apache-poi.1045710.n5.nabble.com/Excel-Column-Width-Unit-Converter-pixels-excel-column-width-units-td2301481.html"
      * >here</a> for Xio explanation and details
      */
-        public static int GetColumnWidthInPx(int widthUnits)
+        public static double GetColumnWidthInPx(double widthUnits)
         {
-            int pixels = (widthUnits / EXCEL_COLUMN_WIDTH_FACTOR)
+            double pixels = (widthUnits / EXCEL_COLUMN_WIDTH_FACTOR)
                     * UNIT_OFFSET_LENGTH;
 
-            int offsetWidthUnits = widthUnits % EXCEL_COLUMN_WIDTH_FACTOR;
+            double offsetWidthUnits = widthUnits % EXCEL_COLUMN_WIDTH_FACTOR;
             pixels += (int)Math.Round(offsetWidthUnits / ((float)EXCEL_COLUMN_WIDTH_FACTOR / UNIT_OFFSET_LENGTH));
 
             return pixels;

--- a/ooxml/XSSF/Streaming/SXSSFSheet.cs
+++ b/ooxml/XSSF/Streaming/SXSSFSheet.cs
@@ -84,7 +84,7 @@ namespace NPOI.XSSF.Streaming
             //set { _sh.ColumnBreaks = value; }
         }
 
-        public int DefaultColumnWidth
+        public double DefaultColumnWidth
         {
             get
             {
@@ -768,12 +768,12 @@ namespace NPOI.XSSF.Streaming
             return _sh.GetColumnStyle(column);
         }
 
-        public int GetColumnWidth(int columnIndex)
+        public double GetColumnWidth(int columnIndex)
         {
             return _sh.GetColumnWidth(columnIndex);
         }
 
-        public float GetColumnWidthInPixels(int columnIndex)
+        public double GetColumnWidthInPixels(int columnIndex)
         {
             return _sh.GetColumnWidthInPixels(columnIndex);
         }
@@ -1048,7 +1048,7 @@ namespace NPOI.XSSF.Streaming
             _sh.SetColumnHidden(columnIndex, hidden);
         }
 
-        public void SetColumnWidth(int columnIndex, int width)
+        public void SetColumnWidth(int columnIndex, double width)
         {
             _sh.SetColumnWidth(columnIndex, width);
         }

--- a/ooxml/XSSF/UserModel/XSSFDialogsheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFDialogsheet.cs
@@ -171,17 +171,17 @@ namespace NPOI.XSSF.UserModel
             throw new System.NotImplementedException();
         }
 
-        void ISheet.SetColumnWidth(int columnIndex, int width)
+        void ISheet.SetColumnWidth(int columnIndex, double width)
         {
             throw new System.NotImplementedException();
         }
 
-        int ISheet.GetColumnWidth(int columnIndex)
+        double ISheet.GetColumnWidth(int columnIndex)
         {
             throw new System.NotImplementedException();
         }
 
-        int ISheet.DefaultColumnWidth
+        double ISheet.DefaultColumnWidth
         {
             get
             {

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -145,21 +145,19 @@ namespace NPOI.XSSF.UserModel
 
         /// <summary>
         /// Get the default column width for the sheet (if the columns do not 
-        /// define their own width) in characters. Note, this value is different 
-        /// from <see cref="GetColumnWidth"/>. The latter is always greater and 
-        /// includes 4 pixels of margin pAdding(two on each side), plus 1 pixel 
-        /// pAdding for the gridlines.
+        /// define their own width) in characters.
         /// </summary>
-        public int DefaultColumnWidth
+        public double DefaultColumnWidth
         {
             get
             {
                 CT_SheetFormatPr pr = worksheet.sheetFormatPr;
-                return pr == null ? 8 : (int)pr.baseColWidth;
+                return pr == null ? 8 : pr.defaultColWidth;
             }
             set
             {
-                GetSheetTypeSheetFormatPr().baseColWidth = (uint)value;
+                var pr = GetSheetTypeSheetFormatPr();
+                pr.defaultColWidth = value;
             }
         }
 
@@ -1649,7 +1647,7 @@ namespace NPOI.XSSF.UserModel
                     width = maxColumnWidth;
                 }
 
-                SetColumnWidth(column, (int)width);
+                SetColumnWidth(column, width);
                 columnHelper.SetColBestFit(column, true);
             }
         }
@@ -2025,22 +2023,16 @@ namespace NPOI.XSSF.UserModel
 
         /// <summary>
         /// Get the actual column width (in units of 1/256th of a character width)
-        /// Note, the returned  value is always gerater that <see cref="DefaultColumnWidth"/> 
-        /// because the latter does not include margins. Actual column width 
-        /// measured as the number of characters of the maximum digit width of 
-        /// thenumbers 0, 1, 2, ..., 9 as rendered in the normal style's font. 
-        /// There are 4 pixels of margin pAdding(two on each side), plus 1 pixel 
-        /// pAdding for the gridlines.
         /// </summary>
         /// <param name="columnIndex">the column to set (0-based)</param>
         /// <returns>the width in units of 1/256th of a character width</returns>
-        public int GetColumnWidth(int columnIndex)
+        public double GetColumnWidth(int columnIndex)
         {
             CT_Col col = columnHelper.GetColumn(columnIndex, false);
             double width = (col == null || !col.IsSetWidth())
                 ? DefaultColumnWidth
                 : col.width;
-            return (int)(width * 256);
+            return width * 256;
         }
 
         /// <summary>
@@ -2050,10 +2042,10 @@ namespace NPOI.XSSF.UserModel
         /// </summary>
         /// <param name="columnIndex"></param>
         /// <returns></returns>
-        public float GetColumnWidthInPixels(int columnIndex)
+        public double GetColumnWidthInPixels(int columnIndex)
         {
-            float widthIn256 = GetColumnWidth(columnIndex);
-            return (float)(widthIn256 / 256.0 * XSSFWorkbook.DEFAULT_CHARACTER_WIDTH);
+            double widthIn256 = GetColumnWidth(columnIndex);
+            return widthIn256 / 256.0 * XSSFWorkbook.DEFAULT_CHARACTER_WIDTH;
         }
 
         /// <summary>
@@ -2611,7 +2603,7 @@ namespace NPOI.XSSF.UserModel
         /// width</param>
         /// <exception cref="ArgumentException">if width more than 255*256 (the
         /// maximum column width in Excel is 255 characters)</exception>
-        public void SetColumnWidth(int columnIndex, int width)
+        public void SetColumnWidth(int columnIndex, double width)
         {
             if (width > 255 * 256)
             {
@@ -2619,7 +2611,7 @@ namespace NPOI.XSSF.UserModel
                     "individual cell is 255 characters.");
             }
 
-            columnHelper.SetColWidth(columnIndex, (double)width / 256);
+            columnHelper.SetColWidth(columnIndex, width / 256);
             columnHelper.SetCustomWidth(columnIndex, true);
         }
 

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -2043,7 +2043,7 @@ namespace NPOI.XSSF.UserModel
                     if (pr.defaultColWidth != 0.0)
                         width = pr.defaultColWidth;
                     else if (pr.baseColWidth != 0)
-                        width = pr.baseColWidth;
+                        width = pr.baseColWidth + 5; 
                 }
 
                 if (width == 0)

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -5971,7 +5971,8 @@ namespace NPOI.XSSF.UserModel
             else
             {
                 var width = worksheet.sheetFormatPr.defaultColWidth;                        //string length with padding
-                width_px = width * MaximumDigitWidth;
+                double widthInPx = width * MaximumDigitWidth;
+                width_px = widthInPx + (8 - widthInPx % 8); // round up to the nearest multiple of 8 pixels
             }
 
             return width_px;

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -2032,7 +2032,7 @@ namespace NPOI.XSSF.UserModel
             double width = (col == null || !col.IsSetWidth())
                 ? DefaultColumnWidth
                 : col.width;
-            return width * 256;
+            return Math.Round(width * 256, 2);
         }
 
         /// <summary>

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -152,7 +152,7 @@ namespace NPOI.XSSF.UserModel
             get
             {
                 CT_SheetFormatPr pr = worksheet.sheetFormatPr;
-                return pr == null ? 8 : pr.defaultColWidth;
+                return pr == null ? 8.43 : pr.defaultColWidth;
             }
             set
             {
@@ -5960,12 +5960,7 @@ namespace NPOI.XSSF.UserModel
             double fontwidth;
             double width_px;
 
-            var width = worksheet.sheetFormatPr.defaultColWidth;                        //string length with padding
-            if (width != 0.0)
-            {
-                width_px = width * MaximumDigitWidth;
-            }
-            else
+            if (worksheet.sheetFormatPr.baseColWidth != 0.0)
             {
                 double MDW = MaximumDigitWidth;
                 var length = worksheet.sheetFormatPr.baseColWidth;                      //string length with out padding
@@ -5973,6 +5968,12 @@ namespace NPOI.XSSF.UserModel
                 double tmp = 256 * fontwidth + Math.Truncate(128 / MDW);
                 width_px = Math.Truncate((tmp / 256) * MDW) + 3;                        // +3 ???
             }
+            else
+            {
+                var width = worksheet.sheetFormatPr.defaultColWidth;                        //string length with padding
+                width_px = width * MaximumDigitWidth;
+            }
+
             return width_px;
         }
 

--- a/openxml4Net/Util/XmlHelper.cs
+++ b/openxml4Net/Util/XmlHelper.cs
@@ -170,14 +170,14 @@ namespace NPOI.OpenXml4Net.Util
         {
             return ReadBool(attr, false);
         }
-        public static double ReadDouble(XmlAttribute attr)
+        public static double ReadDouble(XmlAttribute attr, uint defaultValue)
         {
             if (attr == null)
-                return 0.0;
+                return defaultValue;
             string s = attr.Value;
             if (s == "")
             {
-                return 0.0;
+                return defaultValue;
             }
             else
             {
@@ -188,10 +188,16 @@ namespace NPOI.OpenXml4Net.Util
                 }
                 else
                 {
-                    return 0.0;
+                    return defaultValue;
                 }
             }
         }
+
+        public static double ReadDouble(XmlAttribute attr)
+        {
+            return ReadDouble(attr, 0);
+        } 
+
         public static double? ReadDoubleNull(XmlAttribute attr)
         {
             if (attr == null)

--- a/openxml4Net/Util/XmlHelper.cs
+++ b/openxml4Net/Util/XmlHelper.cs
@@ -170,14 +170,14 @@ namespace NPOI.OpenXml4Net.Util
         {
             return ReadBool(attr, false);
         }
-        public static double ReadDouble(XmlAttribute attr, double defaultValue)
+        public static double ReadDouble(XmlAttribute attr)
         {
             if (attr == null)
-                return defaultValue;
+                return 0.0;
             string s = attr.Value;
             if (s == "")
             {
-                return defaultValue;
+                return 0.0;
             }
             else
             {
@@ -188,15 +188,10 @@ namespace NPOI.OpenXml4Net.Util
                 }
                 else
                 {
-                    return defaultValue;
+                    return 0.0;
                 }
             }
         }
-
-        public static double ReadDouble(XmlAttribute attr)
-        {
-            return ReadDouble(attr, 0);
-        } 
 
         public static double? ReadDoubleNull(XmlAttribute attr)
         {

--- a/openxml4Net/Util/XmlHelper.cs
+++ b/openxml4Net/Util/XmlHelper.cs
@@ -170,7 +170,7 @@ namespace NPOI.OpenXml4Net.Util
         {
             return ReadBool(attr, false);
         }
-        public static double ReadDouble(XmlAttribute attr, uint defaultValue)
+        public static double ReadDouble(XmlAttribute attr, double defaultValue)
         {
             if (attr == null)
                 return defaultValue;

--- a/testcases/main/HSSF/UserModel/TestHSSFSheet.cs
+++ b/testcases/main/HSSF/UserModel/TestHSSFSheet.cs
@@ -936,17 +936,17 @@ namespace TestCases.HSSF.UserModel
             for (char i = 'A'; i <= 'S'; i++)
             {
                 int idx = i - 'A';
-                int w = sh.GetColumnWidth(idx);
+                double w = sh.GetColumnWidth(idx);
                 Assert.AreEqual(ref1[idx], w);
             }
 
             //the second sheet doesn't have overridden column widths
             sh = wb1.GetSheetAt(1);
-            int def_width = sh.DefaultColumnWidth;
+            double def_width = sh.DefaultColumnWidth;
             for (char i = 'A'; i <= 'S'; i++)
             {
                 int idx = i - 'A';
-                int w = sh.GetColumnWidth(idx);
+                double w = sh.GetColumnWidth(idx);
                 //getDefaultColumnWidth returns width measured in characters
                 //getColumnWidth returns width measured in 1/256th units
                 Assert.AreEqual(def_width * 256, w);
@@ -1008,9 +1008,9 @@ namespace TestCases.HSSF.UserModel
             // second and third sheets miss DefaultColWidthRecord
             for (int i = 1; i <= 2; i++)
             {
-                int dw = wb2.GetSheetAt(i).DefaultColumnWidth;
+                double dw = wb2.GetSheetAt(i).DefaultColumnWidth;
                 Assert.AreEqual(8, dw);
-                int cw = wb2.GetSheetAt(i).GetColumnWidth(0);
+                double cw = wb2.GetSheetAt(i).GetColumnWidth(0);
                 Assert.AreEqual(8 * 256, cw);
 
                 Assert.AreEqual(0xFF, sheet.DefaultRowHeight);

--- a/testcases/main/SS/UserModel/BaseTestBugzillaIssues.cs
+++ b/testcases/main/SS/UserModel/BaseTestBugzillaIssues.cs
@@ -1409,9 +1409,9 @@ namespace TestCases.SS.UserModel
             _testDataProvider.TrackAllColumnsForAutosizing(s);
 
             s.AutoSizeColumn(0);
-            Assert.AreEqual(2048, s.GetColumnWidth(0));
+            Assert.AreEqual(2158.08, s.GetColumnWidth(0));
             s.AutoSizeColumn(0, true);
-            Assert.AreEqual(2048, s.GetColumnWidth(0));
+            Assert.AreEqual(2158.08, s.GetColumnWidth(0));
             wb.Close();
         }
 

--- a/testcases/main/SS/UserModel/BaseTestBugzillaIssues.cs
+++ b/testcases/main/SS/UserModel/BaseTestBugzillaIssues.cs
@@ -434,9 +434,9 @@ namespace TestCases.SS.UserModel
             sheet.AutoSizeColumn(1);
             sheet.AutoSizeColumn(2);
 
-            int noWhitespaceColWidth = sheet.GetColumnWidth(0);
-            int leadingWhitespaceColWidth = sheet.GetColumnWidth(1);
-            int trailingWhitespaceColWidth = sheet.GetColumnWidth(2);
+            double noWhitespaceColWidth = sheet.GetColumnWidth(0);
+            double leadingWhitespaceColWidth = sheet.GetColumnWidth(1);
+            double trailingWhitespaceColWidth = sheet.GetColumnWidth(2);
 
             // Based on the amount of text and whitespace used, and the default font
             // assume that the cell with whitespace should be at least 20% wider than

--- a/testcases/main/SS/UserModel/BaseTestSheetAutosizeColumn.cs
+++ b/testcases/main/SS/UserModel/BaseTestSheetAutosizeColumn.cs
@@ -249,8 +249,8 @@ namespace TestCases.SS.UserModel
 
             for (int i = 0; i < 2; i++) sheet.AutoSizeColumn(i);
 
-            int w0 = sheet.GetColumnWidth(0);
-            int w1 = sheet.GetColumnWidth(1);
+            double w0 = sheet.GetColumnWidth(0);
+            double w1 = sheet.GetColumnWidth(1);
 
             Assert.IsTrue(w0 * 5 < w1); // rotated text occupies at least five times less horizontal space than normal text
 
@@ -270,7 +270,7 @@ namespace TestCases.SS.UserModel
             ICell cell0 = row.CreateCell(0);
             cell0.SetCellValue("Apache Software Foundation");
 
-            int defaulWidth = sheet.GetColumnWidth(0);
+            double defaulWidth = sheet.GetColumnWidth(0);
             sheet.AutoSizeColumn(0);
             // column is unChanged if merged regions are ignored (Excel like behavior)
             Assert.AreEqual(defaulWidth, sheet.GetColumnWidth(0));

--- a/testcases/ooxml/XSSF/Streaming/TestSXSSFSheetAutoSizeColumn.cs
+++ b/testcases/ooxml/XSSF/Streaming/TestSXSSFSheetAutoSizeColumn.cs
@@ -400,7 +400,7 @@ namespace TestCases.XSSF.Streaming
             return firstCell;
         }
 
-        private static void assertColumnWidthStrictlyWithinRange(int actualColumnWidth, int lowerBoundExclusive, int upperBoundExclusive)
+        private static void assertColumnWidthStrictlyWithinRange(double actualColumnWidth, int lowerBoundExclusive, int upperBoundExclusive)
         {
             Assert.IsTrue(actualColumnWidth > lowerBoundExclusive,
                 "Expected a column width greater than " + lowerBoundExclusive + " but found " + actualColumnWidth);

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
@@ -2133,7 +2133,7 @@ namespace TestCases.XSSF.UserModel
                 var cell = row.CreateCell(0);
 
                 Assert.AreEqual(sheet.GetColumnWidth(0) / 256, sheet.DefaultColumnWidth);
-                Assert.AreEqual(sheet.DefaultColumnWidth, 8);
+                Assert.AreEqual(sheet.DefaultColumnWidth, 8.43);
 
                 sheet.DefaultColumnWidth = 50.1;
                 Assert.AreEqual(sheet.GetColumnWidth(0) / 256, sheet.DefaultColumnWidth);

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
@@ -31,6 +31,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using TestCases.HSSF;
@@ -2089,9 +2090,11 @@ namespace TestCases.XSSF.UserModel
             List<XSSFShape> shapes = drawing.GetShapes();
             XSSFClientAnchor anchor;
 
-            foreach(var shape in shapes) {
+            foreach (var shape in shapes)
+            {
                 XSSFClientAnchor sa = (XSSFClientAnchor)shape.anchor;
-                switch(shape.Name) {
+                switch (shape.Name)
+                {
                     case "cxn1":
                         anchor = sheet.CreateClientAnchor(Units.ToEMU(50), Units.ToEMU(75), Units.ToEMU(125), Units.ToEMU(150));
                         break;
@@ -2109,13 +2112,35 @@ namespace TestCases.XSSF.UserModel
                         return;
                 }
                 Assert.IsTrue(sa.From.col == anchor.From.col,       /**/"From.col   [{0}]({1}={2})", new object[] { shape.Name, sa.From.col, anchor.From.col });
-                Assert.IsTrue(sa.From.colOff== anchor.From.colOff,  /**/"From.colOff[{0}]({1}={2})", new object[] { shape.Name, sa.From.colOff, anchor.From.colOff });
+                Assert.IsTrue(sa.From.colOff == anchor.From.colOff,  /**/"From.colOff[{0}]({1}={2})", new object[] { shape.Name, sa.From.colOff, anchor.From.colOff });
                 Assert.IsTrue(sa.From.row == anchor.From.row,       /**/"From.row   [{0}]({1}={2})", new object[] { shape.Name, sa.From.row, anchor.From.row });
                 Assert.IsTrue(sa.From.rowOff == anchor.From.rowOff, /**/"From.rowOff[{0}]({1}={2})", new object[] { shape.Name, sa.From.rowOff, anchor.From.rowOff });
                 Assert.IsTrue(sa.To.col == anchor.To.col,           /**/"To.col     [{0}]({1}={2})", new object[] { shape.Name, sa.To.col, anchor.To.col });
                 Assert.IsTrue(sa.To.colOff == anchor.To.colOff,     /**/"To.colOff  [{0}]({1}={2})", new object[] { shape.Name, sa.To.colOff, anchor.To.colOff });
                 Assert.IsTrue(sa.To.row == anchor.To.row,           /**/"To.row     [{0}]({1}={2})", new object[] { shape.Name, sa.To.row, anchor.To.row });
-                Assert.IsTrue(sa.To.rowOff ==  anchor.To.rowOff,    /**/"To.rowOff  [{0}]({1}={2})", new object[] { shape.Name, sa.To.rowOff, anchor.To.rowOff });
+                Assert.IsTrue(sa.To.rowOff == anchor.To.rowOff,    /**/"To.rowOff  [{0}]({1}={2})", new object[] { shape.Name, sa.To.rowOff, anchor.To.rowOff });
+            }
+        }
+
+        [Test]
+        public void TestDefaultColumnWidth()
+        {
+            using (var book = new XSSFWorkbook())
+            {
+                var sheet = book.CreateSheet("Sheet1");
+                var row = sheet.CreateRow(1);
+
+                var cell = row.CreateCell(0);
+
+                Assert.AreEqual(sheet.GetColumnWidth(0) / 256, sheet.DefaultColumnWidth);
+                Assert.AreEqual(sheet.DefaultColumnWidth, 8);
+
+                sheet.DefaultColumnWidth = 50.1;
+                Assert.AreEqual(sheet.GetColumnWidth(0) / 256, sheet.DefaultColumnWidth);
+
+                sheet.SetColumnWidth(0, 100);
+                Assert.AreEqual(sheet.GetColumnWidth(0), 100);
+                Assert.AreNotEqual(sheet.GetColumnWidth(0) / 256, sheet.DefaultColumnWidth);
             }
         }
     }

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
@@ -573,7 +573,7 @@ namespace TestCases.XSSF.UserModel
             workbook.GetSheetAt(1).SetColumnGroupCollapsed(4, false);
 
             Assert.AreEqual("hello world", workbook.GetSheetAt(0).GetRow(0).GetCell(0).StringCellValue);
-            Assert.AreEqual(2048, workbook.GetSheetAt(0).GetColumnWidth(0)); // <-works
+            Assert.AreEqual(2158.08, workbook.GetSheetAt(0).GetColumnWidth(0)); // <-works
         }
 
         [Test]


### PR DESCRIPTION
This PR fixes DefaultColumnWidth type and implementation. Due to POI bug it returned baseColumnWidth, which is integer. This is a breaking change.

Fixes #943