### PR TITLE
Update transitive reference to Cryptography.Pkcs library

### DIFF
--- a/ooxml/NPOI.OOXML.Core.csproj
+++ b/ooxml/NPOI.OOXML.Core.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a fix to update the transitive reference of `System.Security.Cryptography.Pkcs` to `6.0.3` to mitigate [CVE-2023-29331](https://github.com/dotnet/announcements/issues/257). By default, the version pulled in is `6.0.1` which contains this vulnerability and causes Aqua Trivy to scan the `*.deps.json` and raise this error.