### PR TITLE
XSSFColumn class implementation

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Col.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Col.cs
@@ -37,8 +37,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         private byte outlineLevelField;
 
-        private bool collapsedField = true;
-        private bool collapsedSpecifiedField = true;
+        private bool collapsedField = false;
+        private bool collapsedSpecifiedField = false;
 
         [XmlAttribute]
         public uint min

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Col.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Col.cs
@@ -279,7 +279,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             CT_Col ctObj = new CT_Col();
             ctObj.min = XmlHelper.ReadUInt(node.Attributes["min"]);
             ctObj.max = XmlHelper.ReadUInt(node.Attributes["max"]);
-            ctObj.width = XmlHelper.ReadDouble(node.Attributes["width"]);
+            ctObj.widthField = XmlHelper.ReadDouble(node.Attributes["width"]);
             if (node.Attributes["style"] != null)
                 ctObj.style = XmlHelper.ReadUInt(node.Attributes["style"]);
             else
@@ -287,9 +287,9 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             ctObj.hidden = XmlHelper.ReadBool(node.Attributes["hidden"]);
             ctObj.bestFit = XmlHelper.ReadBool(node.Attributes["bestFit"]);
             ctObj.outlineLevel = XmlHelper.ReadByte(node.Attributes["outlineLevel"]);
-            ctObj.customWidth = XmlHelper.ReadBool(node.Attributes["customWidth"]);
+            ctObj.customWidthField = XmlHelper.ReadBool(node.Attributes["customWidth"]);
             ctObj.phonetic = XmlHelper.ReadBool(node.Attributes["phonetic"]);
-            ctObj.collapsed = XmlHelper.ReadBool(node.Attributes["collapsed"]);
+            ctObj.collapsedField = XmlHelper.ReadBool(node.Attributes["collapsed"]);
             return ctObj;
         }
 

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Col.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Col.cs
@@ -347,14 +347,79 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             return col;
         }
 
+        /// <summary>
+        /// Checks if <paramref name="col"/> is adjacent or intersecting with
+        /// current column and can be combined with it. If that is the case -
+        /// will modify current <see cref="CT_Col"/> to have <see cref="min"/>
+        /// and <see cref="max"/> of both columns.
+        /// </summary>
+        /// <param name="col"><see cref="CT_Col"/> to combine with</param>
+        /// <exception cref="InvalidOperationException">Thrown if
+        /// <paramref name="col"/> cannot be combined with current
+        /// <see cref="CT_Col"/></exception>
+        public void CombineWith(CT_Col col)
+        {
+            if(!IsAdjacentAndCanBeCombined(col))
+            {
+                throw new InvalidOperationException($"Columns [{this}] and " +
+                    $"[{col}] could not be combined");
+            }
+
+            min = Math.Min(min, col.min);
+            max = Math.Max(max, col.max);
+        }
+
+        /// <summary>
+        /// Checks if <paramref name="col"/> is adjacent or intersecting with
+        /// current column and can be combined with it.
+        /// </summary>
+        /// <param name="col"> <see cref="CT_Col"/> to check</param>
+        /// <returns><c>true</c> if <paramref name="col"/> is adjacent or
+        /// intersecting and have equal properties with current
+        /// <see cref="CT_Col"/>; <c>false</c> otherwise</returns>
+        public bool IsAdjacentAndCanBeCombined(CT_Col col)
+        {
+            return IsAdjacentOrIntersecting(col) && HasEqualProperties(col);
+        }
+
+        private bool HasEqualProperties(CT_Col col)
+        {
+            return bestFitField == col.bestFitField
+                && collapsedField == col.collapsedField
+                && collapsedSpecifiedField == col.collapsedSpecifiedField
+                && customWidthField == col.customWidthField
+                && hiddenField == col.hiddenField
+                && outlineLevelField == col.outlineLevelField
+                && phoneticField == col.phoneticField
+                && styleField == col.styleField
+                && widthField == col.widthField
+                && widthSpecifiedField == col.widthSpecifiedField;
+        }
+
+        private bool IsAdjacentOrIntersecting(CT_Col col)
+        {
+            return IsAdjacent(col) || IsIntersecting(col);
+        }
+
+        private bool IsAdjacent(CT_Col col)
+        {
+            return min == col.max + 1 || max == col.min - 1;
+        }
+
+        private bool IsIntersecting(CT_Col col)
+        {
+            return (min >= col.min && min <= col.max) || (max <= col.max && max >= col.min) ||
+                (col.min >= min && col.min <= max) || (col.max <= max && col.max >= min);
+        }
+
         public override bool Equals(object obj)
         {
-            if (obj == null)
+            if (obj is not CT_Col col)
+            {
                 return false;
-            if (!(obj is CT_Col))
-                return false;
-            CT_Col col = obj as CT_Col;
-            return col.min == this.min && col.max == this.max;
+            }
+
+            return col.min == min && col.max == max && HasEqualProperties(col);
         }
 
         public override int GetHashCode()

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Cols.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Cols.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using NPOI.SS;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Xml;
@@ -127,9 +128,11 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         /// <param name="ctCol"></param>
         private static void BreakUpCtCol(CT_Cols ctObj, CT_Col ctCol, int lastColumn)
         {
-            int max = (int)Math.Min(ctCol.max, lastColumn);
+            int max = ctCol.max >= SpreadsheetVersion.EXCEL2007.LastColumnIndex - 1
+                ? lastColumn
+                : (int)ctCol.max;
 
-            for (int i = (int)ctCol.min; i <= (int)max; i++)
+            for (int i = (int)ctCol.min; i <= max; i++)
             {
                 CT_Col breakOffCtCol = ctCol.Copy();
                 breakOffCtCol.min = (uint)i;

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Cols.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Cols.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-
-using System.Text;
-using System.Xml.Serialization;
-using System.Xml;
 using System.IO;
+using System.Xml;
+using System.Xml.Serialization;
 
 namespace NPOI.OpenXmlFormats.Spreadsheet
 {
@@ -53,10 +51,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
         public void RemoveCols(IList<CT_Col> toRemove)
         {
-            if (colField == null) return;
+            if (colField == null)
+            {
+                return;
+            }
+
             foreach (CT_Col c in toRemove)
             {
-                colField.Remove(c);
+                _ = colField.Remove(c);
             }
         }
         public int sizeOfColArray()
@@ -67,7 +69,6 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             return colField[index];
         }
-
 
         public List<CT_Col> GetColList()
         {
@@ -89,9 +90,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         public static CT_Cols Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
+            {
                 return null;
-            CT_Cols ctObj = new CT_Cols();
-            ctObj.col = new List<CT_Col>();
+            }
+
+            CT_Cols ctObj = new CT_Cols
+            {
+                col = new List<CT_Col>()
+            };
             foreach (XmlNode childNode in node.ChildNodes)
             {
                 if (childNode.LocalName == "col")
@@ -133,19 +139,59 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
+            List<CT_Col> combinedCols = CombineCols(col);
+
             sw.Write(string.Format("<{0}", nodeName));
             sw.Write(">");
-            if (this.col != null)
+
+            if (combinedCols != null)
             {
-                foreach (CT_Col x in this.col)
+                foreach (CT_Col x in combinedCols)
                 {
                     x.Write(sw, "col");
                 }
             }
+
             sw.Write(string.Format("</{0}>", nodeName));
         }
 
+        /// <summary>
+        /// Broken up by the <see cref="BreakUpCtCol(CT_Cols, CT_Col)"/> method
+        /// <see cref="CT_Col"/>s are combined into <see cref="CT_Col"/> spans
+        /// </summary>
+        private static List<CT_Col> CombineCols(List<CT_Col> cols)
+        {
+            List<CT_Col> combinedCols = new List<CT_Col>();
 
+            cols.Sort((c1, c2) => c1.min.CompareTo(c2.min));
+
+            CT_Col lastCol = null;
+
+            foreach (CT_Col col in cols)
+            {
+                if (lastCol == null)
+                {
+                    lastCol = col;
+                    continue;
+                }
+
+                if (col.IsAdjacentAndCanBeCombined(lastCol))
+                {
+                    lastCol.CombineWith(col);
+                    continue;
+                }
+                
+                combinedCols.Add(lastCol);
+                lastCol = col;
+            }
+
+            if (lastCol != null)
+            {
+                combinedCols.Add(lastCol);
+            }
+
+            return combinedCols;
+        }
 
         public void SetColArray(CT_Col[] colArray)
         {

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Cols.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Cols.cs
@@ -87,7 +87,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
 
-        public static CT_Cols Parse(XmlNode node, XmlNamespaceManager namespaceManager)
+        public static CT_Cols Parse(XmlNode node, XmlNamespaceManager namespaceManager, int lastColumn)
         {
             if (node == null)
             {
@@ -106,7 +106,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
                     if (ctCol.min != ctCol.max)
                     {
-                        BreakUpCtCol(ctObj, ctCol);
+                        BreakUpCtCol(ctObj, ctCol, lastColumn);
                     }
                     else
                     {
@@ -125,9 +125,11 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         /// </summary>
         /// <param name="ctObj"></param>
         /// <param name="ctCol"></param>
-        private static void BreakUpCtCol(CT_Cols ctObj, CT_Col ctCol)
+        private static void BreakUpCtCol(CT_Cols ctObj, CT_Col ctCol, int lastColumn)
         {
-            for (int i = (int)ctCol.min; i <= (int)ctCol.max; i++)
+            int max = (int)Math.Min(ctCol.max, lastColumn);
+
+            for (int i = (int)ctCol.min; i <= (int)max; i++)
             {
                 CT_Col breakOffCtCol = ctCol.Copy();
                 breakOffCtCol.min = (uint)i;
@@ -180,7 +182,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                     lastCol.CombineWith(col);
                     continue;
                 }
-                
+
                 combinedCols.Add(lastCol);
                 lastCol = col;
             }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Cols.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Cols.cs
@@ -95,12 +95,41 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             foreach (XmlNode childNode in node.ChildNodes)
             {
                 if (childNode.LocalName == "col")
-                    ctObj.col.Add(CT_Col.Parse(childNode, namespaceManager));
+                {
+                    CT_Col ctCol = CT_Col.Parse(childNode, namespaceManager);
+
+                    if (ctCol.min != ctCol.max)
+                    {
+                        BreakUpCtCol(ctObj, ctCol);
+                    }
+                    else
+                    {
+                        ctObj.col.Add(ctCol);
+                    }
+                }
             }
+
             return ctObj;
         }
 
+        /// <summary>
+        /// For ease of use of columns in NPOI break up <see cref="CT_Col"/>s
+        /// that span over multiple physical columns into individual
+        /// <see cref="CT_Col"/>s for each physical column.
+        /// </summary>
+        /// <param name="ctObj"></param>
+        /// <param name="ctCol"></param>
+        private static void BreakUpCtCol(CT_Cols ctObj, CT_Col ctCol)
+        {
+            for (int i = (int)ctCol.min; i <= (int)ctCol.max; i++)
+            {
+                CT_Col breakOffCtCol = ctCol.Copy();
+                breakOffCtCol.min = (uint)i;
+                breakOffCtCol.max = (uint)i;
 
+                ctObj.col.Add(breakOffCtCol);
+            }
+        }
 
         internal void Write(StreamWriter sw, string nodeName)
         {

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Row.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Row.cs
@@ -7,6 +7,7 @@ using System.Xml.Serialization;
 using System.Xml;
 using NPOI.OpenXml4Net.Util;
 using System.IO;
+using NPOI.SS.Util;
 
 namespace NPOI.OpenXmlFormats.Spreadsheet
 {
@@ -45,6 +46,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         private bool phField;
         private double dyDescentField; //x14ac:dyDescent
 
+        private int lastCellField = -1;
+
         public static CT_Row Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             if (node == null)
@@ -68,9 +71,26 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             foreach (XmlNode childNode in node.ChildNodes)
             {
                 if (childNode.LocalName == "extLst")
+                {
                     ctObj.extLst = CT_ExtensionList.Parse(childNode, namespaceManager);
+                }
                 else if (childNode.LocalName == "c")
-                    ctObj.c.Add(CT_Cell.Parse(childNode, namespaceManager));
+                {
+                    CT_Cell cell = CT_Cell.Parse(childNode, namespaceManager);
+                    ctObj.c.Add(cell);
+
+                    if (cell.r == null)
+                    {
+                        continue;
+                    }
+
+                    var cellNum = new CellReference(cell.r).Col;
+
+                    if (cellNum > ctObj.lastCellField)
+                    {
+                        ctObj.lastCellField = cellNum;
+                    }
+                }
             }
             return ctObj;
         }
@@ -381,6 +401,17 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             set
             {
                 this.phField = value;
+            }
+        }
+
+        /// <summary>
+        /// An index of the last non-empty cell in the row
+        /// </summary>
+        public int lastCell
+        {
+            get
+            {
+                return this.lastCellField;
             }
         }
     }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_SheetData.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_SheetData.cs
@@ -12,6 +12,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
     [XmlType(Namespace = "http://schemas.openxmlformats.org/spreadsheetml/2006/main")]
     public class CT_SheetData
     {
+        private int lastColumnField = 0;
 
         public static CT_SheetData Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
@@ -19,15 +20,23 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 return null;
             CT_SheetData ctObj = new CT_SheetData();
             ctObj.row = new List<CT_Row>();
+
             foreach (XmlNode childNode in node.ChildNodes)
             {
                 if (childNode.LocalName == "row")
-                    ctObj.row.Add(CT_Row.Parse(childNode, namespaceManager));
+                {
+                    CT_Row row = CT_Row.Parse(childNode, namespaceManager);
+                    ctObj.row.Add(row);
+
+                    if (row.lastCell > ctObj.lastColumnField)
+                    {
+                        ctObj.lastColumnField = row.lastCell;
+                    }
+                }
             }
+
             return ctObj;
         }
-
-
 
         internal void Write(StreamWriter sw, string nodeName)
         {
@@ -45,7 +54,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
 
 
-        private List<CT_Row> rowField = null; // [0..*] 
+        private List<CT_Row> rowField = null; // [0..*]
 
         //public CT_SheetData()
         //{
@@ -114,6 +123,15 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         public bool rowSpecified
         {
             get { return null != rowField; }
+        }
+
+        [XmlIgnore]
+        public int lastColumn
+        {
+            get
+            {
+                return this.lastColumnField;
+            }
         }
     }
 }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Worksheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Worksheet.cs
@@ -175,7 +175,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 else if (childNode.LocalName == "extLst")
                     ctObj.extLst = CT_ExtensionList.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "cols")
-                    cols =childNode;
+                    cols = childNode;
                 else if (childNode.LocalName == "conditionalFormatting")
                     ctObj.conditionalFormatting.Add(CT_ConditionalFormatting.Parse(childNode, namespaceManager));
             }
@@ -193,7 +193,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         internal void Write(Stream stream, bool leaveOpen)
         {
             StreamWriter sw = new StreamWriter(stream);
-            try {
+            try
+            {
                 sw.Write("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>");
                 sw.Write("<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\"");
                 sw.Write(" xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\" mc:Ignorable=\"x14ac xr xr2 xr3\" xmlns:x14ac=\"http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac\"");
@@ -287,9 +288,10 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                     this.extLst.Write(sw, "extLst");
                 sw.Write("</worksheet>");
                 sw.Flush();
-            } finally
+            }
+            finally
             {
-                if (!leaveOpen )
+                if (!leaveOpen)
                 {
                     sw?.Close();
                 }
@@ -359,7 +361,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
         public CT_ConditionalFormatting AddNewConditionalFormatting()
         {
-            if (null == conditionalFormattingField) { conditionalFormattingField = new List<CT_ConditionalFormatting>(); }
+            if (null == conditionalFormattingField)
+            { conditionalFormattingField = new List<CT_ConditionalFormatting>(); }
             CT_ConditionalFormatting cf = new CT_ConditionalFormatting();
             this.conditionalFormattingField.Add(cf);
             return cf;
@@ -451,7 +454,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
         public CT_Cols AddNewCols()
         {
-            if (null == colsField) { colsField = new List<CT_Cols>(); }
+            if (null == colsField)
+            { colsField = new List<CT_Cols>(); }
             CT_Cols newCols = new CT_Cols();
             this.colsField.Add(newCols);
             return newCols;

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Worksheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Worksheet.cs
@@ -99,6 +99,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             CT_Worksheet ctObj = new CT_Worksheet();
             ctObj.cols = new List<CT_Cols>();
             ctObj.conditionalFormatting = new List<CT_ConditionalFormatting>();
+            XmlNode cols = null;
             foreach (XmlNode childNode in node.ChildNodes)
             {
                 if (childNode.LocalName == "sheetPr")
@@ -174,10 +175,16 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 else if (childNode.LocalName == "extLst")
                     ctObj.extLst = CT_ExtensionList.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "cols")
-                    ctObj.cols.Add(CT_Cols.Parse(childNode, namespaceManager));
+                    cols =childNode;
                 else if (childNode.LocalName == "conditionalFormatting")
                     ctObj.conditionalFormatting.Add(CT_ConditionalFormatting.Parse(childNode, namespaceManager));
             }
+
+            if (cols != null)
+            {
+                ctObj.cols.Add(CT_Cols.Parse(cols, namespaceManager, ctObj.sheetData.lastColumn));
+            }
+
             return ctObj;
         }
 
@@ -280,7 +287,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                     this.extLst.Write(sw, "extLst");
                 sw.Write("</worksheet>");
                 sw.Flush();
-            } finally 
+            } finally
             {
                 if (!leaveOpen )
                 {

--- a/main/HSSF/UserModel/HSSFSheet.cs
+++ b/main/HSSF/UserModel/HSSFSheet.cs
@@ -3359,5 +3359,10 @@ namespace NPOI.HSSF.UserModel
                 _sheet.ActiveCellCol = col;
             }
         }
+
+        IEnumerator<IRow> IEnumerable<IRow>.GetEnumerator()
+        {
+            return rows.Values.GetEnumerator();
+        }
     }
 }

--- a/main/SS/Formula/FormulaShifter.cs
+++ b/main/SS/Formula/FormulaShifter.cs
@@ -30,7 +30,9 @@ namespace NPOI.SS.Formula
         {
             RowMove,
             RowCopy,
-            SheetMove
+            SheetMove,
+            ColumnMove,
+            ColumnCopy
         }
         /// <summary>
         /// Extern sheet index of sheet where moving is occurring
@@ -164,6 +166,42 @@ namespace NPOI.SS.Formula
                 version);
         }
 
+        public static FormulaShifter CreateForColumnShift(
+            int externSheetIndex,
+            string sheetName,
+            int firstMovedColumnIndex,
+            int lastMovedColumnIndex,
+            int numberOfColumnsToMove,
+            SpreadsheetVersion version)
+        {
+            return new FormulaShifter(
+                externSheetIndex,
+                sheetName,
+                firstMovedColumnIndex,
+                lastMovedColumnIndex,
+                numberOfColumnsToMove,
+                ShiftMode.ColumnMove,
+                version);
+        }
+
+        public static FormulaShifter CreateForColumnCopy(
+            int externSheetIndex,
+            string sheetName,
+            int firstMovedColumnIndex,
+            int lastMovedColumnIndex,
+            int numberOfColumnsToMove,
+            SpreadsheetVersion version)
+        {
+            return new FormulaShifter(
+                externSheetIndex,
+                sheetName,
+                firstMovedColumnIndex,
+                lastMovedColumnIndex,
+                numberOfColumnsToMove,
+                ShiftMode.ColumnCopy,
+                version);
+        }
+
         public static FormulaShifter CreateForSheetShift(
             int srcSheetIndex, 
             int dstSheetIndex)
@@ -217,6 +255,10 @@ namespace NPOI.SS.Formula
                     // * row copy on same sheet
                     // * row copy between different sheetsin the same workbook
                     return AdjustPtgDueToRowCopy(ptg);
+                case ShiftMode.ColumnMove:
+                    return AdjustPtgDueToColumnMove(ptg, currentExternSheetIx);
+                case ShiftMode.ColumnCopy:
+                    return AdjustPtgDueToColumnCopy(ptg);
                 case ShiftMode.SheetMove:
                     return AdjustPtgDueToSheetMove(ptg);
                 default:
@@ -311,6 +353,91 @@ namespace NPOI.SS.Formula
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="ptg"></param>
+        /// <param name="currentExternSheetIx"></param>
+        /// <returns>in-place modified ptg (if column move would cause Ptg to 
+        /// change), deleted ref ptg (if column move causes an error),
+        /// or null (if no Ptg change is needed)</returns>
+        private Ptg AdjustPtgDueToColumnMove(Ptg ptg, int currentExternSheetIx)
+        {
+            if (ptg is RefPtg refPtg)
+            {
+                if (currentExternSheetIx != _externSheetIndex)
+                {
+                    // local refs on other sheets are unaffected
+                    return null;
+                }
+
+                return ColumnMoveRefPtg(refPtg);
+            }
+
+            if (ptg is Ref3DPtg rptg)
+            {
+                if (_externSheetIndex != rptg.ExternSheetIndex)
+                {
+                    // only move 3D refs that refer to the sheet with
+                    // cells being moved (currentExternSheetIx is irrelevant)
+                    return null;
+                }
+
+                return ColumnMoveRefPtg(rptg);
+            }
+
+            if (ptg is Ref3DPxg rpxg)
+            {
+                if (rpxg.ExternalWorkbookNumber > 0 ||
+                       !_sheetName.Equals(rpxg.SheetName))
+                {
+                    // only move 3D refs that refer to the sheet with cells
+                    // being moved
+                    return null;
+                }
+
+                return ColumnMoveRefPtg(rpxg);
+            }
+
+            if (ptg is Area2DPtgBase areaPtgBase)
+            {
+                if (currentExternSheetIx != _externSheetIndex)
+                {
+                    // local refs on other sheets are unaffected
+                    return ptg;
+                }
+
+                return ColumnMoveAreaPtg(areaPtgBase);
+            }
+
+            if (ptg is Area3DPtg aptg)
+            {
+                if (_externSheetIndex != aptg.ExternSheetIndex)
+                {
+                    // only move 3D refs that refer to the sheet with cells
+                    // being moved (currentExternSheetIx is irrelevant)
+                    return null;
+                }
+
+                return ColumnMoveAreaPtg(aptg);
+            }
+
+            if (ptg is Area3DPxg apxg)
+            {
+                if (apxg.ExternalWorkbookNumber > 0 ||
+                        !_sheetName.Equals(apxg.SheetName))
+                {
+                    // only move 3D refs that refer to the sheet with cells
+                    // being moved
+                    return null;
+                }
+
+                return ColumnMoveAreaPtg(apxg);
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Call this on any ptg reference contained in a row of cells that was
         /// copied. If the ptg reference is relative, the references will be 
         /// shifted by the distance that the rows were copied. In the future 
@@ -362,6 +489,56 @@ namespace NPOI.SS.Formula
             return null;
         }
 
+        /// <summary>
+        /// Call this on any ptg reference contained in a column of cells that was
+        /// copied. If the ptg reference is relative, the references will be 
+        /// shifted by the distance that the columns were copied. Make sure to only call 
+        /// AdjustPtgDueToColumnCopy on formula cells that are copied (unless column 
+        /// shifting, where references outside of the shifted region need to be
+        /// updated to reflect the shift, a copy is self-contained).
+        /// </summary>
+        /// <param name="ptg">the ptg to shift</param>
+        /// <returns>deleted ref ptg, in-place modified ptg, or null 
+        /// <para>If Ptg would be shifted off the first or last row of a sheet, 
+        /// return deleted ref </para>
+        /// <para>If Ptg needs to be changed, modifies Ptg in-place </para>
+        /// <para>If Ptg doesn't need to be changed, returns <code>null</code>
+        /// </para></returns>
+        private Ptg AdjustPtgDueToColumnCopy(Ptg ptg)
+        {
+            if (ptg is RefPtg refPtg)
+            {
+                return ColumnCopyRefPtg(refPtg);
+            }
+
+            if (ptg is Ref3DPtg rptg)
+            {
+                return ColumnCopyRefPtg(rptg);
+            }
+
+            if (ptg is Ref3DPxg rpxg)
+            {
+                return ColumnCopyRefPtg(rpxg);
+            }
+
+            if (ptg is Area2DPtgBase areaPtgBase)
+            {
+                return ColumnCopyAreaPtg(areaPtgBase);
+            }
+
+            if (ptg is Area3DPtg aptg)
+            {
+                return ColumnCopyAreaPtg(aptg);
+            }
+
+            if (ptg is Area3DPxg apxg)
+            {
+                return ColumnCopyAreaPtg(apxg);
+            }
+
+            return null;
+        }
+
         private Ptg AdjustPtgDueToSheetMove(Ptg ptg)
         {
             if (ptg is Ref3DPtg refPtg)
@@ -407,6 +584,7 @@ namespace NPOI.SS.Formula
 
             return null;
         }
+
         private Ptg RowMoveRefPtg(RefPtgBase rptg)
         {
             int refRow = rptg.Row;
@@ -442,6 +620,43 @@ namespace NPOI.SS.Formula
                 "Situation not covered: (" + _firstMovedIndex + ", " +
                         _lastMovedIndex + ", " + _amountToMove + ", " + 
                         refRow + ", " + refRow + ")");
+        }
+
+        private Ptg ColumnMoveRefPtg(RefPtgBase rptg)
+        {
+            int refColumn = rptg.Column;
+            if (_firstMovedIndex <= refColumn && refColumn <= _lastMovedIndex)
+            {
+                // Columns being moved completely enclose the ref. - move the area
+                // ref along with the columns regardless of destination
+                rptg.Column = refColumn + _amountToMove;
+                return rptg;
+            }
+            // else rules for adjusting area may also depend on the destination
+            // of the moved columns
+
+            int destFirstColumnIndex = _firstMovedIndex + _amountToMove;
+            int destLastColumnIndex = _lastMovedIndex + _amountToMove;
+
+            // ref is outside source columns
+            // check for clashes with destination
+
+            if (destLastColumnIndex < refColumn || refColumn < destFirstColumnIndex)
+            {
+                // destination columns are completely outside ref
+                return null;
+            }
+
+            if (destFirstColumnIndex <= refColumn && refColumn <= destLastColumnIndex)
+            {
+                // destination columns enclose the area (possibly exactly)
+                return CreateDeletedRef(rptg);
+            }
+
+            throw new InvalidOperationException(
+                "Situation not covered: (" + _firstMovedIndex + ", " +
+                        _lastMovedIndex + ", " + _amountToMove + ", " +
+                        refColumn + ", " + refColumn + ")");
         }
 
         private Ptg RowMoveAreaPtg(AreaPtgBase aptg)
@@ -610,6 +825,172 @@ namespace NPOI.SS.Formula
                         aFirstRow + ", " + aLastRow + ")");
         }
 
+        private Ptg ColumnMoveAreaPtg(AreaPtgBase aptg)
+        {
+            int aFirstColumn = aptg.FirstColumn;
+            int aLastColumn = aptg.LastColumn;
+            if (_firstMovedIndex <= aFirstColumn && aLastColumn <= _lastMovedIndex)
+            {
+                // Columns being moved completely enclose the area ref. - move the
+                // area ref along with the columns regardless of destination
+                aptg.FirstColumn = aFirstColumn + _amountToMove;
+                aptg.LastColumn = aLastColumn + _amountToMove;
+                return aptg;
+            }
+            // else rules for adjusting area may also depend on the destination
+            // of the moved columns
+
+            int destFirstColumnIndex = _firstMovedIndex + _amountToMove;
+            int destLastColumnIndex = _lastMovedIndex + _amountToMove;
+
+            if (aFirstColumn < _firstMovedIndex && _lastMovedIndex < aLastColumn)
+            {
+                // Columns moved were originally *completely* within the area ref
+
+                // If the destination of the columns overlaps either the left
+                // or right of the area ref there will be a change
+                if (destFirstColumnIndex < aFirstColumn
+                    && aFirstColumn <= destLastColumnIndex)
+                {
+                    // truncate the left of the area by the moved columns
+                    aptg.FirstColumn = destLastColumnIndex + 1;
+                    return aptg;
+                }
+                else if (destFirstColumnIndex <= aLastColumn
+                    && aLastColumn < destLastColumnIndex)
+                {
+                    // truncate the right of the area by the moved columns
+                    aptg.LastColumn = destFirstColumnIndex - 1;
+                    return aptg;
+                }
+                // else - columns have moved completely outside the area ref,
+                // or still remain completely within the area ref
+                return null; // - no change to the area
+            }
+
+            if (_firstMovedIndex <= aFirstColumn && aFirstColumn <= _lastMovedIndex)
+            {
+                // Columns moved include the first column of the area ref, but not
+                // the last column btw: (aLastColumn > _lastMovedIndex)
+                if (_amountToMove < 0)
+                {
+                    // simple case - expand area by shifting left to the left
+                    aptg.FirstColumn = aFirstColumn + _amountToMove;
+                    return aptg;
+                }
+
+                if (destFirstColumnIndex > aLastColumn)
+                {
+                    // in this case, excel ignores the column move
+                    return null;
+                }
+
+                int newFirstColumnIx = aFirstColumn + _amountToMove;
+                if (destLastColumnIndex < aLastColumn)
+                {
+                    // end of area is preserved (will remain exact same column)
+                    // the left area column is moved simply
+                    aptg.FirstColumn = newFirstColumnIx;
+                    return aptg;
+                }
+                // else - right area column has been replaced - both area left and
+                // right may move now
+                int areaRemainingLeftColumnIx = _lastMovedIndex + 1;
+                if (destFirstColumnIndex > areaRemainingLeftColumnIx)
+                {
+                    // old left column of area has moved deep within the area, and
+                    // exposed a new left column
+                    newFirstColumnIx = areaRemainingLeftColumnIx;
+                }
+
+                aptg.FirstColumn = newFirstColumnIx;
+                aptg.LastColumn = Math.Max(aLastColumn, destLastColumnIndex);
+                return aptg;
+            }
+
+            if (_firstMovedIndex <= aLastColumn && aLastColumn <= _lastMovedIndex)
+            {
+                // Columns moved include the last column of the area ref, but not the
+                // first. btw: (aFirstColumn < _firstMovedIndex)
+                if (_amountToMove > 0)
+                {
+                    // simple case - expand area by shifting right to the right
+                    aptg.LastColumn = aLastColumn + _amountToMove;
+                    return aptg;
+                }
+
+                if (destLastColumnIndex < aFirstColumn)
+                {
+                    // in this case, excel ignores the column move
+                    return null;
+                }
+
+                int newLastColumnIx = aLastColumn + _amountToMove;
+                if (destFirstColumnIndex > aFirstColumn)
+                {
+                    // left of area is preserved (will remain exact same column)
+                    // the right area column is moved simply
+                    aptg.LastColumn = newLastColumnIx;
+                    return aptg;
+                }
+                // else - left area column has been replaced - both area left and
+                // right may move now
+                int areaRemainingRightColumnIx = _firstMovedIndex - 1;
+                if (destLastColumnIndex < areaRemainingRightColumnIx)
+                {
+                    // old right column of area has moved left deep within the
+                    // area, and exposed a new right column
+                    newLastColumnIx = areaRemainingRightColumnIx;
+                }
+
+                aptg.FirstColumn = Math.Min(aFirstColumn, destFirstColumnIndex);
+                aptg.LastColumn = newLastColumnIx;
+                return aptg;
+            }
+            // else source columns include none of the columns of the area ref
+            // check for clashes with destination
+
+            if (destLastColumnIndex < aFirstColumn || aLastColumn < destFirstColumnIndex)
+            {
+                // destination columns are completely outside area ref
+                return null;
+            }
+
+            if (destFirstColumnIndex <= aFirstColumn && aLastColumn <= destLastColumnIndex)
+            {
+                // destination columns enclose the area (possibly exactly)
+                return CreateDeletedRef(aptg);
+            }
+
+            if (aFirstColumn <= destFirstColumnIndex && destLastColumnIndex <= aLastColumn)
+            {
+                // destination columns are within area ref (possibly exact on left
+                // or right, but not both)
+                return null; // - no change to area
+            }
+
+            if (destFirstColumnIndex < aFirstColumn && aFirstColumn <= destLastColumnIndex)
+            {
+                // dest columns overlap left of area
+                // - truncate the left
+                aptg.FirstColumn = destLastColumnIndex + 1;
+                return aptg;
+            }
+
+            if (destFirstColumnIndex <= aLastColumn && aLastColumn < destLastColumnIndex)
+            {
+                // dest columns overlap right of area
+                // - truncate the right
+                aptg.LastColumn = destFirstColumnIndex - 1;
+                return aptg;
+            }
+
+            throw new InvalidOperationException(
+                "Situation not covered: (" + _firstMovedIndex + ", " +
+                        _lastMovedIndex + ", " + _amountToMove + ", " +
+                        aFirstColumn + ", " + aLastColumn + ")");
+        }
+
         /// <summary>
         /// Modifies rptg in-place and return a reference to rptg if the cell 
         /// reference would move due to a row copy operation
@@ -629,6 +1010,31 @@ namespace NPOI.SS.Formula
                 }
 
                 rptg.Row = refRow + _amountToMove;
+                return rptg;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Modifies rptg in-place and return a reference to rptg if the cell 
+        /// reference would move due to a column copy operation
+        /// </summary>
+        /// <param name="rptg"></param>
+        /// <returns><code>null</code> or {@link #RefErrorPtg} if no change was
+        /// made</returns>
+        private Ptg ColumnCopyRefPtg(RefPtgBase rptg)
+        {
+            int refColumn = rptg.Column;
+            if (rptg.IsColRelative)
+            {
+                int destColumnIndex = _firstMovedIndex + _amountToMove;
+                if (destColumnIndex < 0 || _version.LastColumnIndex < destColumnIndex)
+                {
+                    return CreateDeletedRef(rptg);
+                }
+
+                rptg.Column = refColumn + _amountToMove;
                 return rptg;
             }
 
@@ -673,6 +1079,55 @@ namespace NPOI.SS.Formula
                 }
 
                 aptg.LastRow = destLastRowIndex;
+                changed = true;
+            }
+
+            if (changed)
+            {
+                aptg.SortTopLeftToBottomRight();
+            }
+
+            return changed ? aptg : null;
+        }
+
+        /// <summary>
+        /// Modifies aptg in-place and return a reference to aptg if the first 
+        /// or last column of of the Area reference would move due to a column 
+        /// copy operation
+        /// </summary>
+        /// <param name="aptg"></param>
+        /// <returns><code>null</code> or <see cref="AreaErrPtg"/>if no change 
+        /// was made</returns>
+        private Ptg ColumnCopyAreaPtg(AreaPtgBase aptg)
+        {
+            bool changed = false;
+
+            int aFirstColumn = aptg.FirstColumn;
+            int aLastColumn = aptg.LastColumn;
+
+            if (aptg.IsFirstColRelative)
+            {
+                int destFirstColumnIndex = aFirstColumn + _amountToMove;
+                if (destFirstColumnIndex < 0
+                    || _version.LastColumnIndex < destFirstColumnIndex)
+                {
+                    return CreateDeletedRef(aptg);
+                }
+
+                aptg.FirstColumn = destFirstColumnIndex;
+                changed = true;
+            }
+
+            if (aptg.IsLastColRelative)
+            {
+                int destLastColumnIndex = aLastColumn + _amountToMove;
+                if (destLastColumnIndex < 0
+                    || _version.LastColumnIndex < destLastColumnIndex)
+                {
+                    return CreateDeletedRef(aptg);
+                }
+
+                aptg.LastColumn = destLastColumnIndex;
                 changed = true;
             }
 

--- a/main/SS/UserModel/CellCopyPolicy.cs
+++ b/main/SS/UserModel/CellCopyPolicy.cs
@@ -33,6 +33,9 @@ namespace NPOI.SS.UserModel
         public static bool DEFAULT_COPY_ROW_HEIGHT_POLICY = true;
         public static bool DEFAULT_CONDENSE_ROWS_POLICY = false;
 
+        // column-level policies
+        public static bool DEFAULT_COPY_COLUMN_WIDTH_POLICY = true;
+
         // sheet-level policies
         public static bool DEFAULT_COPY_MERGED_REGIONS_POLICY = true;
 
@@ -46,6 +49,9 @@ namespace NPOI.SS.UserModel
         // row-level policies
         private bool copyRowHeight = DEFAULT_COPY_ROW_HEIGHT_POLICY;
         private bool condenseRows = DEFAULT_CONDENSE_ROWS_POLICY;
+
+        // column-level policies
+        private bool copyColumnWidth = DEFAULT_COPY_COLUMN_WIDTH_POLICY;
 
         // sheet-level policies
         private bool copyMergedRegions = DEFAULT_COPY_MERGED_REGIONS_POLICY;
@@ -72,6 +78,8 @@ namespace NPOI.SS.UserModel
             copyRowHeight = other.IsCopyRowHeight;
             condenseRows = other.IsCondenseRows;
 
+            copyColumnWidth = other.copyColumnWidth;
+
             copyMergedRegions = other.IsCopyMergedRegions;
         }
 
@@ -89,6 +97,8 @@ namespace NPOI.SS.UserModel
             copyRowHeight = builder.copyRowHeight;
             condenseRows = builder.condenseRows;
 
+            copyColumnWidth = builder.copyColumnWidth;
+
             copyMergedRegions = builder.copyMergedRegions;
         }
 
@@ -104,6 +114,9 @@ namespace NPOI.SS.UserModel
             // row-level policies
             internal bool copyRowHeight = DEFAULT_COPY_ROW_HEIGHT_POLICY;
             internal bool condenseRows = DEFAULT_CONDENSE_ROWS_POLICY;
+
+            // column-level policies
+            internal bool copyColumnWidth = DEFAULT_COPY_COLUMN_WIDTH_POLICY;
 
             // sheet-level policies
             internal bool copyMergedRegions = DEFAULT_COPY_MERGED_REGIONS_POLICY;
@@ -148,9 +161,17 @@ namespace NPOI.SS.UserModel
                 this.copyRowHeight = copyRowHeight;
                 return this;
             }
+
             public Builder CondenseRows(bool condenseRows)
             {
                 this.condenseRows = condenseRows;
+                return this;
+            }
+
+            // column-level policies
+            public Builder ColumnWidth(bool copyColumnWidth)
+            {
+                this.copyColumnWidth = copyColumnWidth;
                 return this;
             }
 
@@ -176,6 +197,7 @@ namespace NPOI.SS.UserModel
                     .MergeHyperlink(mergeHyperlink)
                     .RowHeight(copyRowHeight)
                     .CondenseRows(condenseRows)
+                    .ColumnWidth(copyColumnWidth)
                     .MergedRegions(copyMergedRegions);
             return builder;
         }
@@ -292,6 +314,24 @@ namespace NPOI.SS.UserModel
             set
             {
                 this.condenseRows = value;
+            }
+        }
+
+        /*
+         * Column-level policies 
+         */
+        /**
+         * @return the copyColumnWidth
+         */
+        public bool IsCopyColumnWidth
+        {
+            get
+            {
+                return copyColumnWidth;
+            }
+            set
+            {
+                this.copyColumnWidth = value;
             }
         }
 

--- a/main/SS/UserModel/Column.cs
+++ b/main/SS/UserModel/Column.cs
@@ -167,10 +167,10 @@ namespace NPOI.SS.UserModel
         /// put it into more groups (outlines), reduced as
         /// you take it out of them.
         /// </summary>
-        int OutlineLevel { get; }
+        int OutlineLevel { get; set; }
 
-        bool? Hidden { get; set; }
+        bool Hidden { get; set; }
 
-        bool? Collapsed { get; set; }
+        bool Collapsed { get; set; }
     }
 }

--- a/main/SS/UserModel/Column.cs
+++ b/main/SS/UserModel/Column.cs
@@ -1,0 +1,176 @@
+﻿/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for Additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+using System.Collections.Generic;
+
+namespace NPOI.SS.UserModel
+{
+    /// <summary>
+    /// High level representation of a column of a spreadsheet.
+    /// </summary>  
+    public interface IColumn : IEnumerable<ICell>
+    {
+        /// <summary>
+        /// Use this to create new cells within the column and return it.
+        /// The cell that is returned is a <see cref="CellType.Blank"/>. The type can be Changed
+        /// either through calling <see cref="ICell.SetCellValue"/> or <see cref="ICell.SetCellType"/>.
+        /// </summary>
+        /// <param name="rowIndex">the row number this cell represents</param>
+        /// <returns>a high level representation of the Created cell</returns>
+        /// <exception cref="ArgumentOutOfRangeException">if columnIndex is less than 0 or greater than 16384, 
+        /// the maximum number of columns supported by the SpreadsheetML format(.xlsx)</exception>
+        ICell CreateCell(int rowIndex);
+
+        /// <summary>
+        /// Use this to create new cells within the column and return it.
+        /// </summary>
+        /// <param name="rowIndex">the row number this cell represents</param>
+        /// <param name="type">the cell's data type</param>
+        /// <returns>a high level representation of the Created cell.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">if columnIndex is less than 0 or greater than 16384, 
+        /// the maximum number of columns supported by the SpreadsheetML format(.xlsx)</exception>
+        ICell CreateCell(int rowIndex, CellType type);
+
+        /// <summary>
+        /// Remove the Cell from this column.
+        /// </summary>
+        /// <param name="cell">the cell to remove</param>
+        /// <exception cref="ArgumentException"></exception>
+        void RemoveCell(ICell cell);
+
+        /// <summary>
+        /// Get column number this column represents
+        /// </summary>
+        /// <returns>the column number (0 based)</returns>
+        int ColumnNum { get; set; }
+
+        /// <summary>
+        /// Returns the cell at the given (0 based) index,
+        /// with the <see cref="MissingCellPolicy"/> from the parent Workbook.
+        /// </summary>
+        /// <param name="cellNum"></param>
+        /// <returns>the cell at the given (0 based) index</returns>
+        ICell GetCell(int cellNum);
+
+        /// <summary>
+        /// Returns the cell at the given (0 based) index, with the specified <see cref="MissingCellPolicy"/>
+        /// </summary>
+        /// <param name="cellNum"></param>
+        /// <param name="policy"></param>
+        /// <returns>the cell at the given (0 based) index</returns>
+        /// <exception cref="ArgumentException">if cellnum is less than 0 or the specified MissingCellPolicy is invalid</exception>
+        ICell GetCell(int cellNum, MissingCellPolicy policy);
+
+        /// <summary>
+        /// Get the number of the first cell Contained in this column.
+        /// </summary>
+        /// <returns>short representing the first logical cell in the column,
+        /// or -1 if the column does not contain any cells.</returns>
+        short FirstCellNum { get; }
+
+        /// <summary>
+        /// Gets the index of the last cell Contained in this column <b>PLUS ONE</b>. The result also
+        /// happens to be the 1-based column number of the last cell. This value can be used as a
+        /// standard upper bound when iterating over cells:
+        /// </summary>
+        /// <returns>short representing the last logical cell in the column <b>PLUS ONE</b>,
+        /// or -1 if the column does not contain any cells.</returns>
+        short LastCellNum { get; }
+
+        /// <summary>
+        /// Gets the number of defined cells (NOT number of cells in the actual column!).
+        /// That is to say if only rows 0,4,5 have values then there would be 3.
+        /// </summary>
+        /// <returns>int representing the number of defined cells in the column.</returns>
+        int PhysicalNumberOfCells { get; }
+
+        /// <summary>
+        /// Get whether or not to display this column with 0 width
+        /// </summary>
+        bool ZeroWidth { get; set; }
+
+        /// <summary>
+        /// Get the column's width. 
+        /// If the height is not Set, the default worksheet value is returned
+        /// </summary>
+        /// <returns>column height</returns>
+        double Width { get; set; }
+
+        /// <summary>
+        /// Is this column formatted? Most aren't, but some columns
+        /// do have whole-column styles. For those that do, you
+        /// can get the formatting from <see cref="ColumnStyle"/>
+        /// </summary>
+        bool IsFormatted { get; }
+
+        /// <summary>
+        /// Is the column width set to best fit the content?
+        /// </summary>
+        bool IsBestFit { get; set; }
+
+        /// <summary>
+        /// Returns the Sheet this column belongs to
+        /// </summary>
+        /// <returns>the Sheet that owns this column</returns>
+        ISheet Sheet { get; }
+
+        /// <summary>
+        /// Returns the whole-column cell style. Most columns won't
+        /// have one of these, so will return null. Call
+        /// <see cref="IsFormatted"/> to check first.
+        /// </summary>
+        ICellStyle ColumnStyle { get; set; }
+
+        /// <summary>
+        /// Remove the Cell from this column.
+        /// </summary>
+        /// <param name="cell">the cell to remove</param>
+        /// <exception cref="ArgumentException"></exception>
+        void MoveCell(ICell cell, int newRow);
+
+        /// <summary>
+        /// Copy the current column to the target column
+        /// </summary>
+        /// <param name="targetIndex">column index of the target column</param>
+        /// <returns>the new copied column object</returns>
+        IColumn CopyColumnTo(int targetIndex);
+
+        /// <summary>
+        /// Copy the source cell to the target cell. If the target cell exists, the new copied cell will be inserted before the existing one
+        /// </summary>
+        /// <param name="sourceIndex">index of the source cell</param>
+        /// <param name="targetIndex">index of the target cell</param>
+        /// <returns>the new copied cell object</returns>
+        ICell CopyCell(int sourceIndex, int targetIndex);
+
+        /// <summary>
+        /// Get cells in the column
+        /// </summary>
+        List<ICell> Cells { get; }
+
+        /// <summary>
+        /// Returns the columns outline level. Increased as you
+        /// put it into more groups (outlines), reduced as
+        /// you take it out of them.
+        /// </summary>
+        int OutlineLevel { get; }
+
+        bool? Hidden { get; set; }
+
+        bool? Collapsed { get; set; }
+    }
+}

--- a/main/SS/UserModel/Helpers/RowShifter.cs
+++ b/main/SS/UserModel/Helpers/RowShifter.cs
@@ -101,25 +101,11 @@ namespace NPOI.SS.UserModel.Helpers
         // Keep in sync with {@link ColumnShifter#removalNeeded}
         private bool RemovalNeeded(CellRangeAddress merged, int startRow, int endRow, int n, int lastCol)
         {
-            var movedRows = endRow - startRow + 1;
-
             // build a range of the rows that are overwritten, i.e. the target-area, but without
             // rows that are moved along
-            CellRangeAddress overwrite;
-            if (n > 0)
-            {
-                // area is moved down => overwritten area is [endRow + n - movedRows, endRow + n]
-                var firstRow = Math.Max(endRow + 1, endRow + n - movedRows);
-                var lastRow = endRow + n;
-                overwrite = new CellRangeAddress(firstRow, lastRow, 0, lastCol);
-            }
-            else
-            {
-                // area is moved up => overwritten area is [startRow + n, startRow + n + movedRows]
-                var firstRow = startRow + n;
-                var lastRow = Math.Min(startRow - 1, startRow + n + movedRows);
-                overwrite = new CellRangeAddress(firstRow, lastRow, 0, lastCol);
-            }
+            var firstRow = startRow + n;
+            var lastRow = endRow + n;
+            CellRangeAddress overwrite = new CellRangeAddress(firstRow, lastRow, 0, lastCol);
 
             // if the merged-region and the overwritten area intersect, we need to remove it
             return merged.Intersects(overwrite);

--- a/main/SS/UserModel/Helpers/RowShifter.cs
+++ b/main/SS/UserModel/Helpers/RowShifter.cs
@@ -51,17 +51,13 @@ namespace NPOI.SS.UserModel.Helpers
             ISet<int> removedIndices = new HashSet<int>();
             //move merged regions completely if they fall within the new region boundaries when they are Shifted
             var size = sheet.NumMergedRegions;
+            var lastCol = sheet.Max(r => r.LastCellNum);
 
             for (var i = 0; i < size; i++)
             {
                 var merged = sheet.GetMergedRegion(i);
 
                 // remove merged region that overlaps Shifting
-                var lastCol = sheet.GetRow(startRow) != null 
-                    ? sheet.GetRow(startRow).LastCellNum 
-                    : sheet.GetRow(endRow) != null 
-                        ? sheet.GetRow(endRow).LastCellNum 
-                        : 0;
                 if (RemovalNeeded(merged, startRow, endRow, n, lastCol))
                 {
                     removedIndices.Add(i);

--- a/main/SS/UserModel/Helpers/RowShifter.cs
+++ b/main/SS/UserModel/Helpers/RowShifter.cs
@@ -51,7 +51,7 @@ namespace NPOI.SS.UserModel.Helpers
             ISet<int> removedIndices = new HashSet<int>();
             //move merged regions completely if they fall within the new region boundaries when they are Shifted
             var size = sheet.NumMergedRegions;
-            var lastCol = sheet.Max(r => r.LastCellNum);
+            var lastCol = sheet.Any() ? sheet.Max(r => r.LastCellNum) : 0;
 
             for (var i = 0; i < size; i++)
             {

--- a/main/SS/UserModel/Sheet.cs
+++ b/main/SS/UserModel/Sheet.cs
@@ -82,7 +82,7 @@ namespace NPOI.SS.UserModel
     /// The most common type of sheet is the worksheet, which is represented as a grid of cells. Worksheet cells can
     /// contain text, numbers, dates, and formulas. Cells can also be formatted.
     /// </remarks>
-    public interface ISheet
+    public interface ISheet : IEnumerable<IRow>
     {
 
         /// <summary>

--- a/main/SS/Util/CellUtil.cs
+++ b/main/SS/Util/CellUtil.cs
@@ -129,6 +129,30 @@ namespace NPOI.SS.Util
             return CopyCell(oldCell, newCell, sourceIndex, targetIndex);
         }
 
+        public static ICell CopyCell(IColumn column, int sourceIndex, int targetIndex)
+        {
+            // Grab a copy of the old/new cell
+            ICell oldCell = column.GetCell(sourceIndex);
+
+            // If the old cell is null jump to next cell
+            if (oldCell == null)
+            {
+                return null;
+            }
+
+            ICell newCell = column.GetCell(targetIndex);
+            if (newCell == null) //not exist
+            {
+                newCell = column.CreateCell(targetIndex);
+            }
+            else
+            {
+                //TODO:shift cells                
+            }
+
+            return CopyCell(oldCell, newCell, sourceIndex, targetIndex);
+        }
+
         private static ICell CopyCell(ICell oldCell, ICell newCell, int sourceIndex, int targetIndex)
         {
             if (sourceIndex == targetIndex)

--- a/ooxml/XSSF/Streaming/SXSSFSheet.cs
+++ b/ooxml/XSSF/Streaming/SXSSFSheet.cs
@@ -1469,5 +1469,10 @@ namespace NPOI.XSSF.Streaming
         {
             throw new NotImplementedException();
         }
+
+        IEnumerator<IRow> IEnumerable<IRow>.GetEnumerator()
+        {
+            return ((IEnumerable<IRow>) _sh).GetEnumerator();
+        }
     }
 }

--- a/ooxml/XSSF/UserModel/Helpers/ColumnHelper.cs
+++ b/ooxml/XSSF/UserModel/Helpers/ColumnHelper.cs
@@ -28,6 +28,7 @@ namespace NPOI.XSSF.UserModel.Helpers
     /// (the data part of a sheet). Note - within POI, we use 0 based column 
     /// indexes, but the column defInitions in the XML are 1 based!
     /// </summary>
+    [Obsolete("Use XSSFColumn object for all things column")]
     public class ColumnHelper
     {
 

--- a/ooxml/XSSF/UserModel/Helpers/ColumnShifter.cs
+++ b/ooxml/XSSF/UserModel/Helpers/ColumnShifter.cs
@@ -72,7 +72,7 @@ namespace NPOI.XSSF.UserModel.Helpers
 
                 if (RemovalNeeded(merged, startColumn, endColumn, n, lastCol))
                 {
-                    removedIndices.Add(i);
+                    _ = removedIndices.Add(i);
                     continue;
                 }
 
@@ -96,7 +96,7 @@ namespace NPOI.XSSF.UserModel.Helpers
                     merged.LastColumn += n;
                     //have to Remove/add it back
                     ShiftedRegions.Add(merged);
-                    removedIndices.Add(i);
+                    _ = removedIndices.Add(i);
                 }
             }
 
@@ -108,7 +108,7 @@ namespace NPOI.XSSF.UserModel.Helpers
             //read so it doesn't Get Shifted again
             foreach (CellRangeAddress region in ShiftedRegions)
             {
-                sheet.AddMergedRegion(region);
+                _ = sheet.AddMergedRegion(region);
             }
 
             return ShiftedRegions;

--- a/ooxml/XSSF/UserModel/Helpers/ColumnShifter.cs
+++ b/ooxml/XSSF/UserModel/Helpers/ColumnShifter.cs
@@ -53,7 +53,7 @@ namespace NPOI.XSSF.UserModel.Helpers
             int endColumn,
             int n)
         {
-            List<CellRangeAddress> ShiftedRegions = new List<CellRangeAddress>();
+            List<CellRangeAddress> shiftedRegions = new List<CellRangeAddress>();
             ISet<int> removedIndices = new HashSet<int>();
             //move merged regions completely if they fall within the new region
             //boundaries when they are Shifted
@@ -64,13 +64,7 @@ namespace NPOI.XSSF.UserModel.Helpers
                 CellRangeAddress merged = sheet.GetMergedRegion(i);
 
                 // remove merged region that overlaps Shifting
-                int lastCol = sheet.GetColumn(startColumn) != null
-                    ? sheet.GetColumn(startColumn).LastCellNum
-                    : sheet.GetColumn(endColumn) != null
-                        ? sheet.GetColumn(endColumn).LastCellNum
-                        : 0;
-
-                if (RemovalNeeded(merged, startColumn, endColumn, n, lastCol))
+                if (RemovalNeeded(merged, startColumn, endColumn, n))
                 {
                     _ = removedIndices.Add(i);
                     continue;
@@ -95,7 +89,7 @@ namespace NPOI.XSSF.UserModel.Helpers
                     merged.FirstColumn += n;
                     merged.LastColumn += n;
                     //have to Remove/add it back
-                    ShiftedRegions.Add(merged);
+                    shiftedRegions.Add(merged);
                     _ = removedIndices.Add(i);
                 }
             }
@@ -106,12 +100,12 @@ namespace NPOI.XSSF.UserModel.Helpers
             }
 
             //read so it doesn't Get Shifted again
-            foreach (CellRangeAddress region in ShiftedRegions)
+            foreach (CellRangeAddress region in shiftedRegions)
             {
                 _ = sheet.AddMergedRegion(region);
             }
 
-            return ShiftedRegions;
+            return shiftedRegions;
         }
 
         // Keep in sync with {@link ColumnShifter#removalNeeded}
@@ -119,8 +113,7 @@ namespace NPOI.XSSF.UserModel.Helpers
             CellRangeAddress merged,
             int startColumn,
             int endColumn,
-            int n,
-            int lastCol)
+            int n)
         {
             int movedColumns = endColumn - startColumn + 1;
 
@@ -130,13 +123,13 @@ namespace NPOI.XSSF.UserModel.Helpers
 
             if (n > 0)
             {
-                // area is moved down => overwritten area is
+                // area is moved right => overwritten area is
                 // [endColumn + n - movedColumns, endColumn + n]
                 int firstColumn =
                     Math.Max(endColumn + 1, endColumn + n - movedColumns);
                 int lastColumn = endColumn + n;
                 overwrite =
-                    new CellRangeAddress(firstColumn, lastColumn, 0, lastCol);
+                    new CellRangeAddress(0, sheet.LastRowNum, firstColumn, lastColumn);
             }
             else
             {
@@ -146,7 +139,7 @@ namespace NPOI.XSSF.UserModel.Helpers
                 int lastColumn =
                     Math.Min(startColumn - 1, startColumn + n + movedColumns);
                 overwrite =
-                    new CellRangeAddress(firstColumn, lastColumn, 0, lastCol);
+                    new CellRangeAddress(0, sheet.LastRowNum, firstColumn, lastColumn);
             }
 
             // if the merged-region and the overwritten area intersect,

--- a/ooxml/XSSF/UserModel/Helpers/ColumnShifter.cs
+++ b/ooxml/XSSF/UserModel/Helpers/ColumnShifter.cs
@@ -115,32 +115,10 @@ namespace NPOI.XSSF.UserModel.Helpers
             int endColumn,
             int n)
         {
-            int movedColumns = endColumn - startColumn + 1;
-
-            // build a range of the columns that are overwritten, i.e. the
-            // target-area, but without columns that are moved along
-            CellRangeAddress overwrite;
-
-            if (n > 0)
-            {
-                // area is moved right => overwritten area is
-                // [endColumn + n - movedColumns, endColumn + n]
-                int firstColumn =
-                    Math.Max(endColumn + 1, endColumn + n - movedColumns);
-                int lastColumn = endColumn + n;
-                overwrite =
-                    new CellRangeAddress(0, sheet.LastRowNum, firstColumn, lastColumn);
-            }
-            else
-            {
-                // area is moved up => overwritten area is
-                // [startColumn + n, startColumn + n + movedColumns]
-                int firstColumn = startColumn + n;
-                int lastColumn =
-                    Math.Min(startColumn - 1, startColumn + n + movedColumns);
-                overwrite =
-                    new CellRangeAddress(0, sheet.LastRowNum, firstColumn, lastColumn);
-            }
+            int firstColumn = startColumn + n;
+            int lastColumn = endColumn + n;
+            CellRangeAddress overwrite =
+                new CellRangeAddress(0, sheet.LastRowNum, firstColumn, lastColumn);
 
             // if the merged-region and the overwritten area intersect,
             // we need to remove it

--- a/ooxml/XSSF/UserModel/Helpers/ColumnShifter.cs
+++ b/ooxml/XSSF/UserModel/Helpers/ColumnShifter.cs
@@ -1,0 +1,187 @@
+﻿/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for Additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+using NPOI.SS.Formula;
+using NPOI.SS.UserModel;
+using NPOI.SS.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NPOI.XSSF.UserModel.Helpers
+{
+    /// <summary>
+    /// Helper for Shifting columns left or right
+    /// This abstract class exists to consolidate duplicated code between 
+    /// XSSFColumnShifter and HSSFColumnShifter
+    /// </summary>
+    public abstract class ColumnShifter
+    {
+        protected XSSFSheet sheet;
+
+        public ColumnShifter(XSSFSheet sh)
+        {
+            sheet = sh;
+        }
+
+        /// <summary>
+        /// Shifts, grows, or shrinks the merged regions due to a column Shift.
+        /// Merged regions that are completely overlaid by Shifting will 
+        /// be deleted.
+        /// </summary>
+        /// <param name="startColumn">the column to start Shifting</param>
+        /// <param name="endColumn">the column to end Shifting</param>
+        /// <param name="n">the number of columns to shift</param>
+        /// <returns>an array of affected merged regions, doesn't contain 
+        /// deleted ones</returns>
+        public List<CellRangeAddress> ShiftMergedRegions(
+            int startColumn,
+            int endColumn,
+            int n)
+        {
+            List<CellRangeAddress> ShiftedRegions = new List<CellRangeAddress>();
+            ISet<int> removedIndices = new HashSet<int>();
+            //move merged regions completely if they fall within the new region
+            //boundaries when they are Shifted
+            int size = sheet.NumMergedRegions;
+
+            for (int i = 0; i < size; i++)
+            {
+                CellRangeAddress merged = sheet.GetMergedRegion(i);
+
+                // remove merged region that overlaps Shifting
+                int lastCol = sheet.GetColumn(startColumn) != null
+                    ? sheet.GetColumn(startColumn).LastCellNum
+                    : sheet.GetColumn(endColumn) != null
+                        ? sheet.GetColumn(endColumn).LastCellNum
+                        : 0;
+
+                if (RemovalNeeded(merged, startColumn, endColumn, n, lastCol))
+                {
+                    removedIndices.Add(i);
+                    continue;
+                }
+
+                bool inStart = merged.FirstColumn >= startColumn
+                    || merged.LastColumn >= startColumn;
+                bool inEnd = merged.FirstColumn <= endColumn ||
+                    merged.LastColumn <= endColumn;
+
+                //don't check if it's not within the Shifted area
+                if (!inStart || !inEnd)
+                {
+                    continue;
+                }
+
+                //only shift if the region outside the Shifted columns is not
+                //merged too
+                if (!merged.ContainsColumn(startColumn - 1)
+                    && !merged.ContainsColumn(endColumn + 1))
+                {
+                    merged.FirstColumn += n;
+                    merged.LastColumn += n;
+                    //have to Remove/add it back
+                    ShiftedRegions.Add(merged);
+                    removedIndices.Add(i);
+                }
+            }
+
+            if (removedIndices.Count != 0)
+            {
+                sheet.RemoveMergedRegions(removedIndices.ToList());
+            }
+
+            //read so it doesn't Get Shifted again
+            foreach (CellRangeAddress region in ShiftedRegions)
+            {
+                sheet.AddMergedRegion(region);
+            }
+
+            return ShiftedRegions;
+        }
+
+        // Keep in sync with {@link ColumnShifter#removalNeeded}
+        private bool RemovalNeeded(
+            CellRangeAddress merged,
+            int startColumn,
+            int endColumn,
+            int n,
+            int lastCol)
+        {
+            int movedColumns = endColumn - startColumn + 1;
+
+            // build a range of the columns that are overwritten, i.e. the
+            // target-area, but without columns that are moved along
+            CellRangeAddress overwrite;
+
+            if (n > 0)
+            {
+                // area is moved down => overwritten area is
+                // [endColumn + n - movedColumns, endColumn + n]
+                int firstColumn =
+                    Math.Max(endColumn + 1, endColumn + n - movedColumns);
+                int lastColumn = endColumn + n;
+                overwrite =
+                    new CellRangeAddress(firstColumn, lastColumn, 0, lastCol);
+            }
+            else
+            {
+                // area is moved up => overwritten area is
+                // [startColumn + n, startColumn + n + movedColumns]
+                int firstColumn = startColumn + n;
+                int lastColumn =
+                    Math.Min(startColumn - 1, startColumn + n + movedColumns);
+                overwrite =
+                    new CellRangeAddress(firstColumn, lastColumn, 0, lastCol);
+            }
+
+            // if the merged-region and the overwritten area intersect,
+            // we need to remove it
+            return merged.Intersects(overwrite);
+        }
+
+        /// <summary>
+        /// Updated named ranges
+        /// </summary>
+        /// <param name="Shifter"></param>
+        public abstract void UpdateNamedRanges(FormulaShifter Shifter);
+
+        /// <summary>
+        /// Update formulas.
+        /// </summary>
+        /// <param name="Shifter"></param>
+        public abstract void UpdateFormulas(FormulaShifter Shifter);
+
+        /// <summary>
+        /// Update the formulas in specified column using the formula Shifting 
+        /// policy specified by Shifter
+        /// </summary>
+        /// <param name="column">the column to update the formulas on</param>
+        /// <param name="Shifter">the formula Shifting policy</param>
+        public abstract void UpdateColumnFormulas(IColumn column, FormulaShifter Shifter);
+
+        public abstract void UpdateConditionalFormatting(FormulaShifter Shifter);
+
+        /// <summary>
+        /// Shift the Hyperlink anchors (not the hyperlink text, even if the 
+        /// hyperlink is of type LINK_DOCUMENT and refers to a cell that was 
+        /// Shifted). Hyperlinks do not track the content they point to.
+        /// </summary>
+        /// <param name="Shifter">the formula Shifting policy</param>
+        public abstract void UpdateHyperlinks(FormulaShifter Shifter);
+    }
+}

--- a/ooxml/XSSF/UserModel/Helpers/XSSFColumnShifter.cs
+++ b/ooxml/XSSF/UserModel/Helpers/XSSFColumnShifter.cs
@@ -18,7 +18,6 @@
 using NPOI.OOXML.XSSF.UserModel.Helpers;
 using NPOI.SS.Formula;
 using NPOI.SS.UserModel;
-using NPOI.SS.UserModel.Helpers;
 
 namespace NPOI.XSSF.UserModel.Helpers
 {

--- a/ooxml/XSSF/UserModel/Helpers/XSSFColumnShifter.cs
+++ b/ooxml/XSSF/UserModel/Helpers/XSSFColumnShifter.cs
@@ -1,0 +1,58 @@
+﻿/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for Additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+using NPOI.OOXML.XSSF.UserModel.Helpers;
+using NPOI.SS.Formula;
+using NPOI.SS.UserModel;
+using NPOI.SS.UserModel.Helpers;
+
+namespace NPOI.XSSF.UserModel.Helpers
+{
+    public class XSSFColumnShifter : ColumnShifter
+    {
+        public XSSFColumnShifter(XSSFSheet sh)
+            : base(sh)
+        {
+            sheet = sh;
+        }
+
+        public override void UpdateConditionalFormatting(FormulaShifter formulaShifter)
+        {
+            XSSFRowColShifter.UpdateConditionalFormatting(sheet, formulaShifter);
+        }
+
+        public override void UpdateFormulas(FormulaShifter formulaShifter)
+        {
+            XSSFRowColShifter.UpdateFormulas(sheet, formulaShifter);
+        }
+
+        public override void UpdateHyperlinks(FormulaShifter formulaShifter)
+        {
+            XSSFRowColShifter.UpdateHyperlinks(sheet, formulaShifter);
+        }
+
+        public override void UpdateNamedRanges(FormulaShifter formulaShifter)
+        {
+            XSSFRowColShifter.UpdateNamedRanges(sheet, formulaShifter);
+        }
+
+        public override void UpdateColumnFormulas(IColumn column, FormulaShifter formulaShifter)
+        {
+            XSSFRowColShifter.UpdateColumnFormulas(column, formulaShifter);
+        }
+    }
+}

--- a/ooxml/XSSF/UserModel/XSSFCell.cs
+++ b/ooxml/XSSF/UserModel/XSSFCell.cs
@@ -683,7 +683,12 @@ namespace NPOI.XSSF.UserModel
         {
             get
             {
-                return this._cellNum;
+                return _cellNum;
+            }
+
+            internal set
+            {
+                _cellNum = value;
             }
         }
 

--- a/ooxml/XSSF/UserModel/XSSFColumn.cs
+++ b/ooxml/XSSF/UserModel/XSSFColumn.cs
@@ -496,7 +496,7 @@ namespace NPOI.XSSF.UserModel
                         if (destColumnNum == destRegion.FirstColumn
                             && destColumnNum == destRegion.LastColumn)
                         {
-                            indices.Add(index);
+                            _ = indices.Add(index);
                         }
 
                         index++;
@@ -546,7 +546,7 @@ namespace NPOI.XSSF.UserModel
                             CellRangeAddress destRegion = srcRegion.Copy();
                             destRegion.FirstColumn = destColumnNum;
                             destRegion.LastColumn = destColumnNum;
-                            Sheet.AddMergedRegion(destRegion);
+                            _ = Sheet.AddMergedRegion(destRegion);
                         }
                     }
                 }
@@ -614,10 +614,7 @@ namespace NPOI.XSSF.UserModel
                 }
 
                 //remove the reference in the calculation chain
-                if (calcChain != null)
-                {
-                    calcChain.RemoveItem(sheetId, cell.GetReference());
-                }
+                calcChain?.RemoveItem(sheetId, cell.GetReference());
 
                 CT_Cell CT_Cell = cell.GetCTCell();
                 string r = new CellReference(cell.RowIndex, columnNum)

--- a/ooxml/XSSF/UserModel/XSSFColumn.cs
+++ b/ooxml/XSSF/UserModel/XSSFColumn.cs
@@ -289,7 +289,7 @@ namespace NPOI.XSSF.UserModel
             }
         }
 
-        public bool? Hidden
+        public bool Hidden
         {
             get
             {
@@ -298,11 +298,11 @@ namespace NPOI.XSSF.UserModel
 
             set
             {
-                _column.hidden = value ?? false;
+                _column.hidden = value;
             }
         }
 
-        public bool? Collapsed
+        public bool Collapsed
         {
             get
             {
@@ -311,7 +311,7 @@ namespace NPOI.XSSF.UserModel
 
             set
             {
-                _column.collapsed = value ?? false;
+                _column.collapsed = value;
             }
         }
         #endregion

--- a/ooxml/XSSF/UserModel/XSSFColumn.cs
+++ b/ooxml/XSSF/UserModel/XSSFColumn.cs
@@ -578,7 +578,7 @@ namespace NPOI.XSSF.UserModel
 
         public IColumn CopyColumnTo(int targetIndex)
         {
-            return Sheet.CopyColumn(ColumnNum, targetIndex);
+            return ((XSSFSheet)Sheet).CopyColumn(ColumnNum, targetIndex);
         }
 
         public ICell CopyCell(int sourceIndex, int targetIndex)

--- a/ooxml/XSSF/UserModel/XSSFColumn.cs
+++ b/ooxml/XSSF/UserModel/XSSFColumn.cs
@@ -1,0 +1,804 @@
+﻿/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for Additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+using NPOI.OpenXmlFormats.Spreadsheet;
+using NPOI.SS;
+using NPOI.SS.Formula;
+using NPOI.SS.UserModel;
+using NPOI.SS.Util;
+using NPOI.Util;
+using NPOI.XSSF.Model;
+using NPOI.XSSF.UserModel.Helpers;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NPOI.XSSF.UserModel
+{
+    public class XSSFColumn : IColumn, IComparable<XSSFColumn>
+    {
+        #region Private properties
+        private static readonly POILogger _logger =
+            POILogFactory.GetLogger(typeof(XSSFColumn));
+
+        /// <summary>
+        /// the xml node Containing defInition for this column
+        /// </summary>
+        private readonly CT_Col _column;
+
+        /// <summary>
+        /// Cells of this column keyed by their row indexes.
+        /// The SortedDictionary ensures that the cells are ordered by 
+        /// columnIndex in the ascending order.
+        /// </summary>
+        private readonly SortedDictionary<int, ICell> _cells;
+
+        /// <summary>
+        /// the parent sheet
+        /// </summary>
+        private readonly XSSFSheet _sheet;
+
+        private readonly StylesTable _stylesSource;
+        #endregion
+
+        #region Public properties
+        /// <summary>
+        /// XSSFSheet this column belongs to
+        /// </summary>
+        public ISheet Sheet
+        {
+            get
+            {
+                return _sheet;
+            }
+        }
+
+        /// <summary>
+        /// Get the number of the first cell Contained in this column.
+        /// </summary>
+        /// <returns>short representing the first logical cell in the column,
+        /// or -1 if the column does not contain any cells.</returns>
+        public short FirstCellNum
+        {
+            get
+            {
+                return (short)(_cells.Count == 0 ? -1 : GetFirstKey());
+            }
+        }
+
+        /// <summary>
+        /// Gets the index of the last cell Contained in this column <b>PLUS 
+        /// ONE</b>. The result also happens to be the 1-based row number of 
+        /// the last cell. This value can be used as a standard upper bound 
+        /// when iterating over cells:
+        /// </summary>
+        /// <returns>short representing the last logical cell in the column 
+        /// <b>PLUS ONE</b>, or -1 if the column does not contain any cells.</returns>
+        public short LastCellNum
+        {
+            get
+            {
+                return (short)(_cells.Count == 0 ? -1 : GetLastKey() + 1);
+            }
+        }
+
+        /// <summary>
+        /// Get the column's width. 
+        /// If the width is not Set, the default worksheet value is returned,
+        /// See <see cref="XSSFSheet.DefaultColumnWidth"/>
+        /// </summary>
+        /// <returns>column width</returns>
+        public double Width
+        {
+            get
+            {
+                return _column.width == 0
+                    ? _sheet.DefaultColumnWidth
+                    : _column.width;
+            }
+
+            set
+            {
+                if (value < 0)
+                {
+                    if (_column.IsSetWidth())
+                    {
+                        _column.UnsetWidth();
+                    }
+
+                    if (_column.IsSetCustomWidth())
+                    {
+                        _column.UnsetCustomWidth();
+                    }
+                }
+                else
+                {
+                    _column.width = value;
+                    _column.customWidth = true;
+
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of defined cells (NOT number of cells in the actual
+        /// column!). That is to say if only rows 0,4,5 have values then 
+        /// there would be 3.
+        /// </summary>
+        /// <returns>int representing the number of defined cells in the column.</returns>
+        public int PhysicalNumberOfCells
+        {
+            get
+            {
+                return _cells.Count;
+            }
+        }
+
+        /// <summary>
+        /// Get column number this column represents
+        /// </summary>
+        /// <returns>the column number (0 based)</returns>
+        public int ColumnNum
+        {
+            get
+            {
+                return (int)_column.min - 1;
+            }
+
+            set
+            {
+                int maxColumn = SpreadsheetVersion.EXCEL2007.LastColumnIndex;
+                if (value < 0 || value > maxColumn)
+                {
+                    throw new ArgumentException("Invalid column number (" + value
+                            + ") outside allowable range (0.." + maxColumn + ")");
+                }
+
+                _column.min = (uint)(value + 1);
+                _column.max = (uint)(value + 1);
+            }
+        }
+
+        /// <summary>
+        /// Get whether or not to display this column with 0 width
+        /// </summary>
+        public bool ZeroWidth
+        {
+            get
+            {
+                return _column.hidden;
+            }
+
+            set
+            {
+                _column.hidden = value;
+            }
+        }
+
+        /// <summary>
+        /// Is this column formatted? Most aren't, but some columns
+        /// do have whole-column styles. For those that do, you
+        /// can get the formatting from <see cref="ColumnStyle"/>
+        /// </summary>
+        public bool IsFormatted
+        {
+            get
+            {
+                return _column.IsSetStyle();
+            }
+        }
+
+        /// <summary>
+        /// Is the column width set to best fit the content?
+        /// </summary>
+        public bool IsBestFit
+        {
+            get
+            {
+                return _column.bestFit;
+            }
+
+            set
+            {
+                _column.bestFit = value;
+            }
+        }
+
+        /// <summary>
+        /// Returns the whole-column cell style. Most columns won't
+        /// have one of these, so will return null. Call
+        /// <see cref="IsFormatted"/> to check first.
+        /// </summary>
+        public ICellStyle ColumnStyle
+        {
+            get
+            {
+                if (IsFormatted && _stylesSource != null
+                    && _stylesSource.NumCellStyles > 0)
+                {
+                    return _stylesSource.GetStyleAt((int)_column.style);
+                }
+
+                return null;
+            }
+
+            set
+            {
+                if (value == null)
+                {
+                    if (_column.IsSetStyle())
+                    {
+                        _column.UnsetStyle();
+                    }
+                }
+                else
+                {
+                    XSSFCellStyle xStyle = (XSSFCellStyle)value;
+                    xStyle.VerifyBelongsToStylesSource(_stylesSource);
+
+                    long idx = _stylesSource.PutStyle(xStyle);
+                    _column.style = (uint)idx;
+                }
+
+                foreach (ICell cell in _cells.Values)
+                {
+                    cell.CellStyle = value;
+                }
+            }
+        }
+
+        public List<ICell> Cells
+        {
+            get
+            {
+                List<ICell> cells = new List<ICell>();
+                foreach (ICell cell in _cells.Values)
+                {
+                    cells.Add(cell);
+                }
+
+                return cells;
+            }
+        }
+
+        public int OutlineLevel
+        {
+            get
+            {
+                return _column.outlineLevel;
+            }
+
+            set
+            {
+                _column.outlineLevel = (byte)value;
+            }
+        }
+
+        public bool? Hidden
+        {
+            get
+            {
+                return _column.hidden;
+            }
+
+            set
+            {
+                _column.hidden = value ?? false;
+            }
+        }
+
+        public bool? Collapsed
+        {
+            get
+            {
+                return _column.collapsed;
+            }
+
+            set
+            {
+                _column.collapsed = value ?? false;
+            }
+        }
+        #endregion
+
+        #region Constructor
+        /// <summary>
+        /// Construct an XSSFColumn.
+        /// </summary>
+        /// <param name="column">the xml node Containing defInitions for this row.</param>
+        /// <param name="sheet">the parent sheet.</param>
+        public XSSFColumn(CT_Col column, XSSFSheet sheet)
+        {
+            _column = column;
+            _sheet = sheet;
+            _cells = new SortedDictionary<int, ICell>();
+
+            if (!column.IsSetNumber())
+            {
+                // Certain file format writers skip the row number
+                // Assume no gaps, and give this the next row number
+                int nextColumnNum = sheet.LastColumnNum + 2;
+                if (nextColumnNum == 2 && sheet.PhysicalNumberOfColumns == 0)
+                {
+                    nextColumnNum = 1;
+                }
+
+                _column.min = (uint)nextColumnNum + 1;
+                _column.max = (uint)nextColumnNum + 1;
+            }
+
+            foreach (XSSFRow row in sheet.Cast<XSSFRow>())
+            {
+                foreach (XSSFCell cell in row.Where(c => c.ColumnIndex == ColumnNum).Cast<XSSFCell>())
+                {
+                    _cells.Add(cell.RowIndex, cell);
+                    sheet.OnReadCell(cell);
+                }
+            }
+
+            _stylesSource = ((XSSFWorkbook)sheet.Workbook).GetStylesSource();
+        }
+        #endregion
+
+        #region Public methods
+        /// <summary>
+        /// Use this to create new cells within the column and return it. The 
+        /// cell that is returned is a <see cref="CellType.Blank"/>. The type 
+        /// can be Changed either through calling 
+        /// <see cref="ICell.SetCellValue"/> or <see cref="ICell.SetCellType"/>.
+        /// </summary>
+        /// <param name="rowIndex">the row number this cell represents</param>
+        /// <returns>a high level representation of the Created cell</returns>
+        /// <exception cref="ArgumentOutOfRangeException">if columnIndex is 
+        /// less than 0 or greater than 16384, the maximum number of columns 
+        /// supported by the SpreadsheetML format(.xlsx)</exception>
+        public ICell CreateCell(int rowIndex)
+        {
+            return CreateCell(rowIndex, CellType.Blank);
+        }
+
+        /// <summary>
+        /// Use this to create new cells within the column and return it.
+        /// </summary>
+        /// <param name="rowIndex">the row number this cell represents</param>
+        /// <param name="type">the cell's data type</param>
+        /// <returns>a high level representation of the Created cell.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">if columnIndex is 
+        /// less than 0 or greater than 16384, the maximum number of columns 
+        /// supported by the SpreadsheetML format(.xlsx)</exception>
+        public ICell CreateCell(int rowIndex, CellType type)
+        {
+            if (rowIndex > SpreadsheetVersion.EXCEL2007.LastRowIndex ||
+                rowIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    "Row index should be between 0 and " +
+                    SpreadsheetVersion.EXCEL2007.LastRowIndex + ". Input was " +
+                    rowIndex);
+            }
+
+            ValidateCellType(type);
+
+            IRow row = Sheet.GetRow(rowIndex) ?? Sheet.CreateRow(rowIndex);
+            ICell newCell = row.CreateCell(ColumnNum, type);
+
+            if (IsFormatted)
+            {
+                newCell.CellStyle = ColumnStyle;
+            }
+
+            _cells[rowIndex] = newCell;
+            return newCell;
+        }
+
+        /// <summary>
+        /// Returns the cell at the given (0 based) index,
+        /// with the <see cref="MissingCellPolicy"/> from the parent Workbook.
+        /// </summary>
+        /// <param name="cellNum"></param>
+        /// <returns>the cell at the given (0 based) index</returns>
+        public ICell GetCell(int cellNum)
+        {
+            return GetCell(cellNum, _sheet.Workbook.MissingCellPolicy);
+        }
+
+        /// <summary>
+        /// Returns the cell at the given (0 based) index, with the specified 
+        /// <see cref="MissingCellPolicy"/>
+        /// </summary>
+        /// <param name="cellNum"></param>
+        /// <param name="policy"></param>
+        /// <returns>the cell at the given (0 based) index</returns>
+        /// <exception cref="ArgumentException">if cellnum is less than 0 or 
+        /// the specified MissingCellPolicy is invalid</exception>
+        public ICell GetCell(int cellNum, MissingCellPolicy policy)
+        {
+            if (cellNum < 0 || cellNum > SpreadsheetVersion.EXCEL2007.LastRowIndex)
+            {
+                throw new ArgumentOutOfRangeException(
+                    "Cell number should be between 0 and " +
+                    SpreadsheetVersion.EXCEL2007.LastRowIndex + ". Input was " +
+                    cellNum);
+            }
+
+            XSSFCell cell = (XSSFCell)RetrieveCell(cellNum);
+
+            switch (policy)
+            {
+                case MissingCellPolicy.RETURN_NULL_AND_BLANK:
+                    return cell;
+                case MissingCellPolicy.RETURN_BLANK_AS_NULL:
+                    bool isBlank = cell != null && cell.CellType == CellType.Blank;
+                    return isBlank ? null : cell;
+                case MissingCellPolicy.CREATE_NULL_AS_BLANK:
+                    return cell ?? CreateCell(cellNum, CellType.Blank);
+                default:
+                    throw new ArgumentException("Illegal policy " + policy + " (" + policy + ")");
+            }
+        }
+
+        /// <summary>
+        /// Remove the Cell from this column.
+        /// </summary>
+        /// <param name="cell">the cell to remove</param>
+        /// <exception cref="ArgumentException"></exception>
+        public void RemoveCell(ICell cell)
+        {
+            if (cell == null)
+            {
+                throw new ArgumentException("Cell can not be null");
+            }
+
+            if (cell.ColumnIndex != ColumnNum)
+            {
+                throw new ArgumentException("Specified cell does not belong " +
+                    "to this column");
+            }
+
+            IRow row = _sheet.GetRow(cell.RowIndex);
+
+            row.RemoveCell(cell);
+        }
+
+        /// <summary>
+        /// Copy the cells from srcColumn to this column If this column is not 
+        /// a blank column, this will merge the two columns, overwriting the 
+        /// cells in this column with the cells in srcColumn If srcColumn is 
+        /// null, overwrite cells in destination column with blank values, 
+        /// styles, etc per cell copy policy srcColumn may be from a different 
+        /// sheet in the same workbook
+        /// </summary>
+        /// <param name="srcColumn">the column to copy from</param>
+        /// <param name="policy">the policy to determine what gets copied</param>
+        public void CopyColumnFrom(IColumn srcColumn, CellCopyPolicy policy)
+        {
+            if (srcColumn == null)
+            {
+                // srcColumn is blank. Overwrite cells with blank values,
+                // blank styles, etc per cell copy policy
+                foreach (ICell destCell in this)
+                {
+                    XSSFCell srcCell = null;
+
+                    ((XSSFCell)destCell).CopyCellFrom(srcCell, policy);
+                }
+
+                if (policy.IsCopyMergedRegions)
+                {
+                    // Remove MergedRegions in dest column
+                    int destColumnNum = ColumnNum;
+                    int index = 0;
+                    HashSet<int> indices = new HashSet<int>();
+                    foreach (CellRangeAddress destRegion in Sheet.MergedRegions)
+                    {
+                        if (destColumnNum == destRegion.FirstColumn
+                            && destColumnNum == destRegion.LastColumn)
+                        {
+                            indices.Add(index);
+                        }
+
+                        index++;
+                    }
+
+                    (Sheet as XSSFSheet).RemoveMergedRegions(indices.ToList());
+                }
+
+                if (policy.IsCopyColumnWidth)
+                {
+                    // clear row height
+                    Width = -1;
+                }
+            }
+            else
+            {
+                foreach (ICell c in srcColumn)
+                {
+                    XSSFCell srcCell = (XSSFCell)c;
+                    XSSFCell destCell =
+                        CreateCell(srcCell.RowIndex, srcCell.CellType) as XSSFCell;
+                    destCell.CopyCellFrom(srcCell, policy);
+                }
+
+                XSSFColumnShifter columnShifter = new XSSFColumnShifter(_sheet);
+                int sheetIndex = _sheet.Workbook.GetSheetIndex(_sheet);
+                string sheetName = _sheet.Workbook.GetSheetName(sheetIndex);
+                int srcColumnNum = srcColumn.ColumnNum;
+                int destColumnNum = ColumnNum;
+                int columnDifference = destColumnNum - srcColumnNum;
+                FormulaShifter shifter = FormulaShifter.CreateForColumnCopy(
+                    sheetIndex,
+                    sheetName,
+                    srcColumnNum,
+                    srcColumnNum,
+                    columnDifference,
+                    SpreadsheetVersion.EXCEL2007);
+                columnShifter.UpdateColumnFormulas(this, shifter);
+
+                if (policy.IsCopyMergedRegions)
+                {
+                    foreach (CellRangeAddress srcRegion in srcColumn.Sheet.MergedRegions)
+                    {
+                        if (srcColumnNum == srcRegion.FirstColumn
+                            && srcColumnNum == srcRegion.LastColumn)
+                        {
+                            CellRangeAddress destRegion = srcRegion.Copy();
+                            destRegion.FirstColumn = destColumnNum;
+                            destRegion.LastColumn = destColumnNum;
+                            Sheet.AddMergedRegion(destRegion);
+                        }
+                    }
+                }
+
+                if (policy.IsCopyColumnWidth)
+                {
+                    Width = srcColumn.Width;
+                }
+            }
+        }
+
+        public void MoveCell(ICell cell, int newColumn)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IColumn CopyColumnTo(int targetIndex)
+        {
+            return Sheet.CopyColumn(ColumnNum, targetIndex);
+        }
+
+        public ICell CopyCell(int sourceIndex, int targetIndex)
+        {
+            return CellUtil.CopyCell(this, sourceIndex, targetIndex);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        /// <summary>
+        /// Returns the underlying CT_Col xml node Containing all cell 
+        /// defInitions in this column
+        /// </summary>
+        /// <returns>the underlying CT_Col xml node</returns>
+        public CT_Col GetCTCol()
+        {
+            return _column;
+        }
+        #endregion
+
+        #region Internal methods
+        /// <summary>
+        /// update cell references when Shifting columns
+        /// </summary>
+        /// <param name="n">n the number of columns to move</param>
+        internal void Shift(int n)
+        {
+            int columnNum = ColumnNum + n;
+            CalculationChain calcChain =
+                ((XSSFWorkbook)_sheet.Workbook).GetCalculationChain();
+            int sheetId = (int)_sheet.sheet.sheetId;
+            string msg = "Column[columnNum=" + ColumnNum + "] contains cell(s) " +
+                "included in a multi-cell array formula. You cannot change " +
+                "part of an array.";
+
+            foreach (ICell c in this)
+            {
+                XSSFCell cell = (XSSFCell)c;
+
+                if (cell.IsPartOfArrayFormulaGroup)
+                {
+                    cell.NotifyArrayFormulaChanging(msg);
+                }
+
+                //remove the reference in the calculation chain
+                if (calcChain != null)
+                {
+                    calcChain.RemoveItem(sheetId, cell.GetReference());
+                }
+
+                CT_Cell CT_Cell = cell.GetCTCell();
+                string r = new CellReference(cell.RowIndex, columnNum)
+                    .FormatAsString();
+                CT_Cell.r = r;
+                cell.ColumnIndex = columnNum;
+            }
+
+            ColumnNum = columnNum;
+        }
+
+        internal void RemoveCell(int cellIndex)
+        {
+            _cells.Remove(cellIndex);
+        }
+
+        /// <summary>
+        /// Fired when the document is written to an output stream.
+        /// See <see cref="XSSFSheet.Write"/>
+        /// </summary>
+        internal void OnDocumentWrite()
+        {
+
+        }
+        #endregion
+
+        #region IEnumerable and IComparable members
+        /// <summary>
+        /// Cell iterator over the physically defined cell
+        /// </summary>
+        /// <returns>an iterator over cells in this column.</returns>
+        public SortedDictionary<int, ICell>.ValueCollection.Enumerator CellIterator()
+        {
+            return _cells.Values.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Alias for <see cref="CellIterator"/> to allow  foreach loops
+        /// </summary>
+        /// <returns>an iterator over cells in this row.</returns>
+        public IEnumerator<ICell> GetEnumerator()
+        {
+            return CellIterator();
+        }
+
+        /// <summary>
+        /// Compares two <see cref="XSSFColumn"/> objects. Two columns are 
+        /// equal if they belong to the same worksheet and their column indexes
+        /// are equal.
+        /// </summary>
+        /// <param name="other">the <see cref="XSSFColumn"/> to be compared.</param>
+        /// <returns>
+        /// the value 0 if the column number of this <see cref="XSSFColumn"/> 
+        /// is equal to the column number of the argument <see cref="XSSFColumn"/> 
+        /// a value less than 0 if the column number of this this 
+        /// <see cref="XSSFColumn"/> is numerically less than the column number
+        /// of the argument <see cref="XSSFColumn"/> a value greater than 0 if
+        /// the column number of this this <see cref="XSSFColumn"/> is 
+        /// numerically greater than the column number of the 
+        /// argument <see cref="XSSFColumn"/>
+        /// </returns>
+        /// <exception cref="ArgumentException">if the argument column belongs 
+        /// to a different worksheet</exception>
+        public int CompareTo(XSSFColumn other)
+        {
+            if (Sheet != other.Sheet)
+            {
+                throw new ArgumentException(
+                    "The compared columns must belong to the same sheet");
+            }
+
+            return ColumnNum.CompareTo(other.ColumnNum);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is XSSFColumn other)
+            {
+                return (ColumnNum == other.ColumnNum) &&
+                       (Sheet == other.Sheet);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return _column.GetHashCode();
+        }
+        #endregion
+
+        #region Private methods
+        /// <summary>
+        /// formatted xml representation of this column
+        /// </summary>
+        /// <returns>formatted xml representation of this column</returns>
+        public override string ToString()
+        {
+            return _column.ToString();
+        }
+
+        private void ValidateCellType(CellType cellType)
+        {
+            switch (cellType)
+            {
+                case CellType.Blank:
+                case CellType.Numeric:
+                case CellType.String:
+                case CellType.Formula:
+                case CellType.Boolean:
+                case CellType.Error:
+                    break;
+                default:
+                    throw new ArgumentException("Illegal cell type: " + cellType);
+            }
+        }
+
+        /// <summary>
+        /// Get the xssfcell representing a given column (logical cell)
+        /// 0-based. If you ask for a cell that is not defined, then
+        /// you Get a null.
+        /// This is the basic call, with no policies applied
+        /// </summary>
+        /// <param name="cellnum">0 based row number</param>
+        /// <returns>Cell representing that row or null if Undefined.</returns>
+        private ICell RetrieveCell(int cellnum)
+        {
+            if (!_cells.ContainsKey(cellnum))
+            {
+                if (!CheckRowForCell(cellnum))
+                {
+                    return null;
+                }
+            }
+
+            return _cells[cellnum];
+        }
+
+        private bool CheckRowForCell(int cellnum)
+        {
+            IRow row = Sheet.GetRow(cellnum);
+
+            if (row == null)
+            {
+                return false;
+            }
+
+            ICell cell = row.GetCell(ColumnNum);
+
+            if (cell == null)
+            {
+                return false;
+            }
+
+            _cells[cellnum] = cell;
+
+            return true;
+        }
+
+        private int GetFirstKey()
+        {
+            return _cells.Keys.Min();
+        }
+
+        private int GetLastKey()
+        {
+            return _cells.Keys.Max();
+        }
+        #endregion
+    }
+}

--- a/ooxml/XSSF/UserModel/XSSFRow.cs
+++ b/ooxml/XSSF/UserModel/XSSFRow.cs
@@ -422,8 +422,6 @@ namespace NPOI.XSSF.UserModel
             }
 
             _cells.Remove(cell.ColumnIndex);
-
-            CheckColumnAndRemove(cell.ColumnIndex, cell.RowIndex);
         }
 
         /// <summary>
@@ -780,18 +778,6 @@ namespace NPOI.XSSF.UserModel
         public override string ToString()
         {
             return _row.ToString();
-        }
-
-        private void CheckColumnAndRemove(int columnIndex, int rowIndex)
-        {
-            XSSFColumn column = (XSSFColumn)((XSSFSheet)Sheet).GetColumn(columnIndex);
-
-            if (column == null)
-            {
-                return;
-            }
-
-            column.RemoveCell(rowIndex);
         }
 
         /// <summary>

--- a/ooxml/XSSF/UserModel/XSSFRow.cs
+++ b/ooxml/XSSF/UserModel/XSSFRow.cs
@@ -236,8 +236,8 @@ namespace NPOI.XSSF.UserModel
                     return _stylesSource.GetStyleAt((int)_row.s);
                 }
 
-                    return null;
-                }
+                return null;
+            }
 
             set
             {
@@ -422,6 +422,8 @@ namespace NPOI.XSSF.UserModel
             }
 
             _cells.Remove(cell.ColumnIndex);
+
+            CheckColumnAndRemove(cell.ColumnIndex, cell.RowIndex);
         }
 
         /// <summary>
@@ -778,6 +780,18 @@ namespace NPOI.XSSF.UserModel
         public override string ToString()
         {
             return _row.ToString();
+        }
+
+        private void CheckColumnAndRemove(int columnIndex, int rowIndex)
+        {
+            XSSFColumn column = (XSSFColumn)((XSSFSheet)Sheet).GetColumn(columnIndex);
+
+            if (column == null)
+            {
+                return;
+            }
+
+            column.RemoveCell(rowIndex);
         }
 
         /// <summary>

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -2152,7 +2152,7 @@ namespace NPOI.XSSF.UserModel
             double width = (col == null)
                 ? DefaultColumnWidth
                 : col.Width;
-            return (int)(width * 256);
+            return Math.Round(width * 256, 2);
         }
 
         /// <summary>

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -5088,23 +5088,17 @@ namespace NPOI.XSSF.UserModel
                 throw new RuntimeException("There is no columns in XML part");
             }
 
-            for (int i = startColumn + n; i <= endColumn + n; i++)
-            {
-                _ = GetColumn(i) ?? CreateColumn(i);
-            }
-
             List<IColumn> columnsToRemove = new List<IColumn>();
 
             // first remove all columns which will be overwritten
-            foreach (KeyValuePair<int, XSSFColumn> columnDict in _columns)
+            for (int i = startColumn + n; i <= endColumn + n; i++)
             {
-                XSSFColumn column = columnDict.Value;
-                int columnNum = column.ColumnNum;
-
                 // check if we should remove this column as it will be overwritten
                 // by the data later
-                if (ShouldRemoveAtIndex(startColumn, endColumn, n, columnNum))
+                if (ShouldRemoveAtIndex(startColumn, endColumn, n, i))
                 {
+                    IColumn column = GetColumn(i, true);
+
                     columnsToRemove.Add(column);
                 }
             }

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -1606,6 +1606,11 @@ namespace NPOI.XSSF.UserModel
                 }
             }
         }
+
+        IEnumerator<IRow> IEnumerable<IRow>.GetEnumerator()
+        {
+            return _rows.Values.GetEnumerator();
+        }
         #endregion
 
         #region Public methods

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -5310,7 +5310,11 @@ namespace NPOI.XSSF.UserModel
                 }
             }
 
-            foreach (KeyValuePair<int, XSSFColumn> columnDict in _columns)
+            var sortedColumns = n < 0
+                ? new SortedDictionary<int, XSSFColumn>(_columns)
+                : new SortedDictionary<int, XSSFColumn>(_columns).Reverse();
+
+            foreach (KeyValuePair<int, XSSFColumn> columnDict in sortedColumns)
             {
                 XSSFColumn column = columnDict.Value;
                 int columnNum = column.ColumnNum;

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -2660,6 +2660,18 @@ namespace NPOI.XSSF.UserModel
                 }
             }
 
+            if (hyperlinks != null)
+            {
+                foreach (XSSFHyperlink link in new List<XSSFHyperlink>(hyperlinks))
+                {
+                    CellReference ref1 = new CellReference(link.CellRef);
+                    if (ref1.Col == column.ColumnNum)
+                    {
+                        hyperlinks.Remove(link);
+                    }
+                }
+            }
+
             DestroyColumn(column);
         }
 
@@ -5076,10 +5088,13 @@ namespace NPOI.XSSF.UserModel
                 throw new RuntimeException("There is no columns in XML part");
             }
 
-            XSSFVMLDrawing vml = GetVMLDrawing(false);
-            List<int> columnsToRemove = new List<int>();
-            List<CellAddress> commentsToRemove = new List<CellAddress>();
-            List<CT_Col> ctColsToRemove = new List<CT_Col>();
+            for (int i = startColumn + n; i <= endColumn + n; i++)
+            {
+                _ = GetColumn(i) ?? CreateColumn(i);
+            }
+
+            List<IColumn> columnsToRemove = new List<IColumn>();
+
             // first remove all columns which will be overwritten
             foreach (KeyValuePair<int, XSSFColumn> columnDict in _columns)
             {
@@ -5090,56 +5105,14 @@ namespace NPOI.XSSF.UserModel
                 // by the data later
                 if (ShouldRemoveAtIndex(startColumn, endColumn, n, columnNum))
                 {
-                    int idx = _columns.IndexOfValue(column);
-                    ctColsToRemove.Add(worksheet.cols.FirstOrDefault().GetColArray(idx));
-
-                    // remove column from _columns
-                    columnsToRemove.Add(columnDict.Key);
-
-                    commentsToRemove.Clear();
-
-                    if (sheetComments != null)
-                    {
-                        CT_CommentList lst = sheetComments.GetCTComments().commentList;
-                        foreach (CT_Comment comment in lst.comment)
-                        {
-                            string strRef = comment.@ref;
-                            CellAddress ref1 = new CellAddress(strRef);
-
-                            // is this comment part of the current column?
-                            if (ref1.Column == columnNum)
-                            {
-                                commentsToRemove.Add(ref1);
-                            }
-                        }
-                    }
-
-                    foreach (CellAddress ref1 in commentsToRemove)
-                    {
-                        sheetComments.RemoveComment(ref1);
-                        vml.RemoveCommentShape(ref1.Row, ref1.Column);
-                    }
-
-                    if (hyperlinks != null)
-                    {
-                        foreach (XSSFHyperlink link in new List<XSSFHyperlink>(hyperlinks))
-                        {
-                            CellReference ref1 = new CellReference(link.CellRef);
-                            if (ref1.Col == columnNum)
-                            {
-                                hyperlinks.Remove(link);
-                            }
-                        }
-                    }
+                    columnsToRemove.Add(column);
                 }
             }
 
-            foreach (int columnKey in columnsToRemove)
+            foreach (IColumn column in columnsToRemove)
             {
-                _columns.Remove(columnKey);
+                RemoveColumn(column);
             }
-
-            worksheet.cols.FirstOrDefault().RemoveCols(ctColsToRemove);
         }
 
         private void RebuildRows()

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -4477,7 +4477,7 @@ namespace NPOI.XSSF.UserModel
                 : worksheet.AddNewMergeCells();
             CT_MergeCell ctMergeCell = ctMergeCells.AddNewMergeCell();
             ctMergeCell.@ref = region.FormatAsString();
-            return ctMergeCells.sizeOfMergeCellArray();
+            return ctMergeCells.sizeOfMergeCellArray() - 1;
         }
 
         /// <summary>

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -3920,6 +3920,55 @@ namespace NPOI.XSSF.UserModel
             return newColumn;
         }
 
+        /// <summary>
+        /// This method will destroy the List <see cref="IColumn"/> object
+        /// without affecting the cells, formulas, styles, etc contained in the
+        /// sheet. It isuseful for when you've just created an IColumn to do
+        /// some manipulation on and don't need it anymore, and don't want to
+        /// leave it around in the sheet.</summary>
+        /// <param name="column"><see cref="IColumn"/> to destroy</param>
+        /// <exception cref="ArgumentException">If <paramref name="column"/> is
+        /// null or if it doesn't belong to this <see cref="XSSFSheet"/></exception>
+        public void DestroyColumns(List<IColumn> columnsToDestroy)
+        {
+            foreach (IColumn column in columnsToDestroy)
+            {
+                DestroyColumn(column);
+            }
+        }
+
+        /// <summary>
+        /// This method will destroy the <see cref="IColumn"/> object without
+        /// affecting the cells, formulas, styles, etc contained in the sheet.
+        /// It isuseful for when you've just created an IColumn to do some
+        /// manipulation on and don't need it anymore, and don't want to leave
+        /// it around in the sheet.
+        /// </summary>
+        /// <param name="column"><see cref="IColumn"/> to destroy</param>
+        /// <exception cref="ArgumentException">If <paramref name="column"/> is
+        /// null or if it doesn't belong to this <see cref="XSSFSheet"/></exception>
+        public void DestroyColumn(IColumn column)
+        {
+            if (column == null)
+            {
+                throw new ArgumentException("Column can't be null");
+            }
+
+            if (column.Sheet != this)
+            {
+                throw new ArgumentException("Specified column does not belong to" +
+                    " this sheet");
+            }
+
+            _columns.Remove(column.ColumnNum);
+
+            CT_Cols ctCols = worksheet.cols.FirstOrDefault();
+            CT_Col ctCol = ((XSSFColumn)column).GetCTCol();
+            int colIndex = GetIndexOfColumn(ctCols, ctCol);
+
+            ctCols.RemoveCol(colIndex); // Note that columns in worksheet.sheetData is 1-based.
+        }
+
         public void ShowInPane(int toprow, int leftcol)
         {
             CellReference cellReference = new CellReference(toprow, leftcol);
@@ -5333,36 +5382,6 @@ namespace NPOI.XSSF.UserModel
             RebuildColumns();
             RebuildRowCells();
             DestroyColumns(columnsToDestroy);
-        }
-
-        private void DestroyColumns(List<IColumn> columnsToDestroy)
-        {
-            foreach (IColumn column in columnsToDestroy)
-            {
-                DestroyColumn(column);
-            }
-        }
-
-        private void DestroyColumn(IColumn column)
-        {
-            if (column == null)
-            {
-                throw new ArgumentException("Column can't be null");
-            }
-
-            if (column.Sheet != this)
-            {
-                throw new ArgumentException("Specified column does not belong to" +
-                    " this sheet");
-            }
-
-            _columns.Remove(column.ColumnNum);
-
-            CT_Cols ctCols = worksheet.cols.FirstOrDefault();
-            CT_Col ctCol = ((XSSFColumn)column).GetCTCol();
-            int colIndex = GetIndexOfColumn(ctCols, ctCol);
-
-            ctCols.RemoveCol(colIndex); // Note that columns in worksheet.sheetData is 1-based.
         }
 
         private int GetIndexOfColumn(CT_Cols ctCols, CT_Col ctCol)

--- a/testcases/main/HSSF/Extractor/TestOldExcelExtractor.cs
+++ b/testcases/main/HSSF/Extractor/TestOldExcelExtractor.cs
@@ -27,6 +27,7 @@ namespace TestCases.HSSF.Extractor
     using NPOI.POIFS.FileSystem;
     using NPOI.Util;
     using System.Text;
+    using System.Threading;
 
     /**
      * Unit tests for the Excel 5/95 and Excel 4 (and older) text 
@@ -40,6 +41,11 @@ namespace TestCases.HSSF.Extractor
             FileInfo file = HSSFTestDataSamples.GetSampleFile(sampleFileName);
 
             return new OldExcelExtractor(file);
+        }
+
+        public TestOldExcelExtractor()
+        {
+            Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
         }
 
         [Test]

--- a/testcases/main/SS/Formula/Atp/TestNetworkdaysFunction.cs
+++ b/testcases/main/SS/Formula/Atp/TestNetworkdaysFunction.cs
@@ -47,6 +47,12 @@ namespace TestCases.SS.Formula.Atp
         private static String THIRD_HOLIDAY = formatter.Format(new DateTime(2009, JANUARY, 21), CultureInfo.CurrentCulture);
 
         private static OperationEvaluationContext EC = new OperationEvaluationContext(null, null, 1, 1, 1, null);
+
+        public TestNetworkdaysFunction()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
+        }
+
         [Test]
         public void TestFailWhenNoArguments()
         {

--- a/testcases/main/SS/Formula/Functions/TestBesselJ.cs
+++ b/testcases/main/SS/Formula/Functions/TestBesselJ.cs
@@ -24,6 +24,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestNumError()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmNumError("22.5", "-40");
         }
 
@@ -31,6 +32,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestMicrosoftExample1()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             HSSFWorkbook wb = new HSSFWorkbook();
             ISheet sheet = wb.CreateSheet();
             IRow row = sheet.CreateRow(0);

--- a/testcases/main/SS/Formula/Functions/TestComplex.cs
+++ b/testcases/main/SS/Formula/Functions/TestComplex.cs
@@ -52,6 +52,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestBasic()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             ConfirmValue("Complex number with 3 and 4 as the real and imaginary coefficients (3 + 4i)", "3", "4", "", "3+4i");
             ConfirmValue("Complex number with 3 and 4 as the real and imaginary coefficients, and j as the suffix (3 + 4j)", "3", "4", "j", "3+4j");
 

--- a/testcases/main/SS/Formula/Functions/TestDec2Bin.cs
+++ b/testcases/main/SS/Formula/Functions/TestDec2Bin.cs
@@ -33,6 +33,10 @@ namespace TestCases.SS.Formula.Functions
     [TestFixture]
     public class TestDec2Bin
     {
+        public TestDec2Bin()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
+        }
 
         private static ValueEval invokeValue(String number1)
         {

--- a/testcases/main/SS/Formula/Functions/TestDec2Hex.cs
+++ b/testcases/main/SS/Formula/Functions/TestDec2Hex.cs
@@ -33,6 +33,10 @@ namespace TestCases.SS.Formula.Functions
     [TestFixture]
     public class TestDec2Hex
     {
+        public TestDec2Hex()
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
+        }
 
         private static ValueEval invokeValue(String number1, String number2)
         {

--- a/testcases/main/SS/Formula/Functions/TestDelta.cs
+++ b/testcases/main/SS/Formula/Functions/TestDelta.cs
@@ -52,6 +52,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestBasic()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             ConfirmValue("5", "4", 0); // Checks whether 5 Equals 4 (0)
             ConfirmValue("5", "5", 1); // Checks whether 5 Equals 5 (1)
 

--- a/testcases/main/SS/Formula/Functions/TestDollarDe.cs
+++ b/testcases/main/SS/Formula/Functions/TestDollarDe.cs
@@ -23,12 +23,14 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestNumError()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmNumError("22.5", "-40");
         }
 
         [Test]
         public void TestDiv0()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmDiv0("22.5", "0");
             confirmDiv0("22.5", "0.9");
             confirmDiv0("22.5", "-0.9");
@@ -38,6 +40,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestMicrosoftExample1()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             HSSFWorkbook wb = new HSSFWorkbook();
             var sheet = wb.CreateSheet();
             var row = sheet.CreateRow(0);

--- a/testcases/main/SS/Formula/Functions/TestDollarFr.cs
+++ b/testcases/main/SS/Formula/Functions/TestDollarFr.cs
@@ -23,12 +23,14 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestNumError()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmNumError("22.5", "-40");
         }
 
         [Test]
         public void TestDiv0()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmDiv0("22.5", "0");
             confirmDiv0("22.5", "0.9");
             confirmDiv0("22.5", "-0.9");
@@ -38,6 +40,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestMicrosoftExample1()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             HSSFWorkbook wb = new HSSFWorkbook();
             var sheet = wb.CreateSheet();
             var row = sheet.CreateRow(0);

--- a/testcases/main/SS/Formula/Functions/TestFixed.cs
+++ b/testcases/main/SS/Formula/Functions/TestFixed.cs
@@ -51,6 +51,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestValid()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             // thousands separator
             Confirm("FIXED(1234.56789,2,TRUE)", "1234.57");
             Confirm("FIXED(1234.56789,2,FALSE)", "1,234.57");
@@ -88,6 +89,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestOptionalParams()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             Fixed fixedFunc = new Fixed();
             ValueEval Evaluate = fixedFunc.Evaluate(0, 0, new NumberEval(1234.56789));
             Assert.IsTrue(Evaluate is StringEval);

--- a/testcases/main/SS/Formula/Functions/TestNormDist.cs
+++ b/testcases/main/SS/Formula/Functions/TestNormDist.cs
@@ -17,6 +17,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestBasic()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmValue("42", "40", "1.5", true, 0.908788780274132);
             confirmValue("42", "40", "1.5", false, 0.109340049783996);
         }
@@ -29,6 +30,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestNumError()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmNumError("42", "40", "0", false);
             confirmNumError("42", "40", "0", true);
             confirmNumError("42", "40", "-0.1", false);
@@ -40,6 +42,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestMicrosoftExample1()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             HSSFWorkbook wb = new HSSFWorkbook();
             ISheet sheet = wb.CreateSheet();
             SS.Util.Utils.AddRow(sheet, 0, "Data", "Description");

--- a/testcases/main/SS/Formula/Functions/TestNormInv.cs
+++ b/testcases/main/SS/Formula/Functions/TestNormInv.cs
@@ -18,6 +18,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestBasic()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmValue("0.908789", "40", "1.5", 42.000002);
         }
 
@@ -30,6 +31,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestNumError()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmNumError("0.5", "40", "0");
             confirmNumError("0.5", "40", "-0.1");
             confirmNumError("-0.5", "40", "0.1");
@@ -42,6 +44,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestMicrosoftExample1()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             HSSFWorkbook wb = new HSSFWorkbook();
             ISheet sheet = wb.CreateSheet();
             SS.Util.Utils.AddRow(sheet, 0, "Data", "Description");

--- a/testcases/main/SS/Formula/Functions/TestNormSDist.cs
+++ b/testcases/main/SS/Formula/Functions/TestNormSDist.cs
@@ -17,6 +17,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestBasic()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmValue("1.333333", 0.908788726);
         }
 
@@ -28,6 +29,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestMicrosoftExample1()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             HSSFWorkbook wb = new HSSFWorkbook();
             ISheet sheet = wb.CreateSheet();
             IRow row = sheet.CreateRow(0);

--- a/testcases/main/SS/Formula/Functions/TestNormSInv.cs
+++ b/testcases/main/SS/Formula/Functions/TestNormSInv.cs
@@ -17,6 +17,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestBasic()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmValue("0.9088", 1.3334);
         }
 

--- a/testcases/main/SS/Formula/Functions/TestNormSInv.cs
+++ b/testcases/main/SS/Formula/Functions/TestNormSInv.cs
@@ -29,6 +29,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestNumError()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmNumError("0");
             confirmNumError("-0.5");
             confirmNumError("1");
@@ -37,6 +38,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestMicrosoftExample1()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             HSSFWorkbook wb = new HSSFWorkbook();
             ISheet sheet = wb.CreateSheet();
             IRow row = sheet.CreateRow(0);

--- a/testcases/main/SS/Formula/Functions/TestNumberValue.cs
+++ b/testcases/main/SS/Formula/Functions/TestNumberValue.cs
@@ -12,6 +12,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestMicrosoftExample1()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             HSSFWorkbook wb = new HSSFWorkbook();
             var sheet = wb.CreateSheet();
             var row = sheet.CreateRow(0);
@@ -23,6 +24,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestMicrosoftExample2()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             HSSFWorkbook wb = new HSSFWorkbook();
             var sheet = wb.CreateSheet();
             var row = sheet.CreateRow(0);

--- a/testcases/main/SS/Formula/Functions/TestNumericFunction.cs
+++ b/testcases/main/SS/Formula/Functions/TestNumericFunction.cs
@@ -41,6 +41,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestDOLLAR()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             HSSFWorkbook wb = new HSSFWorkbook();
             ICell cell = wb.CreateSheet().CreateRow(0).CreateCell(0);
             HSSFFormulaEvaluator fe = new HSSFFormulaEvaluator(wb);

--- a/testcases/main/SS/Formula/Functions/TestQuotient.cs
+++ b/testcases/main/SS/Formula/Functions/TestQuotient.cs
@@ -54,6 +54,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestBasic()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             ConfirmValue("int portion of 5/2 (2)", "5", "2", "2");
             ConfirmValue("int portion of 4.5/3.1 (1)", "4.5", "3.1", "1");
 
@@ -65,6 +66,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestErrors()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             ConfirmValueError("numerator is nonnumeric", "ABCD", "", ErrorEval.VALUE_INVALID);
             ConfirmValueError("denominator is nonnumeric", "", "ABCD", ErrorEval.VALUE_INVALID);
 

--- a/testcases/main/SS/Formula/Functions/TestStandardize.cs
+++ b/testcases/main/SS/Formula/Functions/TestStandardize.cs
@@ -17,6 +17,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestBasic()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmValue("42", "40", "1.5", 1.33333333);
         }
 
@@ -29,6 +30,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestNumError()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmNumError("42", "40", "0");
             confirmNumError("42", "40", "-0.1");
         }
@@ -36,6 +38,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestMicrosoftExample1()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             HSSFWorkbook wb = new HSSFWorkbook();
             ISheet sheet = wb.CreateSheet();
             SS.Util.Utils.AddRow(sheet, 0, "Data", "Description");

--- a/testcases/main/SS/Formula/Functions/TestTDist.cs
+++ b/testcases/main/SS/Formula/Functions/TestTDist.cs
@@ -16,6 +16,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestBasic()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmValue("5.968191467", "8", "1", 0.00016754180265310392);
             confirmValue("5.968191467", "8", "2", 0.00033508360530620784);
             confirmValue("5.968191467", "8.2", "2.2", 0.00033508360530620784);
@@ -34,6 +35,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestNumError()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             confirmNumError("5.968191467", "8", "0");
             confirmNumError("-5.968191467", "8", "2");
         }
@@ -42,6 +44,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void testMicrosoftExample1()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             HSSFWorkbook wb = new HSSFWorkbook();
             ISheet sheet = wb.CreateSheet();
             SS.Util.Utils.AddRow(sheet, 0, "Data", "Description");

--- a/testcases/main/SS/Formula/Functions/TestText.cs
+++ b/testcases/main/SS/Formula/Functions/TestText.cs
@@ -47,6 +47,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestTextWithDeciamlFormatSecondArg()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             ValueEval numArg = new NumberEval(321321.321);
             ValueEval formatArg = new StringEval("#,###.00000");
             ValueEval[] args = { numArg, formatArg };
@@ -77,7 +78,7 @@ namespace TestCases.SS.Formula.Functions
         [Test]
         public void TestTextWithFractionFormatSecondArg()
         {
-
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             ValueEval numArg = new NumberEval(321.321);
             ValueEval formatArg = new StringEval("# #/#");
             ValueEval[] args = { numArg, formatArg };

--- a/testcases/main/SS/UserModel/TestFractionFormat.cs
+++ b/testcases/main/SS/UserModel/TestFractionFormat.cs
@@ -21,6 +21,8 @@ using TestCases.HSSF;
 using NUnit.Framework;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading;
+
 namespace TestCases.SS.UserModel
 {
 
@@ -34,6 +36,7 @@ namespace TestCases.SS.UserModel
         [Test]
         public void TestSingle()
         {
+            Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             FractionFormat f = new FractionFormat("", "##");
             string val = "321.321";
             String ret = f.Format(val);

--- a/testcases/main/Util/TestStringUtil.cs
+++ b/testcases/main/Util/TestStringUtil.cs
@@ -20,7 +20,7 @@ namespace TestCases.Util
 {
     using System;
     using System.Text;
-
+    using System.Threading;
     using NPOI.Util;
     using NUnit.Framework;
     /**
@@ -248,6 +248,7 @@ namespace TestCases.Util
         [Test]
         public void Join()
         {
+            Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             Assert.AreEqual("", StringUtil.Join(",")); // degenerate case: nothing to join
             Assert.AreEqual("abc", StringUtil.Join(",", "abc")); // degenerate case: one thing to join, no trailing comma
             Assert.AreEqual("abc|def|ghi", StringUtil.Join("|", "abc", "def", "ghi"));

--- a/testcases/ooxml/XSSF/Streaming/SheetDataWriterTests.cs
+++ b/testcases/ooxml/XSSF/Streaming/SheetDataWriterTests.cs
@@ -19,7 +19,9 @@ using NPOI.XSSF.Streaming;
 using NPOI.XSSF.UserModel;
 using NSubstitute;
 using NUnit.Framework;
+using System.Globalization;
 using System.IO;
+using System.Threading;
 
 namespace TestCases.XSSF.Streaming
 {
@@ -33,6 +35,7 @@ namespace TestCases.XSSF.Streaming
         [SetUp]
         public void Init()
         {
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
             var _xssfsheet = Substitute.For<XSSFSheet>();
             var _workbook = Substitute.For<SXSSFWorkbook>();
             var _sheet = Substitute.For<SXSSFSheet>(_workbook, _xssfsheet);
@@ -74,7 +77,7 @@ namespace TestCases.XSSF.Streaming
             var lines = File.ReadAllLines(_objectToTest.TemporaryFilePath());
 
             Assert.True(lines.Length == 2);
-            Assert.AreEqual("<row r=\"" + 1 + "\" customHeight=\"true\" ht=\"" + row.HeightInPoints + "\">", lines[0]);
+            Assert.AreEqual($"<row r=\"{1}\" customHeight=\"true\" ht=\"{row.HeightInPoints}\">", lines[0]);
             Assert.AreEqual("</row>", lines[1]);
 
 

--- a/testcases/ooxml/XSSF/UserModel/Helpers/TestColumnHelper.cs
+++ b/testcases/ooxml/XSSF/UserModel/Helpers/TestColumnHelper.cs
@@ -20,6 +20,7 @@ using NUnit.Framework;
 using NPOI.XSSF.Model;
 using NPOI.XSSF.UserModel.Helpers;
 using NPOI.XSSF.UserModel;
+using System;
 
 namespace TestCases.XSSF.UserModel.Helpers
 {
@@ -28,6 +29,7 @@ namespace TestCases.XSSF.UserModel.Helpers
      *
      */
     [TestFixture]
+    [Obsolete("Use XSSFColumn object for all things column")]
     public class TestColumnHelper
     {
         [Test]

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFColGrouping.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFColGrouping.cs
@@ -107,17 +107,14 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("test");
 
-            CT_Cols cols = sheet.GetCTWorksheet().GetColsArray(0);
-            CT_Col col = cols.AddNewCol();
-            col.min=(1 + 1);
-            col.max=(4 + 1);
-            col.width=(20);
-            col.customWidth=(true);
+            sheet.CreateColumn(1).Width = 20;
+            sheet.CreateColumn(2).Width = 20;
+            sheet.CreateColumn(3).Width = 20;
+            sheet.CreateColumn(4).Width = 20;
 
             sheet.GroupColumn((short)2, (short)3);
 
-            sheet.GetCTWorksheet().GetColsArray(0);
-            //logger.log(POILogger.DEBUG, "testMergingOverlappingCols_OVERLAPS_2_WRAPS/cols:" + cols);
+            CT_Cols cols = sheet.GetCTWorksheet().GetColsArray(0);
 
             Assert.AreEqual(0, cols.GetColArray(0).outlineLevel);
             Assert.AreEqual(2, cols.GetColArray(0).min); // 1 based
@@ -126,15 +123,20 @@ namespace TestCases.XSSF.UserModel
 
             Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
             Assert.AreEqual(3, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(4, cols.GetColArray(1).max); // 1 based        
+            Assert.AreEqual(3, cols.GetColArray(1).max); // 1 based        
             Assert.AreEqual(true, cols.GetColArray(1).customWidth);
 
-            Assert.AreEqual(0, cols.GetColArray(2).outlineLevel);
-            Assert.AreEqual(5, cols.GetColArray(2).min); // 1 based
-            Assert.AreEqual(5, cols.GetColArray(2).max); // 1 based
+            Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
+            Assert.AreEqual(4, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(4, cols.GetColArray(2).max); // 1 based        
             Assert.AreEqual(true, cols.GetColArray(2).customWidth);
 
-            Assert.AreEqual(3, cols.sizeOfColArray());
+            Assert.AreEqual(0, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(5, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(5, cols.GetColArray(3).max); // 1 based
+            Assert.AreEqual(true, cols.GetColArray(3).customWidth);
+
+            Assert.AreEqual(4, cols.sizeOfColArray());
 
             wb = XSSFTestDataSamples.WriteOutAndReadBack(wb, "testMergingOverlappingCols_OVERLAPS_2_WRAPS");
             sheet = (XSSFSheet)wb.GetSheet("test");
@@ -154,17 +156,13 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("test");
 
-            CT_Cols cols = sheet.GetCTWorksheet().GetColsArray(0);
-            CT_Col col = cols.AddNewCol();
-            col.min=(2 + 1);
-            col.max=(4 + 1);
-            col.width=(20);
-            col.customWidth=(true);
+            sheet.CreateColumn(2).Width = 20;
+            sheet.CreateColumn(3).Width = 20;
+            sheet.CreateColumn(4).Width = 20;
 
             sheet.GroupColumn((short)1, (short)5);
 
-            cols = sheet.GetCTWorksheet().GetColsArray(0);
-            //logger.log(POILogger.DEBUG, "testMergingOverlappingCols_OVERLAPS_1_WRAPS/cols:" + cols);
+            CT_Cols cols = sheet.GetCTWorksheet().GetColsArray(0);
 
             Assert.AreEqual(1, cols.GetColArray(0).outlineLevel);
             Assert.AreEqual(2, cols.GetColArray(0).min); // 1 based
@@ -173,15 +171,25 @@ namespace TestCases.XSSF.UserModel
 
             Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
             Assert.AreEqual(3, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(5, cols.GetColArray(1).max); // 1 based        
+            Assert.AreEqual(3, cols.GetColArray(1).max); // 1 based        
             Assert.AreEqual(true, cols.GetColArray(1).customWidth);
 
             Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
-            Assert.AreEqual(6, cols.GetColArray(2).min); // 1 based
-            Assert.AreEqual(6, cols.GetColArray(2).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(2).customWidth);
+            Assert.AreEqual(4, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(4, cols.GetColArray(2).max); // 1 based        
+            Assert.AreEqual(true, cols.GetColArray(2).customWidth);
 
-            Assert.AreEqual(3, cols.sizeOfColArray());
+            Assert.AreEqual(1, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(5, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(5, cols.GetColArray(3).max); // 1 based        
+            Assert.AreEqual(true, cols.GetColArray(3).customWidth);
+
+            Assert.AreEqual(1, cols.GetColArray(4).outlineLevel);
+            Assert.AreEqual(6, cols.GetColArray(4).min); // 1 based
+            Assert.AreEqual(6, cols.GetColArray(4).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(4).customWidth);
+
+            Assert.AreEqual(5, cols.sizeOfColArray());
 
             wb = XSSFTestDataSamples.WriteOutAndReadBack(wb, "testMergingOverlappingCols_OVERLAPS_1_WRAPS");
             sheet = (XSSFSheet)wb.GetSheet("test");
@@ -201,17 +209,13 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("test");
 
+            sheet.CreateColumn(2).Width = 20;
+            sheet.CreateColumn(3).Width = 20;
+            sheet.CreateColumn(4).Width = 20;
+
+            sheet.GroupColumn(3, 5);
+
             CT_Cols cols = sheet.GetCTWorksheet().GetColsArray(0);
-            CT_Col col = cols.AddNewCol();
-            col.min=(2 + 1);
-            col.max=(4 + 1);
-            col.width=(20);
-            col.customWidth=(true);
-
-            sheet.GroupColumn((short)3, (short)5);
-
-            cols = sheet.GetCTWorksheet().GetColsArray(0);
-            //logger.log(POILogger.DEBUG, "testMergingOverlappingCols_OVERLAPS_1_MINOR/cols:" + cols);
 
             Assert.AreEqual(0, cols.GetColArray(0).outlineLevel);
             Assert.AreEqual(3, cols.GetColArray(0).min); // 1 based
@@ -220,15 +224,20 @@ namespace TestCases.XSSF.UserModel
 
             Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
             Assert.AreEqual(4, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(5, cols.GetColArray(1).max); // 1 based        
+            Assert.AreEqual(4, cols.GetColArray(1).max); // 1 based        
             Assert.AreEqual(true, cols.GetColArray(1).customWidth);
 
             Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
-            Assert.AreEqual(6, cols.GetColArray(2).min); // 1 based
-            Assert.AreEqual(6, cols.GetColArray(2).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(2).customWidth);
+            Assert.AreEqual(5, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(5, cols.GetColArray(2).max); // 1 based        
+            Assert.AreEqual(true, cols.GetColArray(2).customWidth);
 
-            Assert.AreEqual(3, cols.sizeOfColArray());
+            Assert.AreEqual(1, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(6, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(6, cols.GetColArray(3).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(3).customWidth);
+
+            Assert.AreEqual(4, cols.sizeOfColArray());
 
             wb = XSSFTestDataSamples.WriteOutAndReadBack(wb, "testMergingOverlappingCols_OVERLAPS_1_MINOR");
             sheet = (XSSFSheet)wb.GetSheet("test");
@@ -249,14 +258,13 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("test");
 
-            CT_Cols cols = sheet.GetCTWorksheet().GetColsArray(0);
-            CT_Col col = cols.AddNewCol();
-            col.min=(2 + 1);
-            col.max=(4 + 1);
-            col.width=(20);
-            col.customWidth=(true);
+            sheet.CreateColumn(2).Width = 20;
+            sheet.CreateColumn(3).Width = 20;
+            sheet.CreateColumn(4).Width = 20;
 
-            sheet.GroupColumn((short)1, (short)3);
+            sheet.GroupColumn(1, 3);
+
+            CT_Cols cols = sheet.GetCTWorksheet().GetColsArray(0);
 
             cols = sheet.GetCTWorksheet().GetColsArray(0);
             //logger.log(POILogger.DEBUG, "testMergingOverlappingCols_OVERLAPS_2_MINOR/cols:" + cols);
@@ -268,15 +276,20 @@ namespace TestCases.XSSF.UserModel
 
             Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
             Assert.AreEqual(3, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(4, cols.GetColArray(1).max); // 1 based        
+            Assert.AreEqual(3, cols.GetColArray(1).max); // 1 based        
             Assert.AreEqual(true, cols.GetColArray(1).customWidth);
 
-            Assert.AreEqual(0, cols.GetColArray(2).outlineLevel);
-            Assert.AreEqual(5, cols.GetColArray(2).min); // 1 based
-            Assert.AreEqual(5, cols.GetColArray(2).max); // 1 based
+            Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
+            Assert.AreEqual(4, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(4, cols.GetColArray(2).max); // 1 based        
             Assert.AreEqual(true, cols.GetColArray(2).customWidth);
 
-            Assert.AreEqual(3, cols.sizeOfColArray());
+            Assert.AreEqual(0, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(5, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(5, cols.GetColArray(3).max); // 1 based
+            Assert.AreEqual(true, cols.GetColArray(3).customWidth);
+
+            Assert.AreEqual(4, cols.sizeOfColArray());
 
             wb = XSSFTestDataSamples.WriteOutAndReadBack(wb, "testMergingOverlappingCols_OVERLAPS_2_MINOR");
             sheet = (XSSFSheet)wb.GetSheet("test");

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFColumn.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFColumn.cs
@@ -1,0 +1,867 @@
+﻿/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for Additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+using NPOI.SS.UserModel;
+using NPOI.SS.Util;
+using NPOI.Util;
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace TestCases.XSSF.UserModel
+{
+    [TestFixture]
+    public class TestXSSFColumn
+    {
+        public TestXSSFColumn()
+        {
+
+        }
+
+        [Test]
+        public void Sheet_SheetIsNotNull()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            IColumn column = sheet.CreateColumn(columnIndex);
+
+            Assert.NotNull(column.Sheet);
+            Assert.AreEqual(column.Sheet, sheet);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn columnLoaded = sheetLoaded.GetColumn(columnIndex);
+
+            Assert.NotNull(columnLoaded.Sheet);
+            Assert.AreEqual(columnLoaded.Sheet, sheetLoaded);
+        }
+
+        [Test]
+        public void FirstCellNumTest()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            IColumn column1 = sheet.CreateColumn(columnIndex);
+            IColumn column2 = sheet.CreateColumn(columnIndex + 1);
+            int firstRowNum = 5;
+            int numOfCells = 10;
+
+            for (int i = 0; i < numOfCells; i++)
+            {
+                column2.CreateCell(firstRowNum + i);
+            }
+
+            for (int i = 0; i < numOfCells; i++)
+            {
+                column2.CreateCell(firstRowNum + 20 + i);
+            }
+
+            Assert.AreEqual(-1, column1.FirstCellNum);
+            Assert.AreEqual(firstRowNum, column2.FirstCellNum);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn column1Loaded = sheetLoaded.GetColumn(columnIndex);
+            IColumn column2Loaded = sheetLoaded.GetColumn(columnIndex + 1);
+
+            Assert.AreEqual(-1, column1Loaded.FirstCellNum);
+            Assert.AreEqual(firstRowNum, column2Loaded.FirstCellNum);
+        }
+
+        [Test]
+        public void LastCellNumTest()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            IColumn column1 = sheet.CreateColumn(columnIndex);
+            IColumn column2 = sheet.CreateColumn(columnIndex + 1);
+            int firstRowNum = 5;
+            int numOfCells = 10;
+
+            for (int i = 0; i < numOfCells; i++)
+            {
+                column2.CreateCell(firstRowNum + i);
+            }
+
+            for (int i = 0; i < numOfCells; i++)
+            {
+                column2.CreateCell(firstRowNum + 20 + i);
+            }
+
+            Assert.AreEqual(-1, column1.LastCellNum);
+            Assert.AreEqual(firstRowNum + 30, column2.LastCellNum);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn column1Loaded = sheetLoaded.GetColumn(columnIndex);
+            IColumn column2Loaded = sheetLoaded.GetColumn(columnIndex + 1);
+
+            Assert.AreEqual(-1, column1Loaded.LastCellNum);
+            Assert.AreEqual(firstRowNum + 30, column2Loaded.LastCellNum);
+        }
+
+        [Test]
+        public void WidthTest()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            IColumn column1 = sheet.CreateColumn(columnIndex);
+            IColumn column2 = sheet.CreateColumn(columnIndex + 1);
+            short width = 20;
+
+            column2.Width = width;
+
+            Assert.AreEqual(sheet.DefaultColumnWidth, column1.Width);
+            Assert.AreEqual(width, column2.Width);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn column1Loaded = sheetLoaded.GetColumn(columnIndex);
+            IColumn column2Loaded = sheetLoaded.GetColumn(columnIndex + 1);
+
+            Assert.AreEqual(sheetLoaded.DefaultColumnWidth, column1Loaded.Width);
+            Assert.AreEqual(width, column2Loaded.Width);
+        }
+
+        [Test]
+        public void PhysicalNumberOfCellsTest()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            IColumn column1 = sheet.CreateColumn(columnIndex);
+            IColumn column2 = sheet.CreateColumn(columnIndex + 1);
+            int firstRowNum = 5;
+            int numOfCells = 10;
+
+            for (int i = 0; i < numOfCells; i++)
+            {
+                column2.CreateCell(firstRowNum + i);
+            }
+
+            for (int i = 0; i < numOfCells; i++)
+            {
+                column2.CreateCell(firstRowNum + 20 + i);
+            }
+
+            column2.RemoveCell(
+                sheet.GetRow(firstRowNum).GetCell(column2.ColumnNum));
+
+            Assert.AreEqual(0, column1.PhysicalNumberOfCells);
+            Assert.AreEqual((numOfCells * 2) - 1, column2.PhysicalNumberOfCells);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn column1Loaded = sheetLoaded.GetColumn(columnIndex);
+            IColumn column2Loaded = sheetLoaded.GetColumn(columnIndex + 1);
+
+            Assert.AreEqual(0, column1Loaded.PhysicalNumberOfCells);
+            Assert.AreEqual((numOfCells * 2) - 1, column2Loaded.PhysicalNumberOfCells);
+        }
+
+        [Test]
+        public void ZeroWidthTest()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            IColumn column1 = sheet.CreateColumn(columnIndex);
+            IColumn column2 = sheet.CreateColumn(columnIndex + 1);
+            short width = 20;
+
+            column2.Width = width;
+            column2.ZeroWidth = true;
+
+            Assert.IsFalse(column1.ZeroWidth);
+            Assert.AreEqual(sheet.DefaultColumnWidth, column1.Width);
+            Assert.IsTrue(column2.ZeroWidth);
+            Assert.AreEqual(width, column2.Width);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn column1Loaded = sheetLoaded.GetColumn(columnIndex);
+            IColumn column2Loaded = sheetLoaded.GetColumn(columnIndex + 1);
+
+            Assert.IsFalse(column1Loaded.ZeroWidth);
+            Assert.AreEqual(sheetLoaded.DefaultColumnWidth, column1Loaded.Width);
+            Assert.IsTrue(column2Loaded.ZeroWidth);
+            Assert.AreEqual(width, column2Loaded.Width);
+        }
+
+        [Test]
+        public void ColumnStyleTest()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            IColumn column1 = sheet.CreateColumn(columnIndex);
+            IColumn column2 = sheet.CreateColumn(columnIndex + 1);
+            IColumn column3 = sheet.CreateColumn(columnIndex + 2);
+
+            ICellStyle cellStyle = wb.CreateCellStyle();
+            cellStyle.BorderLeft = BorderStyle.Double;
+
+            column2.ColumnStyle = cellStyle;
+            column3.ColumnStyle = cellStyle;
+
+            Assert.IsNull(column1.ColumnStyle);
+            Assert.AreEqual(BorderStyle.None, column1.CreateCell(1).CellStyle.BorderLeft);
+            Assert.IsNotNull(column2.ColumnStyle);
+            Assert.AreEqual(BorderStyle.Double, column2.ColumnStyle.BorderLeft);
+            Assert.AreEqual(BorderStyle.Double, column2.CreateCell(1).CellStyle.BorderLeft);
+            Assert.AreEqual(BorderStyle.Double, column3.ColumnStyle.BorderLeft);
+            Assert.AreEqual(BorderStyle.Double, column3.CreateCell(1).CellStyle.BorderLeft);
+
+            column3.ColumnStyle = null;
+
+            Assert.IsNull(column3.ColumnStyle);
+            Assert.AreEqual(BorderStyle.None, column3.Cells.FirstOrDefault().CellStyle.BorderLeft);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn column1Loaded = sheetLoaded.GetColumn(columnIndex);
+            IColumn column2Loaded = sheetLoaded.GetColumn(columnIndex + 1);
+            IColumn column3Loaded = sheetLoaded.GetColumn(columnIndex + 2);
+
+            Assert.IsNull(column1Loaded.ColumnStyle);
+            Assert.AreEqual(BorderStyle.None, column1Loaded.GetCell(1).CellStyle.BorderLeft);
+            Assert.IsNotNull(column2Loaded.ColumnStyle);
+            Assert.AreEqual(BorderStyle.Double, column2Loaded.ColumnStyle.BorderLeft);
+            Assert.AreEqual(BorderStyle.Double, column2Loaded.GetCell(1).CellStyle.BorderLeft);
+            Assert.IsNull(column3Loaded.ColumnStyle);
+            Assert.AreEqual(BorderStyle.None, column3Loaded.Cells.FirstOrDefault().CellStyle.BorderLeft);
+        }
+
+        [Test]
+        public void IsFormattedTest()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            IColumn column1 = sheet.CreateColumn(columnIndex);
+            IColumn column2 = sheet.CreateColumn(columnIndex + 1);
+
+            ICellStyle cellStyle = wb.CreateCellStyle();
+            cellStyle.BorderLeft = BorderStyle.Double;
+
+            column2.ColumnStyle = cellStyle;
+
+            Assert.IsFalse(column1.IsFormatted);
+            Assert.IsTrue(column2.IsFormatted);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn column1Loaded = sheetLoaded.GetColumn(columnIndex);
+            IColumn column2Loaded = sheetLoaded.GetColumn(columnIndex + 1);
+
+            Assert.IsFalse(column1Loaded.IsFormatted);
+            Assert.IsTrue(column2Loaded.IsFormatted);
+        }
+
+        [Test]
+        public void CreateCell_WithValidIndex_CellCreated()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            int rowIndex = 10;
+            IColumn column = sheet.CreateColumn(columnIndex);
+            ICell cell = column.CreateCell(rowIndex);
+
+            Assert.NotNull(cell);
+            Assert.AreEqual(CellType.Blank, cell.CellType);
+            Assert.NotNull(sheet.GetRow(rowIndex));
+            Assert.NotNull(sheet.GetRow(rowIndex).GetCell(columnIndex));
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            ICell cellLoaded = sheetLoaded.GetColumn(columnIndex).GetCell(rowIndex);
+
+            Assert.NotNull(cellLoaded);
+            Assert.AreEqual(CellType.Blank, cellLoaded.CellType);
+            Assert.NotNull(sheetLoaded.GetRow(rowIndex));
+            Assert.NotNull(sheetLoaded.GetRow(rowIndex).GetCell(columnIndex));
+        }
+
+        [Test]
+        public void CreateCell_WithInValidIndex_ExceptiomnIsThrown()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+
+            IColumn column = sheet.CreateColumn(columnIndex);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => column.CreateCell(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => column.CreateCell(2000000));
+        }
+
+        [Test]
+        public void CreateCell_WithValidIndexVariousTypes_CellsCreatedWithCorrectTypes()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            IColumn column = sheet.CreateColumn(columnIndex);
+            column.CreateCell(0, CellType.Blank);
+            column.CreateCell(1, CellType.Boolean);
+            column.CreateCell(2, CellType.Error);
+            column.CreateCell(3, CellType.Formula);
+            column.CreateCell(4, CellType.Numeric);
+            column.CreateCell(5, CellType.String);
+
+            for (int i = 0; i <= 5; i++)
+            {
+                Assert.NotNull(sheet.GetRow(i));
+                Assert.NotNull(sheet.GetRow(i).GetCell(columnIndex));
+            }
+
+            Assert.AreEqual(CellType.Blank, sheet.GetRow(0).GetCell(columnIndex).CellType);
+            Assert.AreEqual(CellType.Boolean, sheet.GetRow(1).GetCell(columnIndex).CellType);
+            Assert.AreEqual(CellType.Error, sheet.GetRow(2).GetCell(columnIndex).CellType);
+            Assert.AreEqual(CellType.Formula, sheet.GetRow(3).GetCell(columnIndex).CellType);
+            Assert.AreEqual(CellType.Blank, sheet.GetRow(4).GetCell(columnIndex).CellType); // Numeric cell with no data will return blank by default
+            Assert.AreEqual(CellType.String, sheet.GetRow(5).GetCell(columnIndex).CellType);
+
+            Assert.Throws<ArgumentException>(() => column.CreateCell(6, CellType.Unknown));
+            Assert.IsNull(sheet.GetRow(6));
+            Assert.IsNull(column.GetCell(6));
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+
+            for (int i = 0; i <= 5; i++)
+            {
+                Assert.NotNull(sheetLoaded.GetRow(i));
+                Assert.NotNull(sheetLoaded.GetRow(i).GetCell(columnIndex));
+            }
+
+            Assert.AreEqual(CellType.Blank, sheetLoaded.GetRow(0).GetCell(columnIndex).CellType);
+            Assert.AreEqual(CellType.Boolean, sheetLoaded.GetRow(1).GetCell(columnIndex).CellType);
+            Assert.AreEqual(CellType.Error, sheetLoaded.GetRow(2).GetCell(columnIndex).CellType);
+            Assert.AreEqual(CellType.Formula, sheetLoaded.GetRow(3).GetCell(columnIndex).CellType);
+            Assert.AreEqual(CellType.Blank, sheetLoaded.GetRow(4).GetCell(columnIndex).CellType);
+            Assert.AreEqual(CellType.String, sheetLoaded.GetRow(5).GetCell(columnIndex).CellType);
+
+            Assert.IsNull(sheetLoaded.GetRow(6));
+            Assert.IsNull(sheetLoaded.GetColumn(columnIndex).GetCell(6));
+        }
+
+        [Test]
+        public void GetCell_GetExistingAndNonExistinCells_CellsReturnedWhenExistsNullsWhenNot()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            int rowIndex = 10;
+            IColumn column = sheet.CreateColumn(columnIndex);
+            column.CreateCell(rowIndex);
+            ICell cell = column.GetCell(rowIndex);
+            sheet.CreateRow(rowIndex + 1).CreateCell(columnIndex);
+
+            Assert.IsNotNull(cell);
+            Assert.AreEqual(columnIndex, cell.ColumnIndex);
+            Assert.AreEqual(rowIndex, cell.RowIndex);
+            Assert.IsNull(column.GetCell(0));
+            Assert.IsNotNull(column.GetCell(rowIndex + 1));
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn columnLoaded = sheetLoaded.GetColumn(columnIndex);
+            ICell cellLoaded = columnLoaded.GetCell(rowIndex);
+
+            Assert.IsNotNull(cellLoaded);
+            Assert.AreEqual(columnIndex, cellLoaded.ColumnIndex);
+            Assert.AreEqual(rowIndex, cellLoaded.RowIndex);
+            Assert.IsNull(columnLoaded.GetCell(0));
+            Assert.IsNotNull(columnLoaded.GetCell(rowIndex + 1));
+        }
+
+        [Test]
+        public void GetCell_GetExistingCells_CellsReturned()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            int rowIndex = 10;
+            IColumn column = sheet.CreateColumn(columnIndex);
+
+            column.CreateCell(rowIndex, CellType.Blank);
+            column.CreateCell(rowIndex + 1, CellType.Blank).SetCellValue(1);
+            column.CreateCell(rowIndex + 2, CellType.Numeric);
+            column.CreateCell(rowIndex + 3, CellType.Numeric).SetCellValue(1);
+
+            Assert.IsNotNull(column.GetCell(rowIndex, MissingCellPolicy.RETURN_NULL_AND_BLANK));
+            Assert.IsNotNull(column.GetCell(rowIndex + 1, MissingCellPolicy.RETURN_NULL_AND_BLANK));
+            Assert.IsNotNull(column.GetCell(rowIndex + 2, MissingCellPolicy.RETURN_NULL_AND_BLANK));
+            Assert.IsNotNull(column.GetCell(rowIndex + 3, MissingCellPolicy.RETURN_NULL_AND_BLANK));
+            Assert.IsNull(column.GetCell(rowIndex + 4, MissingCellPolicy.RETURN_NULL_AND_BLANK));
+
+            Assert.IsNull(column.GetCell(rowIndex, MissingCellPolicy.RETURN_BLANK_AS_NULL));
+            Assert.IsNotNull(column.GetCell(rowIndex + 1, MissingCellPolicy.RETURN_BLANK_AS_NULL));
+            Assert.IsNull(column.GetCell(rowIndex + 2, MissingCellPolicy.RETURN_BLANK_AS_NULL));
+            Assert.IsNotNull(column.GetCell(rowIndex + 3, MissingCellPolicy.RETURN_BLANK_AS_NULL));
+            Assert.IsNull(column.GetCell(rowIndex + 4, MissingCellPolicy.RETURN_BLANK_AS_NULL));
+
+            Assert.IsNotNull(column.GetCell(rowIndex, MissingCellPolicy.CREATE_NULL_AS_BLANK));
+            Assert.IsNotNull(column.GetCell(rowIndex + 1, MissingCellPolicy.CREATE_NULL_AS_BLANK));
+            Assert.IsNotNull(column.GetCell(rowIndex + 2, MissingCellPolicy.CREATE_NULL_AS_BLANK));
+            Assert.IsNotNull(column.GetCell(rowIndex + 3, MissingCellPolicy.CREATE_NULL_AS_BLANK));
+            Assert.IsNotNull(column.GetCell(rowIndex + 4, MissingCellPolicy.CREATE_NULL_AS_BLANK));
+        }
+
+        [Test]
+        public void RemoveCell_RemoveExistingCells_CellsAreRemoved()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            int rowIndex = 10;
+            int middleRowIndex = 15;
+            int initialNumberOfCells = 10;
+            IColumn column = sheet.CreateColumn(columnIndex);
+
+            for (int i = 0; i < initialNumberOfCells; i++)
+            {
+                column.CreateCell(rowIndex + i);
+            }
+
+            Assert.AreEqual(initialNumberOfCells, column.PhysicalNumberOfCells);
+            Assert.AreEqual(rowIndex, column.FirstCellNum);
+            Assert.AreEqual(rowIndex + initialNumberOfCells, column.LastCellNum);
+
+            column.RemoveCell(column.GetCell(column.FirstCellNum));
+            column.RemoveCell(column.GetCell(column.LastCellNum - 1));
+            column.RemoveCell(column.GetCell(middleRowIndex));
+
+            Assert.AreEqual(initialNumberOfCells - 3, column.PhysicalNumberOfCells);
+            Assert.AreEqual(rowIndex + 1, column.FirstCellNum);
+            Assert.AreEqual(rowIndex + initialNumberOfCells - 1, column.LastCellNum);
+            Assert.IsNull(column.GetCell(rowIndex));
+            Assert.IsNull(column.GetCell(middleRowIndex));
+            Assert.IsNull(column.GetCell(rowIndex + initialNumberOfCells));
+            Assert.IsNull(sheet.GetRow(rowIndex).GetCell(columnIndex));
+            Assert.IsNull(sheet.GetRow(middleRowIndex).GetCell(columnIndex));
+            Assert.IsNull(sheet.GetRow(rowIndex + initialNumberOfCells - 1).GetCell(columnIndex));
+        }
+
+        [Test]
+        public void RemoveCell_RemoveCellNotBelongingToColumn_ExceptionThrownCellIsNotRemoved()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int columnIndex = 10;
+            int rowIndex = 10;
+            IColumn column = sheet.CreateColumn(columnIndex);
+            IRow row = sheet.CreateRow(rowIndex);
+            ICell cell = row.CreateCell(columnIndex + 1);
+
+            Assert.Throws<ArgumentException>(() => column.RemoveCell(cell));
+            Assert.Throws<ArgumentException>(() => column.RemoveCell(null));
+            Assert.IsNotNull(row.GetCell(columnIndex + 1));
+        }
+
+        [Test]
+        public void CopyColumnFrom_CopyOverExistingCells_ExistingCellsAreReplacedByCellsFromCopiedColumn()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFFormulaEvaluator fe = new XSSFFormulaEvaluator(wb);
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            XSSFDrawing dg = (XSSFDrawing)sheet.CreateDrawingPatriarch();
+            XSSFComment comment = (XSSFComment)dg.CreateCellComment(new XSSFClientAnchor());
+            comment.Author = "POI";
+            comment.String = new XSSFRichTextString("A new comment");
+            int originalColIndex = 1;
+            int copyColIndex = 4;
+            short width = 20;
+            int mergedRegionFirstRow = 10;
+            int mergedRegionLastRow = 20;
+            int firstFormulaCellValue = 10;
+            int secondFormulaCellValue = 20;
+            int formulaResult = firstFormulaCellValue + secondFormulaCellValue;
+            int cellToBeErasedRowIndex = 25;
+
+            XSSFColumn anotherColumn = (XSSFColumn)sheet.CreateColumn(copyColIndex);
+            anotherColumn.CreateCell(0).SetCellValue("POI");
+            anotherColumn.Width = (short)(width * 2);
+            anotherColumn.CreateCell(0).SetCellValue("POI");
+            anotherColumn.CreateCell(cellToBeErasedRowIndex).SetCellValue("POI");
+            XSSFColumn originalColumn = (XSSFColumn)sheet.CreateColumn(originalColIndex);
+            originalColumn.Width = width;
+            XSSFCell formulaCell1 = (XSSFCell)originalColumn.CreateCell(0);
+            formulaCell1.SetCellFormula("C1 + D1");
+            formulaCell1.CellComment = comment;
+            sheet.CreateColumn(originalColIndex + 1).CreateCell(0).SetCellValue(firstFormulaCellValue);
+            sheet.CreateColumn(originalColIndex + 2).CreateCell(0).SetCellValue(secondFormulaCellValue);
+            sheet.GetRow(0).CreateCell(originalColIndex + 1 + 3).SetCellValue(firstFormulaCellValue);
+            sheet.GetRow(0).CreateCell(originalColIndex + 2 + 3).SetCellValue(secondFormulaCellValue);
+            originalColumn.CreateCell(mergedRegionFirstRow).SetCellValue("POI");
+            sheet.AddMergedRegion(
+                new CellRangeAddress(
+                    mergedRegionFirstRow,
+                    mergedRegionLastRow,
+                    originalColumn.ColumnNum,
+                    originalColumn.ColumnNum));
+            CellRangeAddress originaMergedRegion = sheet.GetMergedRegion(0);
+
+            fe.EvaluateAll();
+
+            Assert.AreEqual("POI", sheet.GetRow(mergedRegionFirstRow).GetCell(originalColIndex).StringCellValue);
+            Assert.AreEqual("POI", formulaCell1.CellComment.Author);
+            Assert.AreEqual(formulaResult, formulaCell1.NumericCellValue);
+            Assert.AreEqual(1, sheet.NumMergedRegions);
+            Assert.NotNull(originaMergedRegion);
+
+            anotherColumn.CopyColumnFrom(originalColumn, new CellCopyPolicy());
+            CellRangeAddress copyMergedRegion = sheet.GetMergedRegion(1);
+            fe.EvaluateAll();
+
+            XSSFCell formulaCell2 = (XSSFCell)sheet.GetColumn(copyColIndex).GetCell(0);
+
+            Assert.AreEqual(copyColIndex, anotherColumn.ColumnNum);
+            Assert.AreEqual(1, sheet.FirstColumnNum);
+            Assert.AreEqual(4, sheet.LastColumnNum);
+            Assert.AreEqual(width, anotherColumn.Width);
+            Assert.AreEqual("POI", sheet.GetRow(mergedRegionFirstRow).GetCell(copyColIndex).StringCellValue);
+            Assert.AreEqual("F1+G1", formulaCell2.CellFormula);
+            Assert.AreEqual(formulaResult, formulaCell2.NumericCellValue);
+            //Assert.IsNull(anotherColumn.GetCell(cellToBeErasedRowIndex));
+            Assert.AreEqual(2, sheet.NumMergedRegions);
+            Assert.NotNull(originaMergedRegion);
+            Assert.NotNull(copyMergedRegion);
+            Assert.AreEqual(mergedRegionFirstRow, copyMergedRegion.FirstRow);
+            Assert.AreEqual(mergedRegionLastRow, copyMergedRegion.LastRow);
+            Assert.AreEqual(anotherColumn.ColumnNum, copyMergedRegion.FirstColumn);
+            Assert.AreEqual(anotherColumn.ColumnNum, copyMergedRegion.LastColumn);
+
+            FileInfo file = TempFile.CreateTempFile("CopyColumnFrom-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFFormulaEvaluator feLoaded = new XSSFFormulaEvaluator(wbLoaded);
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            XSSFColumn originalColumnLoaded = (XSSFColumn)sheetLoaded.GetColumn(originalColIndex);
+            XSSFColumn copyColumnLoaded = (XSSFColumn)sheetLoaded.GetColumn(copyColIndex);
+            XSSFCell formulaCellLoaded = (XSSFCell)copyColumnLoaded.GetCell(0);
+            CellRangeAddress originalMergedRegionLoaded = sheet.GetMergedRegion(0);
+            CellRangeAddress copyMergedRegionLoaded = sheet.GetMergedRegion(1);
+
+            feLoaded.EvaluateAll();
+
+            Assert.AreEqual(1, sheetLoaded.FirstColumnNum);
+            Assert.AreEqual(4, sheetLoaded.LastColumnNum);
+            Assert.AreEqual(width, copyColumnLoaded.Width);
+            Assert.AreEqual(firstFormulaCellValue, sheetLoaded.GetColumn(originalColIndex + 1).GetCell(0).NumericCellValue);
+            Assert.AreEqual(secondFormulaCellValue, sheetLoaded.GetColumn(originalColIndex + 2).GetCell(0).NumericCellValue);
+            Assert.AreEqual("POI", sheetLoaded.GetRow(mergedRegionFirstRow).GetCell(copyColIndex).StringCellValue);
+            Assert.AreEqual("F1+G1", formulaCellLoaded.CellFormula);
+            Assert.AreEqual(formulaResult, formulaCellLoaded.NumericCellValue);
+            Assert.NotNull(originalMergedRegionLoaded);
+            Assert.AreEqual(mergedRegionFirstRow, originalMergedRegionLoaded.FirstRow);
+            Assert.AreEqual(mergedRegionLastRow, originalMergedRegionLoaded.LastRow);
+            Assert.AreEqual(originalColumnLoaded.ColumnNum, originalMergedRegionLoaded.FirstColumn);
+            Assert.AreEqual(originalColumnLoaded.ColumnNum, originalMergedRegionLoaded.LastColumn);
+            Assert.NotNull(copyMergedRegionLoaded);
+            Assert.AreEqual(mergedRegionFirstRow, copyMergedRegionLoaded.FirstRow);
+            Assert.AreEqual(mergedRegionLastRow, copyMergedRegionLoaded.LastRow);
+            Assert.AreEqual(copyColumnLoaded.ColumnNum, copyMergedRegionLoaded.FirstColumn);
+            Assert.AreEqual(copyColumnLoaded.ColumnNum, copyMergedRegionLoaded.LastColumn);
+        }
+
+        [Test]
+        public void CopyColumnFrom_CopyOntoEmptyColumn_CopiedCellsAreAddedToColumn()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFFormulaEvaluator fe = new XSSFFormulaEvaluator(wb);
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            XSSFDrawing dg = (XSSFDrawing)sheet.CreateDrawingPatriarch();
+            XSSFComment comment = (XSSFComment)dg.CreateCellComment(new XSSFClientAnchor());
+            comment.Author = "POI";
+            comment.String = new XSSFRichTextString("A new comment");
+            int originalColIndex = 1;
+            int copyColIndex = 4;
+            short width = 20;
+            int mergedRegionFirstRow = 10;
+            int mergedRegionLastRow = 20;
+            int firstFormulaCellValue = 10;
+            int secondFormulaCellValue = 20;
+            int formulaResult = firstFormulaCellValue + secondFormulaCellValue;
+
+            XSSFColumn anotherColumn = (XSSFColumn)sheet.CreateColumn(copyColIndex);
+            XSSFColumn originalColumn = (XSSFColumn)sheet.CreateColumn(originalColIndex);
+            originalColumn.Width = width;
+            XSSFCell formulaCell1 = (XSSFCell)originalColumn.CreateCell(0);
+            formulaCell1.SetCellFormula("C1 + D1");
+            formulaCell1.CellComment = comment;
+            sheet.CreateColumn(originalColIndex + 1).CreateCell(0).SetCellValue(firstFormulaCellValue);
+            sheet.CreateColumn(originalColIndex + 2).CreateCell(0).SetCellValue(secondFormulaCellValue);
+            sheet.GetRow(0).CreateCell(originalColIndex + 1 + 3).SetCellValue(firstFormulaCellValue);
+            sheet.GetRow(0).CreateCell(originalColIndex + 2 + 3).SetCellValue(secondFormulaCellValue);
+            originalColumn.CreateCell(mergedRegionFirstRow).SetCellValue("POI");
+            sheet.AddMergedRegion(
+                new CellRangeAddress(
+                    mergedRegionFirstRow,
+                    mergedRegionLastRow,
+                    originalColumn.ColumnNum,
+                    originalColumn.ColumnNum));
+            CellRangeAddress originaMergedRegion = sheet.GetMergedRegion(0);
+
+            fe.EvaluateAll();
+
+            Assert.AreEqual("POI", sheet.GetRow(mergedRegionFirstRow).GetCell(originalColIndex).StringCellValue);
+            Assert.AreEqual("POI", formulaCell1.CellComment.Author);
+            Assert.AreEqual(formulaResult, formulaCell1.NumericCellValue);
+            Assert.AreEqual(1, sheet.NumMergedRegions);
+            Assert.NotNull(originaMergedRegion);
+
+            anotherColumn.CopyColumnFrom(originalColumn, new CellCopyPolicy() { IsCopyColumnWidth = false });
+            CellRangeAddress copyMergedRegion = sheet.GetMergedRegion(1);
+            fe.EvaluateAll();
+
+            XSSFCell formulaCell2 = (XSSFCell)sheet.GetColumn(copyColIndex).GetCell(0);
+
+            Assert.AreEqual(copyColIndex, anotherColumn.ColumnNum);
+            Assert.AreEqual(1, sheet.FirstColumnNum);
+            Assert.AreEqual(4, sheet.LastColumnNum);
+            Assert.AreNotEqual(width, anotherColumn.Width);
+            Assert.AreEqual("POI", sheet.GetRow(mergedRegionFirstRow).GetCell(copyColIndex).StringCellValue);
+            Assert.AreEqual("F1+G1", formulaCell2.CellFormula);
+            Assert.AreEqual(formulaResult, formulaCell2.NumericCellValue);
+            Assert.AreEqual(2, sheet.NumMergedRegions);
+            Assert.NotNull(originaMergedRegion);
+            Assert.NotNull(copyMergedRegion);
+            Assert.AreEqual(mergedRegionFirstRow, copyMergedRegion.FirstRow);
+            Assert.AreEqual(mergedRegionLastRow, copyMergedRegion.LastRow);
+            Assert.AreEqual(anotherColumn.ColumnNum, copyMergedRegion.FirstColumn);
+            Assert.AreEqual(anotherColumn.ColumnNum, copyMergedRegion.LastColumn);
+
+            FileInfo file = TempFile.CreateTempFile("CopyColumnFrom-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFFormulaEvaluator feLoaded = new XSSFFormulaEvaluator(wbLoaded);
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            XSSFColumn originalColumnLoaded = (XSSFColumn)sheetLoaded.GetColumn(originalColIndex);
+            XSSFColumn copyColumnLoaded = (XSSFColumn)sheetLoaded.GetColumn(copyColIndex);
+            XSSFCell formulaCellLoaded = (XSSFCell)copyColumnLoaded.GetCell(0);
+            CellRangeAddress originalMergedRegionLoaded = sheet.GetMergedRegion(0);
+            CellRangeAddress copyMergedRegionLoaded = sheet.GetMergedRegion(1);
+
+            feLoaded.EvaluateAll();
+
+            Assert.AreEqual(1, sheetLoaded.FirstColumnNum);
+            Assert.AreEqual(4, sheetLoaded.LastColumnNum);
+
+            Assert.AreNotEqual(width, copyColumnLoaded.Width);
+            Assert.AreEqual(firstFormulaCellValue, sheetLoaded.GetColumn(originalColIndex + 1).GetCell(0).NumericCellValue);
+            Assert.AreEqual(secondFormulaCellValue, sheetLoaded.GetColumn(originalColIndex + 2).GetCell(0).NumericCellValue);
+            Assert.AreEqual("POI", sheetLoaded.GetRow(mergedRegionFirstRow).GetCell(copyColIndex).StringCellValue);
+            Assert.AreEqual("F1+G1", formulaCellLoaded.CellFormula);
+            Assert.AreEqual(formulaResult, formulaCellLoaded.NumericCellValue);
+            Assert.NotNull(originalMergedRegionLoaded);
+            Assert.AreEqual(mergedRegionFirstRow, originalMergedRegionLoaded.FirstRow);
+            Assert.AreEqual(mergedRegionLastRow, originalMergedRegionLoaded.LastRow);
+            Assert.AreEqual(originalColumnLoaded.ColumnNum, originalMergedRegionLoaded.FirstColumn);
+            Assert.AreEqual(originalColumnLoaded.ColumnNum, originalMergedRegionLoaded.LastColumn);
+            Assert.NotNull(copyMergedRegionLoaded);
+            Assert.AreEqual(mergedRegionFirstRow, copyMergedRegionLoaded.FirstRow);
+            Assert.AreEqual(mergedRegionLastRow, copyMergedRegionLoaded.LastRow);
+            Assert.AreEqual(copyColumnLoaded.ColumnNum, copyMergedRegionLoaded.FirstColumn);
+            Assert.AreEqual(copyColumnLoaded.ColumnNum, copyMergedRegionLoaded.LastColumn);
+        }
+
+        [Test]
+        public void CopyColumnFrom_CopyFromNull_ExistingCellsAreReplacedWithNull()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int copyColIndex = 4;
+            int cellToBeErasedRowIndex = 25;
+
+            XSSFColumn anotherColumn = (XSSFColumn)sheet.CreateColumn(copyColIndex);
+            anotherColumn.CreateCell(0).SetCellValue("POI");
+            anotherColumn.CreateCell(cellToBeErasedRowIndex).SetCellValue("POI");
+
+            anotherColumn.CopyColumnFrom(null, new CellCopyPolicy());
+
+            Assert.AreEqual(copyColIndex, anotherColumn.ColumnNum);
+            Assert.AreEqual(4, sheet.FirstColumnNum);
+            Assert.AreEqual(4, sheet.LastColumnNum);
+            Assert.AreEqual("", anotherColumn.GetCell(0).StringCellValue);
+            Assert.AreEqual("", anotherColumn.GetCell(cellToBeErasedRowIndex).StringCellValue);
+        }
+
+        [Test]
+        public void CopyColumnFrom_FromExternalSheet()
+        {
+            XSSFWorkbook workbook = new XSSFWorkbook();
+            XSSFSheet srcSheet = (XSSFSheet)workbook.CreateSheet("src");
+            XSSFSheet destSheet = workbook.CreateSheet("dest") as XSSFSheet;
+            workbook.CreateSheet("other");
+
+            IColumn srcColumn = srcSheet.CreateColumn(0);
+            int col = 0;
+            //Test 2D and 3D Ref Ptgs (Pxg for OOXML Workbooks)
+            srcColumn.CreateCell(col++).CellFormula = "E5";
+            srcColumn.CreateCell(col++).CellFormula = "src!E5";
+            srcColumn.CreateCell(col++).CellFormula = "dest!E5";
+            srcColumn.CreateCell(col++).CellFormula = "other!E5";
+
+            //Test 2D and 3D Ref Ptgs with absolute column
+            srcColumn.CreateCell(col++).CellFormula = "$E5";
+            srcColumn.CreateCell(col++).CellFormula = "src!$E5";
+            srcColumn.CreateCell(col++).CellFormula = "dest!$E5";
+            srcColumn.CreateCell(col++).CellFormula = "other!$E5";
+
+            //Test 2D and 3D Area Ptgs (Pxg for OOXML Workbooks)
+            srcColumn.CreateCell(col++).CellFormula = "SUM(E5:$E10)";
+            srcColumn.CreateCell(col++).CellFormula = "SUM(src!E5:$E10)";
+            srcColumn.CreateCell(col++).CellFormula = "SUM(dest!E5:$E10)";
+            srcColumn.CreateCell(col++).CellFormula = "SUM(other!E5:$E10)";
+            //////////////////
+            XSSFColumn destColumn = destSheet.CreateColumn(1) as XSSFColumn;
+            destColumn.CopyColumnFrom(srcColumn, new CellCopyPolicy());
+
+            //////////////////
+
+            //Test 2D and 3D Ref Ptgs (Pxg for OOXML Workbooks)
+            col = 0;
+            ICell cell = destColumn.GetCell(col++);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual("F5", cell.CellFormula, "RefPtg");
+
+            cell = destColumn.GetCell(col++);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual("src!F5", cell.CellFormula, "Ref3DPtg");
+
+            cell = destColumn.GetCell(col++);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual("dest!F5", cell.CellFormula, "Ref3DPtg");
+
+            cell = destColumn.GetCell(col++);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual("other!F5", cell.CellFormula, "Ref3DPtg");
+
+            /////////////////////////////////////////////
+
+            //Test 2D and 3D Ref Ptgs with absolute column (Ptg column number shouldn't change)
+            cell = destColumn.GetCell(col++);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual("$E5", cell.CellFormula, "RefPtg");
+
+            cell = destColumn.GetCell(col++);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual("src!$E5", cell.CellFormula, "Ref3DPtg");
+
+            cell = destColumn.GetCell(col++);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual("dest!$E5", cell.CellFormula, "Ref3DPtg");
+
+            cell = destColumn.GetCell(col++);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual("other!$E5", cell.CellFormula, "Ref3DPtg");
+
+            //////////////////////////////////////////
+
+            //Test 2D and 3D Area Ptgs (Pxg for OOXML Workbooks)
+            // Note: absolute column changes from last cell to first cell in order
+            // to maintain topLeft:bottomRight order
+            cell = destColumn.GetCell(col++);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual("SUM($E5:F10)", cell.CellFormula, "Area2DPtg");
+
+            cell = destColumn.GetCell(col++);
+            Assert.IsNotNull(cell);
+            Assert.AreEqual("SUM(src!$E5:F10)", cell.CellFormula, "Area3DPtg");
+
+            cell = destColumn.GetCell(col++);
+            Assert.IsNotNull(destColumn.GetCell(6));
+            Assert.AreEqual("SUM(dest!$E5:F10)", cell.CellFormula, "Area3DPtg");
+
+            cell = destColumn.GetCell(col++);
+            Assert.IsNotNull(destColumn.GetCell(7));
+            Assert.AreEqual("SUM(other!$E5:F10)", cell.CellFormula, "Area3DPtg");
+
+            workbook.Close();
+        }//*/
+    }
+}

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFColumn.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFColumn.cs
@@ -71,12 +71,12 @@ namespace TestCases.XSSF.UserModel
 
             for (int i = 0; i < numOfCells; i++)
             {
-                column2.CreateCell(firstRowNum + i);
+                _ = column2.CreateCell(firstRowNum + i);
             }
 
             for (int i = 0; i < numOfCells; i++)
             {
-                column2.CreateCell(firstRowNum + 20 + i);
+                _ = column2.CreateCell(firstRowNum + 20 + i);
             }
 
             Assert.AreEqual(-1, column1.FirstCellNum);
@@ -109,12 +109,12 @@ namespace TestCases.XSSF.UserModel
 
             for (int i = 0; i < numOfCells; i++)
             {
-                column2.CreateCell(firstRowNum + i);
+                _ = column2.CreateCell(firstRowNum + i);
             }
 
             for (int i = 0; i < numOfCells; i++)
             {
-                column2.CreateCell(firstRowNum + 20 + i);
+                _ = column2.CreateCell(firstRowNum + 20 + i);
             }
 
             Assert.AreEqual(-1, column1.LastCellNum);
@@ -176,12 +176,12 @@ namespace TestCases.XSSF.UserModel
 
             for (int i = 0; i < numOfCells; i++)
             {
-                column2.CreateCell(firstRowNum + i);
+                _ = column2.CreateCell(firstRowNum + i);
             }
 
             for (int i = 0; i < numOfCells; i++)
             {
-                column2.CreateCell(firstRowNum + 20 + i);
+                _ = column2.CreateCell(firstRowNum + 20 + i);
             }
 
             column2.RemoveCell(
@@ -357,8 +357,8 @@ namespace TestCases.XSSF.UserModel
 
             IColumn column = sheet.CreateColumn(columnIndex);
 
-            Assert.Throws<ArgumentOutOfRangeException>(() => column.CreateCell(-1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => column.CreateCell(2000000));
+            _ = Assert.Throws<ArgumentOutOfRangeException>(() => column.CreateCell(-1));
+            _ = Assert.Throws<ArgumentOutOfRangeException>(() => column.CreateCell(2000000));
         }
 
         [Test]
@@ -368,12 +368,12 @@ namespace TestCases.XSSF.UserModel
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
             int columnIndex = 10;
             IColumn column = sheet.CreateColumn(columnIndex);
-            column.CreateCell(0, CellType.Blank);
-            column.CreateCell(1, CellType.Boolean);
-            column.CreateCell(2, CellType.Error);
-            column.CreateCell(3, CellType.Formula);
-            column.CreateCell(4, CellType.Numeric);
-            column.CreateCell(5, CellType.String);
+            _ = column.CreateCell(0, CellType.Blank);
+            _ = column.CreateCell(1, CellType.Boolean);
+            _ = column.CreateCell(2, CellType.Error);
+            _ = column.CreateCell(3, CellType.Formula);
+            _ = column.CreateCell(4, CellType.Numeric);
+            _ = column.CreateCell(5, CellType.String);
 
             for (int i = 0; i <= 5; i++)
             {
@@ -388,7 +388,7 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(CellType.Blank, sheet.GetRow(4).GetCell(columnIndex).CellType); // Numeric cell with no data will return blank by default
             Assert.AreEqual(CellType.String, sheet.GetRow(5).GetCell(columnIndex).CellType);
 
-            Assert.Throws<ArgumentException>(() => column.CreateCell(6, CellType.Unknown));
+            _ = Assert.Throws<ArgumentException>(() => column.CreateCell(6, CellType.Unknown));
             Assert.IsNull(sheet.GetRow(6));
             Assert.IsNull(column.GetCell(6));
 
@@ -425,9 +425,9 @@ namespace TestCases.XSSF.UserModel
             int columnIndex = 10;
             int rowIndex = 10;
             IColumn column = sheet.CreateColumn(columnIndex);
-            column.CreateCell(rowIndex);
+            _ = column.CreateCell(rowIndex);
             ICell cell = column.GetCell(rowIndex);
-            sheet.CreateRow(rowIndex + 1).CreateCell(columnIndex);
+            _ = sheet.CreateRow(rowIndex + 1).CreateCell(columnIndex);
 
             Assert.IsNotNull(cell);
             Assert.AreEqual(columnIndex, cell.ColumnIndex);
@@ -461,9 +461,9 @@ namespace TestCases.XSSF.UserModel
             int rowIndex = 10;
             IColumn column = sheet.CreateColumn(columnIndex);
 
-            column.CreateCell(rowIndex, CellType.Blank);
+            _ = column.CreateCell(rowIndex, CellType.Blank);
             column.CreateCell(rowIndex + 1, CellType.Blank).SetCellValue(1);
-            column.CreateCell(rowIndex + 2, CellType.Numeric);
+            _ = column.CreateCell(rowIndex + 2, CellType.Numeric);
             column.CreateCell(rowIndex + 3, CellType.Numeric).SetCellValue(1);
 
             Assert.IsNotNull(column.GetCell(rowIndex, MissingCellPolicy.RETURN_NULL_AND_BLANK));
@@ -498,7 +498,7 @@ namespace TestCases.XSSF.UserModel
 
             for (int i = 0; i < initialNumberOfCells; i++)
             {
-                column.CreateCell(rowIndex + i);
+                _ = column.CreateCell(rowIndex + i);
             }
 
             Assert.AreEqual(initialNumberOfCells, column.PhysicalNumberOfCells);
@@ -531,8 +531,8 @@ namespace TestCases.XSSF.UserModel
             IRow row = sheet.CreateRow(rowIndex);
             ICell cell = row.CreateCell(columnIndex + 1);
 
-            Assert.Throws<ArgumentException>(() => column.RemoveCell(cell));
-            Assert.Throws<ArgumentException>(() => column.RemoveCell(null));
+            _ = Assert.Throws<ArgumentException>(() => column.RemoveCell(cell));
+            _ = Assert.Throws<ArgumentException>(() => column.RemoveCell(null));
             Assert.IsNotNull(row.GetCell(columnIndex + 1));
         }
 
@@ -571,7 +571,7 @@ namespace TestCases.XSSF.UserModel
             sheet.GetRow(0).CreateCell(originalColIndex + 1 + 3).SetCellValue(firstFormulaCellValue);
             sheet.GetRow(0).CreateCell(originalColIndex + 2 + 3).SetCellValue(secondFormulaCellValue);
             originalColumn.CreateCell(mergedRegionFirstRow).SetCellValue("POI");
-            sheet.AddMergedRegion(
+            _ = sheet.AddMergedRegion(
                 new CellRangeAddress(
                     mergedRegionFirstRow,
                     mergedRegionLastRow,
@@ -675,7 +675,7 @@ namespace TestCases.XSSF.UserModel
             sheet.GetRow(0).CreateCell(originalColIndex + 1 + 3).SetCellValue(firstFormulaCellValue);
             sheet.GetRow(0).CreateCell(originalColIndex + 2 + 3).SetCellValue(secondFormulaCellValue);
             originalColumn.CreateCell(mergedRegionFirstRow).SetCellValue("POI");
-            sheet.AddMergedRegion(
+            _ = sheet.AddMergedRegion(
                 new CellRangeAddress(
                     mergedRegionFirstRow,
                     mergedRegionLastRow,
@@ -776,7 +776,7 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook workbook = new XSSFWorkbook();
             XSSFSheet srcSheet = (XSSFSheet)workbook.CreateSheet("src");
             XSSFSheet destSheet = workbook.CreateSheet("dest") as XSSFSheet;
-            workbook.CreateSheet("other");
+            _ = workbook.CreateSheet("other");
 
             IColumn srcColumn = srcSheet.CreateColumn(0);
             int col = 0;

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
@@ -67,22 +67,25 @@ namespace TestCases.XSSF.UserModel
         {
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
-            sheet.CreateRow(2).CreateCell(0).SetCellValue("2");
-            sheet.CreateRow(3).CreateCell(0).SetCellValue("3");
 
-            sheet.CreateRow(1).CreateCell(1).SetCellValue("regionOutsideShiftedRowsOnTop");
+            for (int i = 0; i < 12; i++)
+            {
+                sheet.CreateRow(i).CreateCell(0).SetCellValue(i);
+            }
+
+            sheet.GetRow(1).CreateCell(1).SetCellValue("regionOutsideShiftedRowsOnTop");
             int regionOutsideToTheLeftId = sheet.AddMergedRegion(new CellRangeAddress(1, 1, 1, 2));
 
             sheet.GetRow(2).CreateCell(3).SetCellValue("regionInsideShiftedRows");
             int regionInsideId = sheet.AddMergedRegion(new CellRangeAddress(2, 3, 3, 4));
 
-            sheet.CreateRow(4).CreateCell(5).SetCellValue("regionRighBelowTheShiftedRows");
+            sheet.GetRow(4).CreateCell(5).SetCellValue("regionRighBelowTheShiftedRows");
             int regionRighNextToId = sheet.AddMergedRegion(new CellRangeAddress(4, 5, 5, 6));
 
-            sheet.CreateRow(6).CreateCell(7).SetCellValue("regionInTheWayOfTheShift");
+            sheet.GetRow(6).CreateCell(7).SetCellValue("regionInTheWayOfTheShift");
             int regionInTheWayOfTheShiftId = sheet.AddMergedRegion(new CellRangeAddress(6, 7, 7, 8));
 
-            sheet.CreateRow(10).CreateCell(9).SetCellValue("regionOutsideShiftedRowsBelow");
+            sheet.GetRow(10).CreateCell(9).SetCellValue("regionOutsideShiftedRowsBelow");
             int regionOutsideToTheRightId = sheet.AddMergedRegion(new CellRangeAddress(10, 11, 9, 10));
 
             sheet.GetRow(1).CreateCell(11).SetCellValue("regionThatEndsWithinShiftedRows");
@@ -194,8 +197,12 @@ namespace TestCases.XSSF.UserModel
         {
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
-            sheet.CreateRow(0).CreateCell(2).SetCellValue("2");
-            sheet.GetRow(0).CreateCell(3).SetCellValue("3");
+            _ = sheet.CreateRow(0);
+
+            for (int i = 0; i < 12; i++)
+            {
+                sheet.GetRow(0).CreateCell(i).SetCellValue(i);
+            }
 
             sheet.CreateRow(1).CreateCell(1).SetCellValue("regionOutsideShiftedColumnsToTheLeft");
             int regionOutsideToTheLeftId = sheet.AddMergedRegion(new CellRangeAddress(1, 2, 1, 1));

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
@@ -61,6 +61,261 @@ namespace TestCases.XSSF.UserModel
         {
             BaseTestGetSetMargin(new double[] { 0.7, 0.7, 0.75, 0.75, 0.3, 0.3 });
         }
+
+        [Test]
+        public void ShiftRows_ShiftRowsWithVariousMergedRegions_RowsShiftedWithMergedRegion()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            sheet.CreateRow(2).CreateCell(0).SetCellValue("2");
+            sheet.CreateRow(3).CreateCell(0).SetCellValue("3");
+
+            sheet.CreateRow(1).CreateCell(1).SetCellValue("regionOutsideShiftedRowsOnTop");
+            int regionOutsideToTheLeftId = sheet.AddMergedRegion(new CellRangeAddress(1, 1, 1, 2));
+
+            sheet.GetRow(2).CreateCell(3).SetCellValue("regionInsideShiftedRows");
+            int regionInsideId = sheet.AddMergedRegion(new CellRangeAddress(2, 3, 3, 4));
+
+            sheet.CreateRow(4).CreateCell(5).SetCellValue("regionRighBelowTheShiftedRows");
+            int regionRighNextToId = sheet.AddMergedRegion(new CellRangeAddress(4, 5, 5, 6));
+
+            sheet.CreateRow(6).CreateCell(7).SetCellValue("regionInTheWayOfTheShift");
+            int regionInTheWayOfTheShiftId = sheet.AddMergedRegion(new CellRangeAddress(6, 7, 7, 8));
+
+            sheet.CreateRow(10).CreateCell(9).SetCellValue("regionOutsideShiftedRowsBelow");
+            int regionOutsideToTheRightId = sheet.AddMergedRegion(new CellRangeAddress(10, 11, 9, 10));
+
+            sheet.GetRow(1).CreateCell(11).SetCellValue("regionThatEndsWithinShiftedRows");
+            int regionThatEndsWithinShiftedRowsId = sheet.AddMergedRegion(new CellRangeAddress(1, 2, 11, 12));
+
+            sheet.GetRow(1).CreateCell(13).SetCellValue("regionThatEndsOnLastShiftedRow");
+            int regionThatEndsOnLastShiftedRowId = sheet.AddMergedRegion(new CellRangeAddress(1, 3, 13, 14));
+
+            sheet.GetRow(1).CreateCell(15).SetCellValue("regionThatEndsOutsideShiftedRows");
+            int regionThatEndsOutsideShiftedRowsId = sheet.AddMergedRegion(new CellRangeAddress(1, 4, 15, 16));
+
+            sheet.GetRow(1).CreateCell(17).SetCellValue("reallyLongRegion");
+            int reallyLongRegionId = sheet.AddMergedRegion(new CellRangeAddress(1, 11, 17, 18));
+
+            Assert.AreEqual("regionOutsideShiftedRowsOnTop", sheet.GetRow(1).GetCell(1).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("B2:C2")));
+
+            Assert.AreEqual("regionInsideShiftedRows", sheet.GetRow(2).GetCell(3).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("D3:E4")));
+
+            Assert.AreEqual("regionRighBelowTheShiftedRows", sheet.GetRow(4).GetCell(5).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("F5:G6")));
+
+            Assert.AreEqual("regionInTheWayOfTheShift", sheet.GetRow(6).GetCell(7).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("H7:I8")));
+
+            Assert.AreEqual("regionOutsideShiftedRowsBelow", sheet.GetRow(10).GetCell(9).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("J11:K12")));
+
+            Assert.AreEqual("regionThatEndsWithinShiftedRows", sheet.GetRow(1).GetCell(11).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("L2:M3")));
+
+            Assert.AreEqual("regionThatEndsOnLastShiftedRow", sheet.GetRow(1).GetCell(13).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("N2:O4")));
+
+            Assert.AreEqual("regionThatEndsOutsideShiftedRows", sheet.GetRow(1).GetCell(15).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("P2:Q5")));
+
+            Assert.AreEqual("reallyLongRegion", sheet.GetRow(1).GetCell(17).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("R2:S12")));
+
+            sheet.ShiftRows(2, 3, 4);
+
+            Assert.AreEqual("regionOutsideShiftedRowsOnTop", sheet.GetRow(1).GetCell(1).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("B2:C2")));
+
+            Assert.AreEqual("regionInsideShiftedRows", sheet.GetRow(6).GetCell(3).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("D7:E8")));
+
+            Assert.AreEqual("regionRighBelowTheShiftedRows", sheet.GetRow(4).GetCell(5).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("F5:G6")));
+
+            Assert.IsNull(sheet.GetRow(6).GetCell(7));
+            Assert.False(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("H7:I8")));
+
+            Assert.AreEqual("regionOutsideShiftedRowsBelow", sheet.GetRow(10).GetCell(9).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("J11:K12")));
+
+            Assert.AreEqual("regionThatEndsWithinShiftedRows", sheet.GetRow(1).GetCell(11).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("L2:M3")));
+
+            Assert.AreEqual("regionThatEndsOnLastShiftedRow", sheet.GetRow(1).GetCell(13).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("N2:O4")));
+
+            Assert.AreEqual("regionThatEndsOutsideShiftedRows", sheet.GetRow(1).GetCell(15).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("P2:Q5")));
+
+            Assert.AreEqual("reallyLongRegion", sheet.GetRow(1).GetCell(17).StringCellValue);
+            Assert.False(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("R2:S12")));
+
+            FileInfo file = TempFile.CreateTempFile("ShiftRows-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+
+            Assert.AreEqual("regionOutsideShiftedRowsOnTop", sheetLoaded.GetRow(1).GetCell(1).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("B2:C2")));
+
+            Assert.AreEqual("regionInsideShiftedRows", sheetLoaded.GetRow(6).GetCell(3).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("D7:E8")));
+
+            Assert.AreEqual("regionRighBelowTheShiftedRows", sheetLoaded.GetRow(4).GetCell(5).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("F5:G6")));
+
+            Assert.IsNull(sheetLoaded.GetRow(6).GetCell(7));
+            Assert.False(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("H7:I8")));
+
+            Assert.AreEqual("regionOutsideShiftedRowsBelow", sheetLoaded.GetRow(10).GetCell(9).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("J11:K12")));
+
+            Assert.AreEqual("regionThatEndsWithinShiftedRows", sheetLoaded.GetRow(1).GetCell(11).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("L2:M3")));
+
+            Assert.AreEqual("regionThatEndsOnLastShiftedRow", sheetLoaded.GetRow(1).GetCell(13).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("N2:O4")));
+
+            Assert.AreEqual("regionThatEndsOutsideShiftedRows", sheetLoaded.GetRow(1).GetCell(15).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("P2:Q5")));
+
+            Assert.AreEqual("reallyLongRegion", sheetLoaded.GetRow(1).GetCell(17).StringCellValue);
+            Assert.False(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("R2:S12")));
+        }
+
+        [Test]
+        public void ShiftColumns_ShiftColumnsWithVariousMergedRegions_ColumnsShiftedWithMergedRegion()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            sheet.CreateRow(0).CreateCell(2).SetCellValue("2");
+            sheet.GetRow(0).CreateCell(3).SetCellValue("3");
+
+            sheet.CreateRow(1).CreateCell(1).SetCellValue("regionOutsideShiftedColumnsToTheLeft");
+            int regionOutsideToTheLeftId = sheet.AddMergedRegion(new CellRangeAddress(1, 2, 1, 1));
+
+            sheet.CreateRow(3).CreateCell(2).SetCellValue("regionInsideShiftedColumns");
+            int regionInsideId = sheet.AddMergedRegion(new CellRangeAddress(3, 4, 2, 3));
+
+            sheet.CreateRow(5).CreateCell(4).SetCellValue("regionRighNextToTheShiftedColumns");
+            int regionRighNextToId = sheet.AddMergedRegion(new CellRangeAddress(5, 6, 4, 5));
+
+            sheet.CreateRow(7).CreateCell(6).SetCellValue("regionInTheWayOfTheShift");
+            int regionInTheWayOfTheShiftId = sheet.AddMergedRegion(new CellRangeAddress(7, 8, 6, 7));
+
+            sheet.CreateRow(9).CreateCell(10).SetCellValue("regionOutsideShiftedColumnsToTheRight");
+            int regionOutsideToTheRightId = sheet.AddMergedRegion(new CellRangeAddress(9, 10, 10, 11));
+
+            sheet.CreateRow(11).CreateCell(1).SetCellValue("regionThatEndsWithinShiftedColumns");
+            int regionThatEndsWithinShiftedColumnsId = sheet.AddMergedRegion(new CellRangeAddress(11, 12, 1, 2));
+
+            sheet.CreateRow(13).CreateCell(1).SetCellValue("regionThatEndsOnLastShiftedColumn");
+            int regionThatEndsOnLastShiftedColumnId = sheet.AddMergedRegion(new CellRangeAddress(13, 14, 1, 3));
+
+            sheet.CreateRow(15).CreateCell(1).SetCellValue("regionThatEndsOutsideShiftedColumns");
+            int regionThatEndsOutsideShiftedColumnsId = sheet.AddMergedRegion(new CellRangeAddress(15, 16, 1, 4));
+
+            sheet.CreateRow(17).CreateCell(1).SetCellValue("reallyLongRegion");
+            int reallyLongRegionId = sheet.AddMergedRegion(new CellRangeAddress(17, 18, 1, 11));
+
+            Assert.AreEqual("regionOutsideShiftedColumnsToTheLeft", sheet.GetRow(1).GetCell(1).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("B2:B3")));
+
+            Assert.AreEqual("regionInsideShiftedColumns", sheet.GetRow(3).GetCell(2).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("C4:D5")));
+
+            Assert.AreEqual("regionRighNextToTheShiftedColumns", sheet.GetRow(5).GetCell(4).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("E6:F7")));
+
+            Assert.AreEqual("regionInTheWayOfTheShift", sheet.GetRow(7).GetCell(6).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("G8:H9")));
+
+            Assert.AreEqual("regionOutsideShiftedColumnsToTheRight", sheet.GetRow(9).GetCell(10).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("K10:L11")));
+
+            Assert.AreEqual("regionThatEndsWithinShiftedColumns", sheet.GetRow(11).GetCell(1).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("B12:C13")));
+
+            Assert.AreEqual("regionThatEndsOnLastShiftedColumn", sheet.GetRow(13).GetCell(1).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("B14:D15")));
+
+            Assert.AreEqual("regionThatEndsOutsideShiftedColumns", sheet.GetRow(15).GetCell(1).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("B16:E17")));
+
+            Assert.AreEqual("reallyLongRegion", sheet.GetRow(17).GetCell(1).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("B18:L19")));
+
+            sheet.ShiftColumns(2, 3, 4);
+
+            Assert.AreEqual("regionOutsideShiftedColumnsToTheLeft", sheet.GetRow(1).GetCell(1).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("B2:B3")));
+
+            Assert.AreEqual("regionInsideShiftedColumns", sheet.GetRow(3).GetCell(6).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("G4:H5")));
+
+            Assert.AreEqual("regionRighNextToTheShiftedColumns", sheet.GetRow(5).GetCell(4).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("E6:F7")));
+
+            Assert.IsNull(sheet.GetRow(7).GetCell(6));
+            Assert.False(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("G8:H9")));
+
+            Assert.AreEqual("regionOutsideShiftedColumnsToTheRight", sheet.GetRow(9).GetCell(10).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("K10:L11")));
+
+            Assert.AreEqual("regionThatEndsWithinShiftedColumns", sheet.GetRow(11).GetCell(1).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("B12:C13")));
+
+            Assert.AreEqual("regionThatEndsOnLastShiftedColumn", sheet.GetRow(13).GetCell(1).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("B14:D15")));
+
+            Assert.AreEqual("regionThatEndsOutsideShiftedColumns", sheet.GetRow(15).GetCell(1).StringCellValue);
+            Assert.True(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("B16:E17")));
+
+            Assert.AreEqual("reallyLongRegion", sheet.GetRow(17).GetCell(1).StringCellValue);
+            Assert.False(sheet.MergedRegions.Any(r => r.FormatAsString().Equals("B18:L19")));
+
+            FileInfo file = TempFile.CreateTempFile("ShiftCols1-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+
+            Assert.AreEqual("regionOutsideShiftedColumnsToTheLeft", sheetLoaded.GetRow(1).GetCell(1).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("B2:B3")));
+
+            Assert.AreEqual("regionInsideShiftedColumns", sheetLoaded.GetRow(3).GetCell(6).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("G4:H5")));
+
+            Assert.AreEqual("regionRighNextToTheShiftedColumns", sheetLoaded.GetRow(5).GetCell(4).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("E6:F7")));
+
+            Assert.IsNull(sheetLoaded.GetRow(7).GetCell(6));
+            Assert.False(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("G8:H9")));
+
+            Assert.AreEqual("regionOutsideShiftedColumnsToTheRight", sheetLoaded.GetRow(9).GetCell(10).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("K10:L11")));
+
+            Assert.AreEqual("regionThatEndsWithinShiftedColumns", sheetLoaded.GetRow(11).GetCell(1).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("B12:C13")));
+
+            Assert.AreEqual("regionThatEndsOnLastShiftedColumn", sheetLoaded.GetRow(13).GetCell(1).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("B14:D15")));
+
+            Assert.AreEqual("regionThatEndsOutsideShiftedColumns", sheetLoaded.GetRow(15).GetCell(1).StringCellValue);
+            Assert.True(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("B16:E17")));
+
+            Assert.AreEqual("reallyLongRegion", sheetLoaded.GetRow(17).GetCell(1).StringCellValue);
+            Assert.False(sheetLoaded.MergedRegions.Any(r => r.FormatAsString().Equals("B18:L19")));
+        }
+
         [Test]
         public void TestExistingHeaderFooter()
         {

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
@@ -1116,78 +1116,79 @@ namespace TestCases.XSSF.UserModel
             // Save and re-load
             XSSFWorkbook wb2 = XSSFTestDataSamples.WriteOutAndReadBack(wb1);
             wb1.Close();
-            sheet1 = (XSSFSheet)wb2.GetSheetAt(0);
-            Assert.AreEqual(10, cols.sizeOfColArray());
+            var sheet2 = (XSSFSheet)wb2.GetSheetAt(0);
+            var cols2 = sheet2.GetCTWorksheet().GetColsArray(0);
+            Assert.AreEqual(10, cols2.sizeOfColArray());
 
-            Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
-            Assert.AreEqual(false, cols.GetColArray(0).IsSetCollapsed());
-            Assert.AreEqual(false, cols.GetColArray(0).collapsed);
-            Assert.AreEqual(1, cols.GetColArray(0).outlineLevel);
-            Assert.AreEqual(4 + 1, cols.GetColArray(0).min); // 1 based
-            Assert.AreEqual(4 + 1, cols.GetColArray(0).max); // 1 based
+            Assert.AreEqual(false, cols2.GetColArray(0).IsSetHidden());
+            Assert.AreEqual(false, cols2.GetColArray(0).IsSetCollapsed());
+            Assert.AreEqual(false, cols2.GetColArray(0).collapsed);
+            Assert.AreEqual(1, cols2.GetColArray(0).outlineLevel);
+            Assert.AreEqual(4 + 1, cols2.GetColArray(0).min); // 1 based
+            Assert.AreEqual(4 + 1, cols2.GetColArray(0).max); // 1 based
 
-            Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
-            Assert.AreEqual(false, cols.GetColArray(1).IsSetCollapsed());
-            Assert.AreEqual(false, cols.GetColArray(1).collapsed);
-            Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
-            Assert.AreEqual(5 + 1, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(5 + 1, cols.GetColArray(1).max); // 1 based
+            Assert.AreEqual(false, cols2.GetColArray(1).IsSetHidden());
+            Assert.AreEqual(false, cols2.GetColArray(1).IsSetCollapsed());
+            Assert.AreEqual(false, cols2.GetColArray(1).collapsed);
+            Assert.AreEqual(1, cols2.GetColArray(1).outlineLevel);
+            Assert.AreEqual(5 + 1, cols2.GetColArray(1).min); // 1 based
+            Assert.AreEqual(5 + 1, cols2.GetColArray(1).max); // 1 based
 
-            Assert.AreEqual(false, cols.GetColArray(2).IsSetHidden());
-            Assert.AreEqual(false, cols.GetColArray(2).IsSetCollapsed());
-            Assert.AreEqual(false, cols.GetColArray(2).collapsed);
-            Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
-            Assert.AreEqual(6 + 1, cols.GetColArray(2).min); // 1 based
-            Assert.AreEqual(6 + 1, cols.GetColArray(2).max); // 1 based
+            Assert.AreEqual(false, cols2.GetColArray(2).IsSetHidden());
+            Assert.AreEqual(false, cols2.GetColArray(2).IsSetCollapsed());
+            Assert.AreEqual(false, cols2.GetColArray(2).collapsed);
+            Assert.AreEqual(1, cols2.GetColArray(2).outlineLevel);
+            Assert.AreEqual(6 + 1, cols2.GetColArray(2).min); // 1 based
+            Assert.AreEqual(6 + 1, cols2.GetColArray(2).max); // 1 based
 
-            Assert.AreEqual(false, cols.GetColArray(3).IsSetHidden());
-            Assert.AreEqual(false, cols.GetColArray(3).IsSetCollapsed());
-            Assert.AreEqual(false, cols.GetColArray(3).collapsed);
-            Assert.AreEqual(1, cols.GetColArray(3).outlineLevel);
-            Assert.AreEqual(7 + 1, cols.GetColArray(3).min); // 1 based
-            Assert.AreEqual(7 + 1, cols.GetColArray(3).max); // 1 based
+            Assert.AreEqual(false, cols2.GetColArray(3).IsSetHidden());
+            Assert.AreEqual(false, cols2.GetColArray(3).IsSetCollapsed());
+            Assert.AreEqual(false, cols2.GetColArray(3).collapsed);
+            Assert.AreEqual(1, cols2.GetColArray(3).outlineLevel);
+            Assert.AreEqual(7 + 1, cols2.GetColArray(3).min); // 1 based
+            Assert.AreEqual(7 + 1, cols2.GetColArray(3).max); // 1 based
 
-            Assert.AreEqual(false, cols.GetColArray(4).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
-            Assert.AreEqual(false, cols.GetColArray(4).collapsed);
-            Assert.AreEqual(0, cols.GetColArray(4).outlineLevel);
-            Assert.AreEqual(8 + 1, cols.GetColArray(4).min); // 1 based
-            Assert.AreEqual(8 + 1, cols.GetColArray(4).max); // 1 based
+            Assert.AreEqual(false, cols2.GetColArray(4).IsSetHidden());
+            Assert.AreEqual(false, cols2.GetColArray(4).IsSetCollapsed());
+            Assert.AreEqual(false, cols2.GetColArray(4).collapsed);
+            Assert.AreEqual(0, cols2.GetColArray(4).outlineLevel);
+            Assert.AreEqual(8 + 1, cols2.GetColArray(4).min); // 1 based
+            Assert.AreEqual(8 + 1, cols2.GetColArray(4).max); // 1 based
 
-            Assert.AreEqual(false, cols.GetColArray(5).IsSetHidden());
-            Assert.AreEqual(false, cols.GetColArray(5).IsSetCollapsed());
-            Assert.AreEqual(false, cols.GetColArray(5).collapsed);
-            Assert.AreEqual(1, cols.GetColArray(5).outlineLevel);
-            Assert.AreEqual(9 + 1, cols.GetColArray(5).min); // 1 based
-            Assert.AreEqual(9 + 1, cols.GetColArray(5).max); // 1 based
+            Assert.AreEqual(false, cols2.GetColArray(5).IsSetHidden());
+            Assert.AreEqual(false, cols2.GetColArray(5).IsSetCollapsed());
+            Assert.AreEqual(false, cols2.GetColArray(5).collapsed);
+            Assert.AreEqual(1, cols2.GetColArray(5).outlineLevel);
+            Assert.AreEqual(9 + 1, cols2.GetColArray(5).min); // 1 based
+            Assert.AreEqual(9 + 1, cols2.GetColArray(5).max); // 1 based
 
-            Assert.AreEqual(false, cols.GetColArray(6).IsSetHidden());
-            Assert.AreEqual(false, cols.GetColArray(6).IsSetCollapsed());
-            Assert.AreEqual(false, cols.GetColArray(6).collapsed);
-            Assert.AreEqual(2, cols.GetColArray(6).outlineLevel);
-            Assert.AreEqual(10 + 1, cols.GetColArray(6).min); // 1 based
-            Assert.AreEqual(10 + 1, cols.GetColArray(6).max); // 1 based
+            Assert.AreEqual(false, cols2.GetColArray(6).IsSetHidden());
+            Assert.AreEqual(false, cols2.GetColArray(6).IsSetCollapsed());
+            Assert.AreEqual(false, cols2.GetColArray(6).collapsed);
+            Assert.AreEqual(2, cols2.GetColArray(6).outlineLevel);
+            Assert.AreEqual(10 + 1, cols2.GetColArray(6).min); // 1 based
+            Assert.AreEqual(10 + 1, cols2.GetColArray(6).max); // 1 based
 
-            Assert.AreEqual(false, cols.GetColArray(7).IsSetHidden());
-            Assert.AreEqual(false, cols.GetColArray(7).IsSetCollapsed());
-            Assert.AreEqual(false, cols.GetColArray(7).collapsed);
-            Assert.AreEqual(2, cols.GetColArray(7).outlineLevel);
-            Assert.AreEqual(11 + 1, cols.GetColArray(7).min); // 1 based
-            Assert.AreEqual(11 + 1, cols.GetColArray(7).max); // 1 based
+            Assert.AreEqual(false, cols2.GetColArray(7).IsSetHidden());
+            Assert.AreEqual(false, cols2.GetColArray(7).IsSetCollapsed());
+            Assert.AreEqual(false, cols2.GetColArray(7).collapsed);
+            Assert.AreEqual(2, cols2.GetColArray(7).outlineLevel);
+            Assert.AreEqual(11 + 1, cols2.GetColArray(7).min); // 1 based
+            Assert.AreEqual(11 + 1, cols2.GetColArray(7).max); // 1 based
 
-            Assert.AreEqual(false, cols.GetColArray(8).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(8).IsSetCollapsed());
-            Assert.AreEqual(false, cols.GetColArray(8).collapsed);
-            Assert.AreEqual(1, cols.GetColArray(8).outlineLevel);
-            Assert.AreEqual(12 + 1, cols.GetColArray(8).min); // 1 based
-            Assert.AreEqual(12 + 1, cols.GetColArray(8).max); // 1 based
+            Assert.AreEqual(false, cols2.GetColArray(8).IsSetHidden());
+            Assert.AreEqual(false, cols2.GetColArray(8).IsSetCollapsed());
+            Assert.AreEqual(false, cols2.GetColArray(8).collapsed);
+            Assert.AreEqual(1, cols2.GetColArray(8).outlineLevel);
+            Assert.AreEqual(12 + 1, cols2.GetColArray(8).min); // 1 based
+            Assert.AreEqual(12 + 1, cols2.GetColArray(8).max); // 1 based
 
-            Assert.AreEqual(false, cols.GetColArray(9).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(9).IsSetCollapsed());
-            Assert.AreEqual(false, cols.GetColArray(9).collapsed);
-            Assert.AreEqual(0, cols.GetColArray(9).outlineLevel);
-            Assert.AreEqual(13 + 1, cols.GetColArray(9).min); // 1 based
-            Assert.AreEqual(13 + 1, cols.GetColArray(9).max); // 1 based
+            Assert.AreEqual(false, cols2.GetColArray(9).IsSetHidden());
+            Assert.AreEqual(false, cols2.GetColArray(9).IsSetCollapsed());
+            Assert.AreEqual(false, cols2.GetColArray(9).collapsed);
+            Assert.AreEqual(0, cols2.GetColArray(9).outlineLevel);
+            Assert.AreEqual(13 + 1, cols2.GetColArray(9).min); // 1 based
+            Assert.AreEqual(13 + 1, cols2.GetColArray(9).max); // 1 based
 
             wb2.Close();
         }

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
@@ -19,6 +19,7 @@ using NPOI;
 using NPOI.OpenXmlFormats.Spreadsheet;
 using NPOI.POIFS.Crypt;
 using NPOI.SS;
+using NPOI.SS.Formula.Functions;
 using NPOI.SS.UserModel;
 using NPOI.SS.Util;
 using NPOI.Util;
@@ -134,27 +135,27 @@ namespace TestCases.XSSF.UserModel
             Assert.IsNotNull(sheet.FirstHeader);
 
             Assert.AreEqual("", sheet.OddFooter.Left);
-            sheet.OddFooter.Left = ("odd footer left");
+            sheet.OddFooter.Left = "odd footer left";
             Assert.AreEqual("odd footer left", sheet.OddFooter.Left);
 
             Assert.AreEqual("", sheet.EvenFooter.Left);
-            sheet.EvenFooter.Left = ("even footer left");
+            sheet.EvenFooter.Left = "even footer left";
             Assert.AreEqual("even footer left", sheet.EvenFooter.Left);
 
             Assert.AreEqual("", sheet.FirstFooter.Left);
-            sheet.FirstFooter.Left = ("first footer left");
+            sheet.FirstFooter.Left = "first footer left";
             Assert.AreEqual("first footer left", sheet.FirstFooter.Left);
 
             Assert.AreEqual("", sheet.OddHeader.Left);
-            sheet.OddHeader.Left = ("odd header left");
+            sheet.OddHeader.Left = "odd header left";
             Assert.AreEqual("odd header left", sheet.OddHeader.Left);
 
             Assert.AreEqual("", sheet.OddHeader.Right);
-            sheet.OddHeader.Right = ("odd header right");
+            sheet.OddHeader.Right = "odd header right";
             Assert.AreEqual("odd header right", sheet.OddHeader.Right);
 
             Assert.AreEqual("", sheet.OddHeader.Center);
-            sheet.OddHeader.Center = ("odd header center");
+            sheet.OddHeader.Center = "odd header center";
             Assert.AreEqual("odd header center", sheet.OddHeader.Center);
 
             // Defaults are odd
@@ -172,9 +173,7 @@ namespace TestCases.XSSF.UserModel
 
             sheet.AutoSizeColumn(13);
 
-            ColumnHelper columnHelper = sheet.GetColumnHelper();
-            CT_Col col = columnHelper.GetColumn(13, false);
-            Assert.IsTrue(col.bestFit);
+            Assert.IsTrue(sheet.GetColumn(13).IsBestFit);
 
             workbook.Close();
         }
@@ -186,10 +185,10 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook workbook = new XSSFWorkbook();
             XSSFSheet sheet = (XSSFSheet)workbook.CreateSheet("Sheet 1");
 
-            var row = sheet.CreateRow(0);
-            var cell = row.CreateCell(13);
+            IRow row = sheet.CreateRow(0);
+            ICell cell = row.CreateCell(13);
             cell.SetCellValue("test");
-            var font = cell.CellStyle.GetFont(workbook);
+            IFont font = cell.CellStyle.GetFont(workbook);
             font.FontHeightInPoints = 20;
             cell.CellStyle.SetFont(font);
             row.Height = 100;
@@ -215,9 +214,9 @@ namespace TestCases.XSSF.UserModel
             CommentsTable comments = sheet.GetCommentsTable(false);
             CT_Comments ctComments = comments.GetCTComments();
 
-            cell.CellComment = (comment);
+            cell.CellComment = comment;
             Assert.AreEqual("A1", ctComments.commentList.GetCommentArray(0).@ref);
-            comment.Author = ("test A1 author");
+            comment.Author = "test A1 author";
             Assert.AreEqual("test A1 author", comments.GetAuthor((int)ctComments.commentList.GetCommentArray(0).authorId));
 
             workbook.Close();
@@ -282,7 +281,6 @@ namespace TestCases.XSSF.UserModel
             workbook.Close();
         }
 
-
         [Test]
         public void TestSetDefaultColumnStyle()
         {
@@ -290,17 +288,23 @@ namespace TestCases.XSSF.UserModel
             XSSFSheet sheet = (XSSFSheet)workbook.CreateSheet();
             CT_Worksheet ctWorksheet = sheet.GetCTWorksheet();
             StylesTable stylesTable = workbook.GetStylesSource();
-            XSSFFont font = new XSSFFont();
-            font.FontName = ("Cambria");
+            XSSFFont font = new XSSFFont
+            {
+                FontName = "Cambria"
+            };
             stylesTable.PutFont(font);
-            CT_Xf cellStyleXf = new CT_Xf();
-            cellStyleXf.fontId = (1);
-            cellStyleXf.fillId = 0;
-            cellStyleXf.borderId = 0;
-            cellStyleXf.numFmtId = 0;
+            CT_Xf cellStyleXf = new CT_Xf
+            {
+                fontId = 1,
+                fillId = 0,
+                borderId = 0,
+                numFmtId = 0
+            };
             stylesTable.PutCellStyleXf(cellStyleXf);
-            CT_Xf cellXf = new CT_Xf();
-            cellXf.xfId = (1);
+            CT_Xf cellXf = new CT_Xf
+            {
+                xfId = 1
+            };
             stylesTable.PutCellXf(cellXf);
             XSSFCellStyle cellStyle = new XSSFCellStyle(1, 1, stylesTable, null);
             Assert.AreEqual(1, cellStyle.FontIndex);
@@ -321,18 +325,39 @@ namespace TestCases.XSSF.UserModel
             sheet.GroupColumn(2, 7);
             sheet.GroupColumn(10, 11);
             CT_Cols cols = sheet.GetCTWorksheet().GetColsArray(0);
-            Assert.AreEqual(2, cols.sizeOfColArray());
+            Assert.AreEqual(8, cols.sizeOfColArray());
             List<CT_Col> colArray = cols.GetColList();
             Assert.IsNotNull(colArray);
             Assert.AreEqual((uint)(2 + 1), colArray[0].min); // 1 based
-            Assert.AreEqual((uint)(7 + 1), colArray[0].max); // 1 based
+            Assert.AreEqual((uint)(2 + 1), colArray[0].max); // 1 based
             Assert.AreEqual(1, colArray[0].outlineLevel);
+
+            Assert.AreEqual((uint)(3 + 1), colArray[1].min); // 1 based
+            Assert.AreEqual((uint)(3 + 1), colArray[1].max); // 1 based
+            Assert.AreEqual(1, colArray[1].outlineLevel);
+
+            Assert.AreEqual((uint)(4 + 1), colArray[2].min); // 1 based
+            Assert.AreEqual((uint)(4 + 1), colArray[2].max); // 1 based
+            Assert.AreEqual(1, colArray[2].outlineLevel);
+
+            Assert.AreEqual((uint)(5 + 1), colArray[3].min); // 1 based
+            Assert.AreEqual((uint)(5 + 1), colArray[3].max); // 1 based
+            Assert.AreEqual(1, colArray[3].outlineLevel);
+
+            Assert.AreEqual((uint)(6 + 1), colArray[4].min); // 1 based
+            Assert.AreEqual((uint)(6 + 1), colArray[4].max); // 1 based
+            Assert.AreEqual(1, colArray[4].outlineLevel);
+
+            Assert.AreEqual((uint)(7 + 1), colArray[5].min); // 1 based
+            Assert.AreEqual((uint)(7 + 1), colArray[5].max); // 1 based
+            Assert.AreEqual(1, colArray[5].outlineLevel);
+
             Assert.AreEqual(0, sheet.GetColumnOutlineLevel(0));
 
             //two level
             sheet.GroupColumn(1, 2);
             cols = sheet.GetCTWorksheet().GetColsArray(0);
-            Assert.AreEqual(4, cols.sizeOfColArray());
+            Assert.AreEqual(9, cols.sizeOfColArray());
             colArray = cols.GetColList();
             Assert.AreEqual(2, colArray[1].outlineLevel);
 
@@ -340,7 +365,7 @@ namespace TestCases.XSSF.UserModel
             sheet.GroupColumn(6, 8);
             sheet.GroupColumn(2, 3);
             cols = sheet.GetCTWorksheet().GetColsArray(0);
-            Assert.AreEqual(7, cols.sizeOfColArray());
+            Assert.AreEqual(10, cols.sizeOfColArray());
             colArray = cols.GetColList();
             Assert.AreEqual(3, colArray[1].outlineLevel);
             Assert.AreEqual(3, sheet.GetCTWorksheet().sheetFormatPr.outlineLevelCol);
@@ -352,7 +377,7 @@ namespace TestCases.XSSF.UserModel
             sheet.UngroupColumn(4, 6);
             sheet.UngroupColumn(2, 2);
             colArray = cols.GetColList();
-            Assert.AreEqual(4, colArray.Count);
+            Assert.AreEqual(6, colArray.Count);
             Assert.AreEqual(2, sheet.GetCTWorksheet().sheetFormatPr.outlineLevelCol);
 
             workbook.Close();
@@ -382,7 +407,6 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(11u, ctrow.r);
             Assert.AreEqual(2, ctrow.outlineLevel);
             Assert.AreEqual(2, sheet.GetCTWorksheet().sheetFormatPr.outlineLevelRow);
-
 
             sheet.UngroupRow(8, 10);
             Assert.AreEqual(4, sheet.PhysicalNumberOfRows);
@@ -434,226 +458,640 @@ namespace TestCases.XSSF.UserModel
         {
             XSSFWorkbook wb1 = new XSSFWorkbook();
             XSSFSheet sheet1 = (XSSFSheet)wb1.CreateSheet();
-
             CT_Cols cols = sheet1.GetCTWorksheet().GetColsArray(0);
+
             Assert.AreEqual(0, cols.sizeOfColArray());
 
-            sheet1.GroupColumn((short)4, (short)7);
-            sheet1.GroupColumn((short)9, (short)12);
+            sheet1.GroupColumn(4, 7);
+            sheet1.GroupColumn(9, 12);
 
-            Assert.AreEqual(2, cols.sizeOfColArray());
-
-            Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(0).IsSetCollapsed());
-            Assert.AreEqual(5, cols.GetColArray(0).min); // 1 based
-            Assert.AreEqual(8, cols.GetColArray(0).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(1).IsSetCollapsed());
-            Assert.AreEqual(10, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(13, cols.GetColArray(1).max); // 1 based
-
-            sheet1.GroupColumn((short)10, (short)11);
-            Assert.AreEqual(4, cols.sizeOfColArray());
+            Assert.AreEqual(8, cols.sizeOfColArray());
 
             Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(0).IsSetCollapsed());
-            Assert.AreEqual(5, cols.GetColArray(0).min); // 1 based
-            Assert.AreEqual(8, cols.GetColArray(0).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(1).IsSetCollapsed());
-            Assert.AreEqual(10, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(10, cols.GetColArray(1).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(2).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(2).IsSetCollapsed());
-            Assert.AreEqual(11, cols.GetColArray(2).min); // 1 based
-            Assert.AreEqual(12, cols.GetColArray(2).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(3).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(3).IsSetCollapsed());
-            Assert.AreEqual(13, cols.GetColArray(3).min); // 1 based
-            Assert.AreEqual(13, cols.GetColArray(3).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(0).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(0).outlineLevel);
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).min); // 1 based
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).max); // 1 based
 
-            // collapse columns - 1
-            sheet1.SetColumnGroupCollapsed((short)5, true);
-            Assert.AreEqual(5, cols.sizeOfColArray());
-
-            Assert.AreEqual(true, cols.GetColArray(0).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(0).IsSetCollapsed());
-            Assert.AreEqual(5, cols.GetColArray(0).min); // 1 based
-            Assert.AreEqual(8, cols.GetColArray(0).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(1).IsSetCollapsed());
-            Assert.AreEqual(9, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(9, cols.GetColArray(1).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(2).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(2).IsSetCollapsed());
-            Assert.AreEqual(10, cols.GetColArray(2).min); // 1 based
-            Assert.AreEqual(10, cols.GetColArray(2).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(3).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(3).IsSetCollapsed());
-            Assert.AreEqual(11, cols.GetColArray(3).min); // 1 based
-            Assert.AreEqual(12, cols.GetColArray(3).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(4).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
-            Assert.AreEqual(13, cols.GetColArray(4).min); // 1 based
-            Assert.AreEqual(13, cols.GetColArray(4).max); // 1 based
-
-
-            // expand columns - 1
-            sheet1.SetColumnGroupCollapsed((short)5, false);
-
-            Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(0).IsSetCollapsed());
-            Assert.AreEqual(5, cols.GetColArray(0).min); // 1 based
-            Assert.AreEqual(8, cols.GetColArray(0).max); // 1 based
             Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
             Assert.AreEqual(false, cols.GetColArray(1).IsSetCollapsed());
-            Assert.AreEqual(9, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(9, cols.GetColArray(1).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(1).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).min); // 1 based
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).max); // 1 based
+
             Assert.AreEqual(false, cols.GetColArray(2).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(2).IsSetCollapsed());
-            Assert.AreEqual(10, cols.GetColArray(2).min); // 1 based
-            Assert.AreEqual(10, cols.GetColArray(2).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(2).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).max); // 1 based
+
             Assert.AreEqual(false, cols.GetColArray(3).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(3).IsSetCollapsed());
-            Assert.AreEqual(11, cols.GetColArray(3).min); // 1 based
-            Assert.AreEqual(12, cols.GetColArray(3).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(3).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).max); // 1 based
+
             Assert.AreEqual(false, cols.GetColArray(4).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
-            Assert.AreEqual(13, cols.GetColArray(4).min); // 1 based
-            Assert.AreEqual(13, cols.GetColArray(4).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(4).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(4).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(4).outlineLevel);
+            Assert.AreEqual(9 + 1, cols.GetColArray(4).min); // 1 based
+            Assert.AreEqual(9 + 1, cols.GetColArray(4).max); // 1 based
 
-
-            //collapse - 2
-            sheet1.SetColumnGroupCollapsed((short)9, true);
-            Assert.AreEqual(6, cols.sizeOfColArray());
-            Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(0).IsSetCollapsed());
-            Assert.AreEqual(5, cols.GetColArray(0).min); // 1 based
-            Assert.AreEqual(8, cols.GetColArray(0).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
-            Assert.AreEqual(false, cols.GetColArray(1).IsSetCollapsed());
-            Assert.AreEqual(9, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(9, cols.GetColArray(1).max); // 1 based
-            Assert.AreEqual(true, cols.GetColArray(2).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(2).IsSetCollapsed());
-            Assert.AreEqual(10, cols.GetColArray(2).min); // 1 based
-            Assert.AreEqual(10, cols.GetColArray(2).max); // 1 based
-            Assert.AreEqual(true, cols.GetColArray(3).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(3).IsSetCollapsed());
-            Assert.AreEqual(11, cols.GetColArray(3).min); // 1 based
-            Assert.AreEqual(12, cols.GetColArray(3).max); // 1 based
-            Assert.AreEqual(true, cols.GetColArray(4).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
-            Assert.AreEqual(13, cols.GetColArray(4).min); // 1 based
-            Assert.AreEqual(13, cols.GetColArray(4).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(5).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(5).IsSetCollapsed());
-            Assert.AreEqual(14, cols.GetColArray(5).min); // 1 based
-            Assert.AreEqual(14, cols.GetColArray(5).max); // 1 based
-
-
-            //expand - 2
-            sheet1.SetColumnGroupCollapsed((short)9, false);
-            Assert.AreEqual(6, cols.sizeOfColArray());
-            Assert.AreEqual(14, cols.GetColArray(5).min);
-
-            //outline level 2: the line under ==> collapsed==True
-            Assert.AreEqual(2, cols.GetColArray(3).outlineLevel);
-            Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
-
-            Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(0).IsSetCollapsed());
-            Assert.AreEqual(5, cols.GetColArray(0).min); // 1 based
-            Assert.AreEqual(8, cols.GetColArray(0).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
-            Assert.AreEqual(false, cols.GetColArray(1).IsSetCollapsed());
-            Assert.AreEqual(9, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(9, cols.GetColArray(1).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(2).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(2).IsSetCollapsed());
-            Assert.AreEqual(10, cols.GetColArray(2).min); // 1 based
-            Assert.AreEqual(10, cols.GetColArray(2).max); // 1 based
-            Assert.AreEqual(true, cols.GetColArray(3).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(3).IsSetCollapsed());
-            Assert.AreEqual(11, cols.GetColArray(3).min); // 1 based
-            Assert.AreEqual(12, cols.GetColArray(3).max); // 1 based
-            Assert.AreEqual(false, cols.GetColArray(4).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
-            Assert.AreEqual(13, cols.GetColArray(4).min); // 1 based
-            Assert.AreEqual(13, cols.GetColArray(4).max); // 1 based
             Assert.AreEqual(false, cols.GetColArray(5).IsSetHidden());
             Assert.AreEqual(false, cols.GetColArray(5).IsSetCollapsed());
-            Assert.AreEqual(14, cols.GetColArray(5).min); // 1 based
-            Assert.AreEqual(14, cols.GetColArray(5).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(5).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(5).outlineLevel);
+            Assert.AreEqual(10 + 1, cols.GetColArray(5).min); // 1 based
+            Assert.AreEqual(10 + 1, cols.GetColArray(5).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(6).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(6).outlineLevel);
+            Assert.AreEqual(11 + 1, cols.GetColArray(6).min); // 1 based
+            Assert.AreEqual(11 + 1, cols.GetColArray(6).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(7).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(7).outlineLevel);
+            Assert.AreEqual(12 + 1, cols.GetColArray(7).min); // 1 based
+            Assert.AreEqual(12 + 1, cols.GetColArray(7).max); // 1 based
+
+            sheet1.GroupColumn(10, 11);
+
+            Assert.AreEqual(8, cols.sizeOfColArray());
+
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(0).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(0).outlineLevel);
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).min); // 1 based
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(1).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(1).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).min); // 1 based
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(2).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(3).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(4).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(4).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(4).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(4).outlineLevel);
+            Assert.AreEqual(9 + 1, cols.GetColArray(4).min); // 1 based
+            Assert.AreEqual(9 + 1, cols.GetColArray(4).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(5).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(5).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(5).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(5).outlineLevel);
+            Assert.AreEqual(10 + 1, cols.GetColArray(5).min); // 1 based
+            Assert.AreEqual(10 + 1, cols.GetColArray(5).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(6).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(6).outlineLevel);
+            Assert.AreEqual(11 + 1, cols.GetColArray(6).min); // 1 based
+            Assert.AreEqual(11 + 1, cols.GetColArray(6).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(7).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(7).outlineLevel);
+            Assert.AreEqual(12 + 1, cols.GetColArray(7).min); // 1 based
+            Assert.AreEqual(12 + 1, cols.GetColArray(7).max); // 1 based
+
+            // collapse columns - 1
+            sheet1.SetColumnGroupCollapsed(5, true);
+
+            Assert.AreEqual(9, cols.sizeOfColArray());
+
+            Assert.AreEqual(true, cols.GetColArray(0).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(0).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(0).outlineLevel);
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).min); // 1 based
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).max); // 1 based
+
+            Assert.AreEqual(true, cols.GetColArray(1).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(1).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(1).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).min); // 1 based
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).max); // 1 based
+
+            Assert.AreEqual(true, cols.GetColArray(2).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(2).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).max); // 1 based
+
+            Assert.AreEqual(true, cols.GetColArray(3).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(3).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(4).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
+            Assert.AreEqual(true, cols.GetColArray(4).collapsed);
+            Assert.AreEqual(0, cols.GetColArray(4).outlineLevel);
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).min); // 1 based
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(5).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(5).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(5).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(5).outlineLevel);
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).min); // 1 based
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(6).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(6).outlineLevel);
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).min); // 1 based
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(7).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(7).outlineLevel);
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).min); // 1 based
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(8).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(8).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(8).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(8).outlineLevel);
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).min); // 1 based
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).max); // 1 based
+
+            // expand columns - 1
+            sheet1.SetColumnGroupCollapsed(5, false);
+
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(0).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(0).outlineLevel);
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).min); // 1 based
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(1).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(1).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).min); // 1 based
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(2).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(3).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(4).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(4).collapsed);
+            Assert.AreEqual(0, cols.GetColArray(4).outlineLevel);
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).min); // 1 based
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(5).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(5).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(5).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(5).outlineLevel);
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).min); // 1 based
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(6).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(6).outlineLevel);
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).min); // 1 based
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(7).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(7).outlineLevel);
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).min); // 1 based
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(8).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(8).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(8).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(8).outlineLevel);
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).min); // 1 based
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).max); // 1 based
+
+            //collapse - 2
+            sheet1.SetColumnGroupCollapsed(9, true);
+
+            Assert.AreEqual(10, cols.sizeOfColArray());
+
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(0).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(0).outlineLevel);
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).min); // 1 based
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(1).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(1).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).min); // 1 based
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(2).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(3).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(4).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(4).collapsed);
+            Assert.AreEqual(0, cols.GetColArray(4).outlineLevel);
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).min); // 1 based
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).max); // 1 based
+
+            Assert.AreEqual(true, cols.GetColArray(5).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(5).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(5).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(5).outlineLevel);
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).min); // 1 based
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).max); // 1 based
+
+            Assert.AreEqual(true, cols.GetColArray(6).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(6).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(6).outlineLevel);
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).min); // 1 based
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).max); // 1 based
+
+            Assert.AreEqual(true, cols.GetColArray(7).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(7).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(7).outlineLevel);
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).min); // 1 based
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).max); // 1 based
+
+            Assert.AreEqual(true, cols.GetColArray(8).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(8).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(8).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(8).outlineLevel);
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).min); // 1 based
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(9).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(9).IsSetCollapsed());
+            Assert.AreEqual(true, cols.GetColArray(9).collapsed);
+            Assert.AreEqual(0, cols.GetColArray(9).outlineLevel);
+            Assert.AreEqual(13 + 1, cols.GetColArray(9).min); // 1 based
+            Assert.AreEqual(13 + 1, cols.GetColArray(9).max); // 1 based
+
+            //expand - 2
+            sheet1.SetColumnGroupCollapsed(9, false);
+
+            Assert.AreEqual(10, cols.sizeOfColArray());
+
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(0).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(0).outlineLevel);
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).min); // 1 based
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(1).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(1).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).min); // 1 based
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(2).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(3).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(4).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(4).collapsed);
+            Assert.AreEqual(0, cols.GetColArray(4).outlineLevel);
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).min); // 1 based
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(5).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(5).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(5).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(5).outlineLevel);
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).min); // 1 based
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(6).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(6).outlineLevel);
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).min); // 1 based
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(7).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(7).outlineLevel);
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).min); // 1 based
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(8).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(8).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(8).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(8).outlineLevel);
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).min); // 1 based
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(9).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(9).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(9).collapsed);
+            Assert.AreEqual(0, cols.GetColArray(9).outlineLevel);
+            Assert.AreEqual(13 + 1, cols.GetColArray(9).min); // 1 based
+            Assert.AreEqual(13 + 1, cols.GetColArray(9).max); // 1 based
 
             //DOCUMENTARE MEGLIO IL DISCORSO DEL LIVELLO
             //collapse - 3
-            sheet1.SetColumnGroupCollapsed((short)10, true);
-            Assert.AreEqual(6, cols.sizeOfColArray());
+            sheet1.SetColumnGroupCollapsed(10, true);
+
+            Assert.AreEqual(10, cols.sizeOfColArray());
+
             Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(0).IsSetCollapsed());
-            Assert.AreEqual(5, cols.GetColArray(0).min); // 1 based
-            Assert.AreEqual(8, cols.GetColArray(0).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(0).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(0).outlineLevel);
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).min); // 1 based
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).max); // 1 based
+
             Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
             Assert.AreEqual(false, cols.GetColArray(1).IsSetCollapsed());
-            Assert.AreEqual(9, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(9, cols.GetColArray(1).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(1).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).min); // 1 based
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).max); // 1 based
+
             Assert.AreEqual(false, cols.GetColArray(2).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(2).IsSetCollapsed());
-            Assert.AreEqual(10, cols.GetColArray(2).min); // 1 based
-            Assert.AreEqual(10, cols.GetColArray(2).max); // 1 based
-            Assert.AreEqual(true, cols.GetColArray(3).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(3).IsSetCollapsed());
-            Assert.AreEqual(11, cols.GetColArray(3).min); // 1 based
-            Assert.AreEqual(12, cols.GetColArray(3).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(2).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(3).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).max); // 1 based
+
             Assert.AreEqual(false, cols.GetColArray(4).IsSetHidden());
             Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
-            Assert.AreEqual(13, cols.GetColArray(4).min); // 1 based
-            Assert.AreEqual(13, cols.GetColArray(4).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(4).collapsed);
+            Assert.AreEqual(0, cols.GetColArray(4).outlineLevel);
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).min); // 1 based
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).max); // 1 based
+
             Assert.AreEqual(false, cols.GetColArray(5).IsSetHidden());
             Assert.AreEqual(false, cols.GetColArray(5).IsSetCollapsed());
-            Assert.AreEqual(14, cols.GetColArray(5).min); // 1 based
-            Assert.AreEqual(14, cols.GetColArray(5).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(5).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(5).outlineLevel);
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).min); // 1 based
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).max); // 1 based
 
+            Assert.AreEqual(true, cols.GetColArray(6).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(6).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(6).outlineLevel);
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).min); // 1 based
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).max); // 1 based
+
+            Assert.AreEqual(true, cols.GetColArray(7).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(7).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(7).outlineLevel);
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).min); // 1 based
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(8).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(8).IsSetCollapsed());
+            Assert.AreEqual(true, cols.GetColArray(8).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(8).outlineLevel);
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).min); // 1 based
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(9).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(9).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(9).collapsed);
+            Assert.AreEqual(0, cols.GetColArray(9).outlineLevel);
+            Assert.AreEqual(13 + 1, cols.GetColArray(9).min); // 1 based
+            Assert.AreEqual(13 + 1, cols.GetColArray(9).max); // 1 based
 
             //expand - 3
-            sheet1.SetColumnGroupCollapsed((short)10, false);
-            Assert.AreEqual(6, cols.sizeOfColArray());
-            Assert.AreEqual(false, cols.GetColArray(0).hidden);
-            Assert.AreEqual(false, cols.GetColArray(5).hidden);
-            Assert.AreEqual(false, cols.GetColArray(4).IsSetCollapsed());
+            sheet1.SetColumnGroupCollapsed(10, false);
 
-            //      write out and give back
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(0).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(0).outlineLevel);
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).min); // 1 based
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(1).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(1).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).min); // 1 based
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(2).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(3).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(4).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(4).collapsed);
+            Assert.AreEqual(0, cols.GetColArray(4).outlineLevel);
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).min); // 1 based
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(5).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(5).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(5).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(5).outlineLevel);
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).min); // 1 based
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(6).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(6).outlineLevel);
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).min); // 1 based
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(7).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(7).outlineLevel);
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).min); // 1 based
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(8).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(8).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(8).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(8).outlineLevel);
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).min); // 1 based
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(9).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(9).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(9).collapsed);
+            Assert.AreEqual(0, cols.GetColArray(9).outlineLevel);
+            Assert.AreEqual(13 + 1, cols.GetColArray(9).min); // 1 based
+            Assert.AreEqual(13 + 1, cols.GetColArray(9).max); // 1 based
+
+            // write out and give back
             // Save and re-load
             XSSFWorkbook wb2 = XSSFTestDataSamples.WriteOutAndReadBack(wb1);
             wb1.Close();
             sheet1 = (XSSFSheet)wb2.GetSheetAt(0);
-            Assert.AreEqual(6, cols.sizeOfColArray());
+            Assert.AreEqual(10, cols.sizeOfColArray());
 
             Assert.AreEqual(false, cols.GetColArray(0).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(0).IsSetCollapsed());
-            Assert.AreEqual(5, cols.GetColArray(0).min); // 1 based
-            Assert.AreEqual(8, cols.GetColArray(0).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(0).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(0).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(0).outlineLevel);
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).min); // 1 based
+            Assert.AreEqual(4 + 1, cols.GetColArray(0).max); // 1 based
+
             Assert.AreEqual(false, cols.GetColArray(1).IsSetHidden());
             Assert.AreEqual(false, cols.GetColArray(1).IsSetCollapsed());
-            Assert.AreEqual(9, cols.GetColArray(1).min); // 1 based
-            Assert.AreEqual(9, cols.GetColArray(1).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(1).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(1).outlineLevel);
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).min); // 1 based
+            Assert.AreEqual(5 + 1, cols.GetColArray(1).max); // 1 based
+
             Assert.AreEqual(false, cols.GetColArray(2).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(2).IsSetCollapsed());
-            Assert.AreEqual(10, cols.GetColArray(2).min); // 1 based
-            Assert.AreEqual(10, cols.GetColArray(2).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(2).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(2).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(2).outlineLevel);
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).min); // 1 based
+            Assert.AreEqual(6 + 1, cols.GetColArray(2).max); // 1 based
+
             Assert.AreEqual(false, cols.GetColArray(3).IsSetHidden());
-            Assert.AreEqual(true, cols.GetColArray(3).IsSetCollapsed());
-            Assert.AreEqual(11, cols.GetColArray(3).min); // 1 based
-            Assert.AreEqual(12, cols.GetColArray(3).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(3).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(3).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(3).outlineLevel);
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).min); // 1 based
+            Assert.AreEqual(7 + 1, cols.GetColArray(3).max); // 1 based
+
             Assert.AreEqual(false, cols.GetColArray(4).IsSetHidden());
-            Assert.AreEqual(false, cols.GetColArray(4).IsSetCollapsed());
-            Assert.AreEqual(13, cols.GetColArray(4).min); // 1 based
-            Assert.AreEqual(13, cols.GetColArray(4).max); // 1 based
+            Assert.AreEqual(true, cols.GetColArray(4).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(4).collapsed);
+            Assert.AreEqual(0, cols.GetColArray(4).outlineLevel);
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).min); // 1 based
+            Assert.AreEqual(8 + 1, cols.GetColArray(4).max); // 1 based
+
             Assert.AreEqual(false, cols.GetColArray(5).IsSetHidden());
             Assert.AreEqual(false, cols.GetColArray(5).IsSetCollapsed());
-            Assert.AreEqual(14, cols.GetColArray(5).min); // 1 based
-            Assert.AreEqual(14, cols.GetColArray(5).max); // 1 based
+            Assert.AreEqual(false, cols.GetColArray(5).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(5).outlineLevel);
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).min); // 1 based
+            Assert.AreEqual(9 + 1, cols.GetColArray(5).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(6).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(6).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(6).outlineLevel);
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).min); // 1 based
+            Assert.AreEqual(10 + 1, cols.GetColArray(6).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetHidden());
+            Assert.AreEqual(false, cols.GetColArray(7).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(7).collapsed);
+            Assert.AreEqual(2, cols.GetColArray(7).outlineLevel);
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).min); // 1 based
+            Assert.AreEqual(11 + 1, cols.GetColArray(7).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(8).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(8).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(8).collapsed);
+            Assert.AreEqual(1, cols.GetColArray(8).outlineLevel);
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).min); // 1 based
+            Assert.AreEqual(12 + 1, cols.GetColArray(8).max); // 1 based
+
+            Assert.AreEqual(false, cols.GetColArray(9).IsSetHidden());
+            Assert.AreEqual(true, cols.GetColArray(9).IsSetCollapsed());
+            Assert.AreEqual(false, cols.GetColArray(9).collapsed);
+            Assert.AreEqual(0, cols.GetColArray(9).outlineLevel);
+            Assert.AreEqual(13 + 1, cols.GetColArray(9).min); // 1 based
+            Assert.AreEqual(13 + 1, cols.GetColArray(9).max); // 1 based
 
             wb2.Close();
         }
@@ -719,7 +1157,6 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(false, ((XSSFRow)sheet1.GetRow(16)).GetCTRow().IsSetHidden());
             Assert.AreEqual(false, ((XSSFRow)sheet1.GetRow(18)).GetCTRow().IsSetCollapsed());
             Assert.AreEqual(false, ((XSSFRow)sheet1.GetRow(18)).GetCTRow().IsSetHidden());
-
 
             // Save and re-load
             XSSFWorkbook wb2 = XSSFTestDataSamples.WriteOutAndReadBack(wb1);
@@ -806,9 +1243,21 @@ namespace TestCases.XSSF.UserModel
             //</cols>
 
             //a span of columns [1,5]
-            Assert.AreEqual(1, cols.sizeOfColArray());
+            Assert.AreEqual(5, cols.sizeOfColArray());
             CT_Col col = cols.GetColArray(0);
             Assert.AreEqual((uint)1, col.min);
+            Assert.AreEqual((uint)1, col.max);
+            col = cols.GetColArray(1);
+            Assert.AreEqual((uint)2, col.min);
+            Assert.AreEqual((uint)2, col.max);
+            col = cols.GetColArray(2);
+            Assert.AreEqual((uint)3, col.min);
+            Assert.AreEqual((uint)3, col.max);
+            col = cols.GetColArray(3);
+            Assert.AreEqual((uint)4, col.min);
+            Assert.AreEqual((uint)4, col.max);
+            col = cols.GetColArray(4);
+            Assert.AreEqual((uint)5, col.min);
             Assert.AreEqual((uint)5, col.max);
             double swidth = 15.77734375; //width of columns in the span
             Assert.AreEqual(swidth, col.width, 0.0);
@@ -866,7 +1315,7 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook wb1 = XSSFTestDataSamples.OpenSampleWorkbook("47804.xlsx");
             XSSFSheet sheet = (XSSFSheet)wb1.GetSheetAt(0);
             CT_Cols cols = sheet.GetCTWorksheet().GetColsArray(0);
-            Assert.AreEqual(2, cols.sizeOfColArray());
+            Assert.AreEqual(4, cols.sizeOfColArray());
             CT_Col col;
             //<cols>
             //  <col min="2" max="4" width="12" customWidth="1"/>
@@ -876,9 +1325,15 @@ namespace TestCases.XSSF.UserModel
             //a span of columns [2,4]
             col = cols.GetColArray(0);
             Assert.AreEqual((uint)2, col.min);
+            Assert.AreEqual((uint)2, col.max);
+            col = cols.GetColArray(1);
+            Assert.AreEqual((uint)3, col.min);
+            Assert.AreEqual((uint)3, col.max);
+            col = cols.GetColArray(2);
+            Assert.AreEqual((uint)4, col.min);
             Assert.AreEqual((uint)4, col.max);
             //individual column
-            col = cols.GetColArray(1);
+            col = cols.GetColArray(3);
             Assert.AreEqual((uint)7, col.min);
             Assert.AreEqual((uint)7, col.max);
 
@@ -919,7 +1374,7 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual((uint)7, col.max);
 
             //serialize and check again
-            XSSFWorkbook wb2 = (XSSFWorkbook)XSSFTestDataSamples.WriteOutAndReadBack(wb1);
+            XSSFWorkbook wb2 = XSSFTestDataSamples.WriteOutAndReadBack(wb1);
             wb1.Close();
 
             sheet = (XSSFSheet)wb2.GetSheetAt(0);
@@ -1000,7 +1455,6 @@ namespace TestCases.XSSF.UserModel
             row3.CreateCell(2);
             row3.CreateCell(5);
 
-
             List<CT_Row> xrow = sheetData.row;
             Assert.AreEqual(3, xrow.Count);
 
@@ -1046,7 +1500,6 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual("C1", xcell[1].r);
             Assert.AreEqual("D1", xcell[2].r);
             Assert.AreEqual("F1", xcell[3].r);
-
 
             Assert.AreEqual(0, xrow[1].SizeOfCArray());
             Assert.AreEqual(2u, xrow[1].r);
@@ -1096,7 +1549,6 @@ namespace TestCases.XSSF.UserModel
             int actualVal = int.Parse(pr.password, NumberStyles.HexNumber);
             Assert.AreEqual(hashVal, actualVal, "well known value for top secret hash should match");
 
-
             sheet.ProtectSheet(null);
             Assert.IsNull(sheet.GetCTWorksheet().sheetProtection, "protectSheet(null) should unset CTSheetProtection");
 
@@ -1125,7 +1577,6 @@ namespace TestCases.XSSF.UserModel
             Assert.IsNull(sheet.GetCTWorksheet().sheetProtection, "protectSheet(null) should unset CTSheetProtection");
             wb.Close();
         }
-
 
         [Test]
         public void ProtectSheet_lowlevel_2013()
@@ -1160,7 +1611,7 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(0, calcChain.GetCTCalcChain().SizeOfCArray(), "XSSFSheet#RemoveRow did not clear calcChain entries");
 
             //calcChain should be gone 
-            XSSFWorkbook wb2 = (XSSFWorkbook)XSSFTestDataSamples.WriteOutAndReadBack(wb1);
+            XSSFWorkbook wb2 = XSSFTestDataSamples.WriteOutAndReadBack(wb1);
             wb1.Close();
             Assert.IsNull(wb2.GetCalculationChain());
 
@@ -1210,22 +1661,21 @@ namespace TestCases.XSSF.UserModel
             Assert.IsFalse(sheet.ForceFormulaRecalculation);
 
             // Set
-            sheet.ForceFormulaRecalculation = (true);
+            sheet.ForceFormulaRecalculation = true;
             Assert.AreEqual(true, sheet.ForceFormulaRecalculation);
 
             // calcMode="manual" is unset when forceFormulaRecalculation=true
             CT_CalcPr calcPr = wb1.GetCTWorkbook().AddNewCalcPr();
-            calcPr.calcMode = (ST_CalcMode.manual);
-            sheet.ForceFormulaRecalculation = (true);
+            calcPr.calcMode = ST_CalcMode.manual;
+            sheet.ForceFormulaRecalculation = true;
             Assert.AreEqual(ST_CalcMode.auto, calcPr.calcMode);
 
             // Check
-            sheet.ForceFormulaRecalculation = (false);
+            sheet.ForceFormulaRecalculation = false;
             Assert.AreEqual(false, sheet.ForceFormulaRecalculation);
 
-
             // Save, re-load, and re-check
-            XSSFWorkbook wb2 = (XSSFWorkbook)XSSFTestDataSamples.WriteOutAndReadBack(wb1);
+            XSSFWorkbook wb2 = XSSFTestDataSamples.WriteOutAndReadBack(wb1);
             wb1.Close();
 
             sheet = (XSSFSheet)wb2.GetSheet("Sheet 1");
@@ -1251,7 +1701,7 @@ namespace TestCases.XSSF.UserModel
 
         private void runGetTopRow(String file, bool isXSSF, params int[] topRows)
         {
-            IWorkbook wb = (isXSSF) ?
+            IWorkbook wb = isXSSF ?
                 wb = XSSFTestDataSamples.OpenSampleWorkbook(file) :
                 wb = HSSFTestDataSamples.OpenSampleWorkbook(file);
 
@@ -1261,6 +1711,7 @@ namespace TestCases.XSSF.UserModel
                 Assert.IsNotNull(sh.SheetName);
                 Assert.AreEqual(topRows[si], sh.TopRow, "Did not match for sheet " + si);
             }
+
             Assert.Warn("test about SXSSFWorkbook was commented");
             // for XSSF also test with SXSSF
             if (isXSSF)
@@ -1280,12 +1731,13 @@ namespace TestCases.XSSF.UserModel
                     swb.Close();
                 }
             }
+
             wb.Close();
         }
 
         private void runGetLeftCol(String file, bool isXSSF, params int[] topRows)
         {
-            IWorkbook wb = (isXSSF) ?
+            IWorkbook wb = isXSSF ?
                 wb = XSSFTestDataSamples.OpenSampleWorkbook(file) :
                 wb = HSSFTestDataSamples.OpenSampleWorkbook(file);
 
@@ -1307,8 +1759,10 @@ namespace TestCases.XSSF.UserModel
                     Assert.IsNotNull(sh.SheetName);
                     Assert.AreEqual(topRows[si], sh.LeftCol, "Did not match for sheet " + si);
                 }
+
                 swb.Close();
             }
+
             wb.Close();
         }
 
@@ -1376,22 +1830,22 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = wb.CreateSheet() as XSSFSheet;
 
-            IRow row1 = sheet.CreateRow((short)0);
-            ICell cell = row1.CreateCell((short)0);
+            IRow row1 = sheet.CreateRow(0);
+            ICell cell = row1.CreateCell(0);
             cell.SetCellValue("Names");
-            ICell cell2 = row1.CreateCell((short)1);
+            ICell cell2 = row1.CreateCell(1);
             cell2.SetCellValue("#");
 
-            IRow row2 = sheet.CreateRow((short)1);
-            ICell cell3 = row2.CreateCell((short)0);
+            IRow row2 = sheet.CreateRow(1);
+            ICell cell3 = row2.CreateCell(0);
             cell3.SetCellValue("Jane");
-            ICell cell4 = row2.CreateCell((short)1);
+            ICell cell4 = row2.CreateCell(1);
             cell4.SetCellValue(3);
 
-            IRow row3 = sheet.CreateRow((short)2);
-            ICell cell5 = row3.CreateCell((short)0);
+            IRow row3 = sheet.CreateRow(2);
+            ICell cell5 = row3.CreateCell(0);
             cell5.SetCellValue("John");
-            ICell cell6 = row3.CreateCell((short)1);
+            ICell cell6 = row3.CreateCell(1);
             cell6.SetCellValue(3);
 
             return wb;
@@ -1528,7 +1982,6 @@ namespace TestCases.XSSF.UserModel
 
             wb.Close();
         }
-
 
         protected void testCopyOneRow(String copyRowsTestWorkbook)
         {
@@ -1907,7 +2360,7 @@ namespace TestCases.XSSF.UserModel
             Dictionary<IgnoredErrorType, ISet<CellRangeAddress>> ignoredErrors = sheet.GetIgnoredErrors();
             Assert.AreEqual(1, ignoredErrors.Count);
             Assert.AreEqual(1, ignoredErrors[IgnoredErrorType.NumberStoredAsText].Count);
-            var it = ignoredErrors[IgnoredErrorType.NumberStoredAsText].GetEnumerator();
+            IEnumerator<CellRangeAddress> it = ignoredErrors[IgnoredErrorType.NumberStoredAsText].GetEnumerator();
             it.MoveNext();
             Assert.AreEqual("B2:D4", it.Current.FormatAsString());
 
@@ -1930,7 +2383,7 @@ namespace TestCases.XSSF.UserModel
             Dictionary<IgnoredErrorType, ISet<CellRangeAddress>> ignoredErrors = sheet.GetIgnoredErrors();
             Assert.AreEqual(2, ignoredErrors.Count);
             Assert.AreEqual(1, ignoredErrors[IgnoredErrorType.Formula].Count);
-            var it = ignoredErrors[IgnoredErrorType.Formula].GetEnumerator();
+            IEnumerator<CellRangeAddress> it = ignoredErrors[IgnoredErrorType.Formula].GetEnumerator();
             it.MoveNext();
             Assert.AreEqual("B2:D4", it.Current.FormatAsString());
             Assert.AreEqual(1, ignoredErrors[IgnoredErrorType.EvaluationError].Count);
@@ -1964,7 +2417,7 @@ namespace TestCases.XSSF.UserModel
             Dictionary<IgnoredErrorType, ISet<CellRangeAddress>> ignoredErrors = sheet.GetIgnoredErrors();
             Assert.AreEqual(2, ignoredErrors.Count);
             Assert.AreEqual(1, ignoredErrors[IgnoredErrorType.Formula].Count);
-            var it = ignoredErrors[IgnoredErrorType.Formula].GetEnumerator();
+            IEnumerator<CellRangeAddress> it = ignoredErrors[IgnoredErrorType.Formula].GetEnumerator();
             it.MoveNext();
             Assert.AreEqual("B2:D4", it.Current.FormatAsString());
             Assert.AreEqual(1, ignoredErrors[IgnoredErrorType.EvaluationError].Count);
@@ -2027,8 +2480,10 @@ namespace TestCases.XSSF.UserModel
                 Assert.AreEqual(expected, (wb.GetSheet("indexedRed") as XSSFSheet).TabColor);
 
                 // test regular-colored (non-indexed, ARGB) sheet
-                expected = new XSSFColor();
-                expected.ARGBHex = "FF7F2700";
+                expected = new XSSFColor
+                {
+                    ARGBHex = "FF7F2700"
+                };
                 Assert.AreEqual(expected, (wb.GetSheet("customOrange") as XSSFSheet).TabColor);
             }
             finally
@@ -2065,7 +2520,7 @@ namespace TestCases.XSSF.UserModel
                 anchor.Col2 = 2;
                 anchor.Row2 = 3 + i;
                 IComment comment = drawing.CreateCellComment(anchor);
-                comment.String = (helper.CreateRichTextString("BugTesting"));
+                comment.String = helper.CreateRichTextString("BugTesting");
                 IRow row = sheet.GetRow(0 + i);
                 if (row == null)
                 {

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheet.cs
@@ -384,6 +384,102 @@ namespace TestCases.XSSF.UserModel
         }
 
         [Test]
+        public void UngroupColumn_SimpleOneLevelUngroupNoOverlaps_ColumnsUngroupedAndDestroyed()
+        {
+            XSSFWorkbook workbook = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)workbook.CreateSheet();
+            ICellStyle style = workbook.CreateCellStyle();
+            style.BorderLeft = BorderStyle.Double;
+
+            sheet.GroupColumn(2, 7);
+            sheet.GroupColumn(10, 11);
+            sheet.GetColumn(2).CreateCell(0);
+            sheet.GetColumn(10).ColumnStyle = style;
+
+            Assert.AreEqual(8, sheet.GetCTWorksheet().cols[0].col.Count);
+
+            for (int i = 2; i <= 7; i++)
+            {
+                Assert.AreEqual(1, sheet.GetColumn(i).OutlineLevel);
+            }
+
+            for (int i = 10; i <= 11; i++)
+            {
+                Assert.AreEqual(1, sheet.GetColumn(i).OutlineLevel);
+            }
+
+            sheet.UngroupColumn(2, 7);
+            sheet.UngroupColumn(10, 11);
+
+            Assert.AreEqual(2, sheet.GetCTWorksheet().cols[0].col.Count);
+            Assert.AreEqual(0, sheet.GetColumn(2).OutlineLevel);
+            Assert.AreEqual(0, sheet.GetColumn(10).OutlineLevel);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            workbook.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheetAt(0);
+
+            Assert.AreEqual(2, sheetLoaded.GetCTWorksheet().cols[0].col.Count);
+            Assert.AreEqual(0, sheetLoaded.GetColumn(2).OutlineLevel);
+            Assert.AreEqual(0, sheetLoaded.GetColumn(10).OutlineLevel);
+
+            wbLoaded.Close();
+        }
+
+        [Test]
+        public void UngroupColumn_TwoOverlappingGroups_ColumnsUngroupedAndDestroyed()
+        {
+            XSSFWorkbook workbook = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)workbook.CreateSheet();
+            ICellStyle style = workbook.CreateCellStyle();
+            style.BorderLeft = BorderStyle.Double;
+
+            sheet.GroupColumn(2, 7);
+            sheet.GroupColumn(6, 11);
+            sheet.GetColumn(2).CreateCell(0);
+            sheet.GetColumn(6).ColumnStyle = style;
+
+            Assert.AreEqual(10, sheet.GetCTWorksheet().cols[0].col.Count);
+
+            for (int i = 2; i <= 11; i++)
+            {
+                if (i == 6 || i == 7)
+                {
+                    Assert.AreEqual(2, sheet.GetColumn(i).OutlineLevel);
+                }
+                else
+                {
+                    Assert.AreEqual(1, sheet.GetColumn(i).OutlineLevel);
+                }
+            }
+
+            sheet.UngroupColumn(2, 7);
+            sheet.UngroupColumn(6, 11);
+
+            Assert.AreEqual(2, sheet.GetCTWorksheet().cols[0].col.Count);
+            Assert.AreEqual(0, sheet.GetColumn(2).OutlineLevel);
+            Assert.AreEqual(0, sheet.GetColumn(6).OutlineLevel);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            workbook.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheetAt(0);
+
+            Assert.AreEqual(2, sheetLoaded.GetCTWorksheet().cols[0].col.Count);
+            Assert.AreEqual(0, sheetLoaded.GetColumn(2).OutlineLevel);
+            Assert.AreEqual(0, sheetLoaded.GetColumn(6).OutlineLevel);
+
+            wbLoaded.Close();
+        }
+
+        [Test]
         public void TestGroupUngroupRow()
         {
             XSSFWorkbook workbook = new XSSFWorkbook();

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheetColumns.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheetColumns.cs
@@ -1,0 +1,677 @@
+﻿/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for Additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+using NPOI.SS.UserModel;
+using NPOI.SS.Util;
+using NPOI.Util;
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
+using System;
+using System.IO;
+
+namespace TestCases.XSSF.UserModel
+{
+    [TestFixture]
+    public class TestXSSFSheetColumns
+    {
+        public TestXSSFSheetColumns()
+        {
+
+        }
+
+        [Test]
+        public void FirstColumnNum_ReturnsCorrectNumber()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+
+            sheet.CreateColumn(10);
+
+            Assert.AreEqual(10, sheet.FirstColumnNum);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+
+            Assert.AreEqual(10, sheetLoaded.FirstColumnNum);
+        }
+
+        [Test]
+        public void LastColumnNum_ReturnsCorrectNumber()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+
+            sheet.CreateColumn(10);
+
+            Assert.AreEqual(10, sheet.LastColumnNum);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+
+            Assert.AreEqual(10, sheetLoaded.LastColumnNum);
+        }
+
+        [Test]
+        public void PhysicalNumberOfColumns_ReturnsCorrectNumber()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int colNumber = 12;
+
+            for (int i = 0; i < colNumber; i++)
+            {
+                sheet.CreateColumn(i);
+            }
+
+            Assert.AreEqual(0, sheet.FirstColumnNum);
+            Assert.AreEqual(colNumber - 1, sheet.LastColumnNum);
+            Assert.AreEqual(colNumber, sheet.PhysicalNumberOfColumns);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+
+            Assert.AreEqual(0, sheetLoaded.FirstColumnNum);
+            Assert.AreEqual(colNumber - 1, sheetLoaded.LastColumnNum);
+            Assert.AreEqual(colNumber, sheetLoaded.PhysicalNumberOfColumns);
+        }
+
+        [Test]
+        public void CreateColumn_AtIndex6_ColumnIsCreatedWithCorrectIndex()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int colIndex = 6;
+
+            sheet.CreateColumn(colIndex);
+
+            IColumn column = sheet.GetColumn(colIndex);
+
+            Assert.NotNull(column);
+            Assert.AreEqual(colIndex, column.ColumnNum);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn columnLoaded = sheetLoaded.GetColumn(colIndex);
+
+            Assert.NotNull(columnLoaded);
+            Assert.AreEqual(colIndex, columnLoaded.ColumnNum);
+        }
+
+        [Test]
+        public void CreateColumn_AtIndex6Twice_ColumnIsCreatedWithCorrectIndexAndNoCells()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            int colIndex = 6;
+
+            sheet.CreateColumn(colIndex).CreateCell(0).SetCellValue(1);
+            IColumn column = sheet.GetColumn(colIndex);
+
+            Assert.NotNull(column);
+            Assert.AreEqual(colIndex, column.ColumnNum);
+            Assert.AreEqual(1, column.GetCell(0).NumericCellValue);
+
+            IColumn columnOverwrite = sheet.CreateColumn(colIndex);
+
+            Assert.NotNull(columnOverwrite);
+            Assert.AreEqual(colIndex, columnOverwrite.ColumnNum);
+            Assert.IsNull(columnOverwrite.GetCell(0));
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn columnLoaded = sheetLoaded.GetColumn(colIndex);
+
+            Assert.NotNull(columnLoaded);
+            Assert.AreEqual(colIndex, columnLoaded.ColumnNum);
+            Assert.IsNull(columnLoaded.GetCell(0));
+        }
+
+        [Test]
+        public void GetColumn_GetExistingColumn_ReturnsAColumn()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+
+            sheet.CreateColumn(10);
+            IColumn column = sheet.GetColumn(10);
+
+            Assert.NotNull(column);
+            Assert.AreEqual(10, column.ColumnNum);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn columnLoaded = sheetLoaded.GetColumn(10);
+
+            Assert.NotNull(columnLoaded);
+            Assert.AreEqual(10, columnLoaded.ColumnNum);
+        }
+
+        [Test]
+        public void GetColumn_GetNonExistingColumn_ReturnsNull()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+
+            IColumn column = sheet.GetColumn(10);
+
+            Assert.IsNull(column);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            IColumn columnLoaded = sheetLoaded.GetColumn(10);
+
+            Assert.IsNull(columnLoaded);
+        }
+
+        [Test]
+        public void RemoveColumn_RemoveExistingColumn_ColumnIsRemoved()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+
+            sheet.CreateColumn(1);
+            sheet.CreateColumn(2);
+            sheet.CreateColumn(3);
+
+            Assert.NotNull(sheet.GetColumn(1));
+            Assert.NotNull(sheet.GetColumn(2));
+            Assert.NotNull(sheet.GetColumn(3));
+            Assert.AreEqual(1, sheet.FirstColumnNum);
+            Assert.AreEqual(3, sheet.LastColumnNum);
+
+            sheet.RemoveColumn(sheet.GetColumn(3));
+
+            Assert.IsNull(sheet.GetColumn(3));
+            Assert.AreEqual(1, sheet.FirstColumnNum);
+            Assert.AreEqual(2, sheet.LastColumnNum);
+
+            sheet.CreateColumn(3);
+
+            sheet.RemoveColumn(sheet.GetColumn(1));
+
+            Assert.IsNull(sheet.GetColumn(1));
+            Assert.AreEqual(2, sheet.FirstColumnNum);
+            Assert.AreEqual(3, sheet.LastColumnNum);
+
+            sheet.CreateColumn(1);
+
+            Assert.NotNull(sheet.GetColumn(3));
+            Assert.AreEqual(3, sheet.LastColumnNum);
+
+            sheet.RemoveColumn(sheet.GetColumn(2));
+
+            Assert.IsNull(sheet.GetColumn(2));
+            Assert.AreEqual(1, sheet.FirstColumnNum);
+            Assert.AreEqual(3, sheet.LastColumnNum);
+
+            FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+
+            Assert.IsNull(sheetLoaded.GetColumn(2));
+            Assert.AreEqual(1, sheetLoaded.FirstColumnNum);
+            Assert.AreEqual(3, sheetLoaded.LastColumnNum);
+        }
+
+        [Test]
+        public void RemoveColumn_RemoveNonExistingColumn_ExceptionIsThrown()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+
+            sheet.CreateColumn(1);
+            sheet.CreateColumn(2);
+            sheet.CreateColumn(3);
+
+            Assert.NotNull(sheet.GetColumn(1));
+            Assert.NotNull(sheet.GetColumn(2));
+            Assert.NotNull(sheet.GetColumn(3));
+            Assert.AreEqual(1, sheet.FirstColumnNum);
+            Assert.AreEqual(3, sheet.LastColumnNum);
+
+            Assert.Throws<ArgumentException>(() => sheet.RemoveColumn(sheet.GetColumn(4)));
+        }
+
+        /// <summary>
+        /// Tests sets up a column with formula, merged region with data in it
+        /// custom width and comments and copies in to a place where there is no
+        /// column exsits yet. The outcome is exact copy of the column is created
+        /// in a new index with no data loss.
+        /// </summary>
+        [Test]
+        public void CopyColumn_ColumnWithDataCommentsFormulasMergedRegionsCopiedToNewPlace_ColumncopiedWithAllItsContents()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFFormulaEvaluator fe = new XSSFFormulaEvaluator(wb);
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            XSSFDrawing dg = (XSSFDrawing)sheet.CreateDrawingPatriarch();
+            XSSFComment comment = (XSSFComment)dg.CreateCellComment(new XSSFClientAnchor());
+            comment.Author = "POI";
+            comment.String = new XSSFRichTextString("A new comment");
+            int originalColIndex = 1;
+            int copyColIndex = 4;
+            short width = 20;
+            int mergedRegionFirstRow = 10;
+            int mergedRegionLastRow = 20;
+
+            XSSFColumn originalColumn = (XSSFColumn)sheet.CreateColumn(originalColIndex);
+            originalColumn.Width = width;
+            XSSFCell formulaCell1 = (XSSFCell)originalColumn.CreateCell(0);
+            formulaCell1.SetCellFormula("C1 + D1");
+            formulaCell1.CellComment = comment;
+            sheet.CreateColumn(originalColIndex + 1).CreateCell(0).SetCellValue(10);
+            sheet.CreateColumn(originalColIndex + 2).CreateCell(0).SetCellValue(20);
+            originalColumn.CreateCell(mergedRegionFirstRow).SetCellValue("POI");
+            sheet.AddMergedRegion(
+                new CellRangeAddress(
+                    mergedRegionFirstRow, 
+                    mergedRegionLastRow, 
+                    originalColumn.ColumnNum, 
+                    originalColumn.ColumnNum + 1));
+            CellRangeAddress originaMergedRegion = sheet.GetMergedRegion(0);
+
+            fe.EvaluateAll();
+
+            Assert.AreEqual("POI", sheet.GetRow(mergedRegionFirstRow).GetCell(originalColIndex).StringCellValue);
+            Assert.AreEqual("POI", formulaCell1.CellComment.Author);
+            Assert.AreEqual(30, formulaCell1.NumericCellValue);
+            Assert.AreEqual(1, sheet.NumMergedRegions);
+            Assert.NotNull(originaMergedRegion);
+
+            XSSFColumn copyColumn = (XSSFColumn)sheet.CopyColumn(originalColIndex, copyColIndex);
+            CellRangeAddress copyMergedRegion = sheet.GetMergedRegion(1);
+            fe.EvaluateAll();
+
+            XSSFCell formulaCell2 = (XSSFCell)sheet.GetColumn(copyColIndex).GetCell(0);
+
+            Assert.AreEqual(1, sheet.FirstColumnNum);
+            Assert.AreEqual(4, sheet.LastColumnNum);
+            Assert.AreEqual(width, copyColumn.Width);
+            //Assert.AreEqual("POI", sheet.GetRow(mergedRegionFirstRow).GetCell(copyColIndex).StringCellValue);
+            Assert.AreEqual("POI", formulaCell2.CellComment.Author);
+            Assert.AreEqual("C1 + D1", formulaCell2.CellFormula);
+            Assert.AreEqual(30, formulaCell2.NumericCellValue);
+            Assert.AreEqual(2, sheet.NumMergedRegions);
+            Assert.NotNull(originaMergedRegion);
+            Assert.NotNull(copyMergedRegion);
+            Assert.AreEqual(mergedRegionFirstRow, copyMergedRegion.FirstRow);
+            Assert.AreEqual(mergedRegionLastRow, copyMergedRegion.LastRow);
+            Assert.AreEqual(copyColumn.ColumnNum, copyMergedRegion.FirstColumn);
+            Assert.AreEqual(copyColumn.ColumnNum + 1, copyMergedRegion.LastColumn);
+
+            FileInfo file = TempFile.CreateTempFile("ShiftCols-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFFormulaEvaluator feLoaded = new XSSFFormulaEvaluator(wbLoaded);
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            XSSFColumn originalColumnLoaded = (XSSFColumn)sheetLoaded.GetColumn(originalColIndex);
+            XSSFColumn copyColumnLoaded = (XSSFColumn)sheetLoaded.GetColumn(copyColIndex);
+            XSSFCell formulaCellLoaded = (XSSFCell)copyColumnLoaded.GetCell(0);
+            CellRangeAddress originalMergedRegionLoaded = sheet.GetMergedRegion(0);
+            CellRangeAddress copyMergedRegionLoaded = sheet.GetMergedRegion(1);
+
+            feLoaded.EvaluateAll();
+
+            Assert.AreEqual(1, sheetLoaded.FirstColumnNum);
+            Assert.AreEqual(4, sheetLoaded.LastColumnNum);
+            Assert.AreEqual(width, copyColumnLoaded.Width);
+            Assert.AreEqual(10, sheetLoaded.GetColumn(originalColIndex + 1).GetCell(0).NumericCellValue);
+            Assert.AreEqual(20, sheetLoaded.GetColumn(originalColIndex + 2).GetCell(0).NumericCellValue);
+            Assert.AreEqual("POI", sheetLoaded.GetRow(mergedRegionFirstRow).GetCell(copyColIndex).StringCellValue);
+            Assert.AreEqual("POI", formulaCellLoaded.CellComment.Author);
+            Assert.AreEqual("C1 + D1", formulaCellLoaded.CellFormula);
+            Assert.AreEqual(30, formulaCellLoaded.NumericCellValue);
+            Assert.NotNull(originalMergedRegionLoaded);
+            Assert.AreEqual(mergedRegionFirstRow, originalMergedRegionLoaded.FirstRow);
+            Assert.AreEqual(mergedRegionLastRow, originalMergedRegionLoaded.LastRow);
+            Assert.AreEqual(originalColumnLoaded.ColumnNum, originalMergedRegionLoaded.FirstColumn);
+            Assert.AreEqual(originalColumnLoaded.ColumnNum + 1, originalMergedRegionLoaded.LastColumn);
+            Assert.NotNull(copyMergedRegionLoaded);
+            Assert.AreEqual(mergedRegionFirstRow, copyMergedRegionLoaded.FirstRow);
+            Assert.AreEqual(mergedRegionLastRow, copyMergedRegionLoaded.LastRow);
+            Assert.AreEqual(copyColumnLoaded.ColumnNum, copyMergedRegionLoaded.FirstColumn);
+            Assert.AreEqual(copyColumnLoaded.ColumnNum + 1, copyMergedRegionLoaded.LastColumn);
+        }
+
+        /// <summary>
+        /// Tests sets up a column with formula, merged region with data in it
+        /// custom width and comments and copies in to a place of pre-existing
+        /// column. The outcome is pre-existing column gets shifted to the right,
+        /// exact copy of the copied column is created in it's place with no data loss.
+        /// </summary>
+        [Test]
+        public void CopyColumn_ColumnWithDataCommentsFormulasMergedRegionsCopiedToPlaceOfExistingColumn_ExistingColumnIsShiftedColumnCopied()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFFormulaEvaluator fe = new XSSFFormulaEvaluator(wb);
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            XSSFDrawing dg = (XSSFDrawing)sheet.CreateDrawingPatriarch();
+            XSSFComment comment = (XSSFComment)dg.CreateCellComment(new XSSFClientAnchor());
+            comment.Author = "POI";
+            comment.String = new XSSFRichTextString("A new comment");
+            int originalColIndex = 1;
+            int copyColIndex = 4;
+            short width = 20;
+            int mergedRegionFirstRow = 10;
+            int mergedRegionLastRow = 20;
+
+            XSSFColumn anotherColumn = (XSSFColumn)sheet.CreateColumn(copyColIndex);
+            anotherColumn.CreateCell(0).SetCellValue("POI");
+            anotherColumn.Width = (short)(width * 2);
+            XSSFColumn originalColumn = (XSSFColumn)sheet.CreateColumn(originalColIndex);
+            originalColumn.Width = width;
+            XSSFCell formulaCell1 = (XSSFCell)originalColumn.CreateCell(0);
+            formulaCell1.SetCellFormula("C1 + D1");
+            formulaCell1.CellComment = comment;
+            sheet.CreateColumn(originalColIndex + 1).CreateCell(0).SetCellValue(10);
+            sheet.CreateColumn(originalColIndex + 2).CreateCell(0).SetCellValue(20);
+            originalColumn.CreateCell(mergedRegionFirstRow).SetCellValue("POI");
+            sheet.AddMergedRegion(
+                new CellRangeAddress(
+                    mergedRegionFirstRow,
+                    mergedRegionLastRow,
+                    originalColumn.ColumnNum,
+                    originalColumn.ColumnNum + 1));
+            CellRangeAddress originaMergedRegion = sheet.GetMergedRegion(0);
+
+            fe.EvaluateAll();
+
+            Assert.AreEqual("POI", sheet.GetRow(mergedRegionFirstRow).GetCell(originalColIndex).StringCellValue);
+            Assert.AreEqual("POI", formulaCell1.CellComment.Author);
+            Assert.AreEqual(30, formulaCell1.NumericCellValue);
+            Assert.AreEqual(1, sheet.NumMergedRegions);
+            Assert.NotNull(originaMergedRegion);
+
+            XSSFColumn copyColumn = (XSSFColumn)sheet.CopyColumn(originalColIndex, copyColIndex);
+            CellRangeAddress copyMergedRegion = sheet.GetMergedRegion(1);
+            fe.EvaluateAll();
+
+            XSSFCell formulaCell2 = (XSSFCell)sheet.GetColumn(copyColIndex).GetCell(0);
+
+            Assert.AreEqual(copyColIndex + 1, anotherColumn.ColumnNum);
+            Assert.AreEqual("POI", sheet.GetRow(0).GetCell(copyColIndex + 1).StringCellValue);
+            Assert.AreEqual(1, sheet.FirstColumnNum);
+            Assert.AreEqual(5, sheet.LastColumnNum);
+            Assert.AreEqual(width, copyColumn.Width);
+            Assert.AreEqual("POI", sheet.GetRow(mergedRegionFirstRow).GetCell(copyColIndex).StringCellValue);
+            Assert.AreEqual("POI", formulaCell2.CellComment.Author);
+            Assert.AreEqual("C1 + D1", formulaCell2.CellFormula);
+            Assert.AreEqual(30, formulaCell2.NumericCellValue);
+            Assert.AreEqual(2, sheet.NumMergedRegions);
+            Assert.NotNull(originaMergedRegion);
+            Assert.NotNull(copyMergedRegion);
+            Assert.AreEqual(mergedRegionFirstRow, copyMergedRegion.FirstRow);
+            Assert.AreEqual(mergedRegionLastRow, copyMergedRegion.LastRow);
+            Assert.AreEqual(copyColumn.ColumnNum, copyMergedRegion.FirstColumn);
+            Assert.AreEqual(copyColumn.ColumnNum + 1, copyMergedRegion.LastColumn);
+
+            FileInfo file = TempFile.CreateTempFile("ShiftCols-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFFormulaEvaluator feLoaded = new XSSFFormulaEvaluator(wbLoaded);
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            XSSFColumn originalColumnLoaded = (XSSFColumn)sheetLoaded.GetColumn(originalColIndex);
+            XSSFColumn copyColumnLoaded = (XSSFColumn)sheetLoaded.GetColumn(copyColIndex);
+            XSSFCell formulaCellLoaded = (XSSFCell)copyColumnLoaded.GetCell(0);
+            CellRangeAddress originalMergedRegionLoaded = sheet.GetMergedRegion(0);
+            CellRangeAddress copyMergedRegionLoaded = sheet.GetMergedRegion(1);
+
+            feLoaded.EvaluateAll();
+
+            Assert.AreEqual(1, sheetLoaded.FirstColumnNum);
+            Assert.AreEqual(5, sheetLoaded.LastColumnNum);
+            Assert.AreEqual(width, copyColumnLoaded.Width);
+            Assert.AreEqual(10, sheetLoaded.GetColumn(originalColIndex + 1).GetCell(0).NumericCellValue);
+            Assert.AreEqual(20, sheetLoaded.GetColumn(originalColIndex + 2).GetCell(0).NumericCellValue);
+            Assert.AreEqual("POI", sheetLoaded.GetRow(mergedRegionFirstRow).GetCell(copyColIndex).StringCellValue);
+            Assert.AreEqual("POI", formulaCellLoaded.CellComment.Author);
+            Assert.AreEqual("C1 + D1", formulaCellLoaded.CellFormula);
+            Assert.AreEqual(30, formulaCellLoaded.NumericCellValue);
+            Assert.NotNull(originalMergedRegionLoaded);
+            Assert.AreEqual(mergedRegionFirstRow, originalMergedRegionLoaded.FirstRow);
+            Assert.AreEqual(mergedRegionLastRow, originalMergedRegionLoaded.LastRow);
+            Assert.AreEqual(originalColumnLoaded.ColumnNum, originalMergedRegionLoaded.FirstColumn);
+            Assert.AreEqual(originalColumnLoaded.ColumnNum + 1, originalMergedRegionLoaded.LastColumn);
+            Assert.NotNull(copyMergedRegionLoaded);
+            Assert.AreEqual(mergedRegionFirstRow, copyMergedRegionLoaded.FirstRow);
+            Assert.AreEqual(mergedRegionLastRow, copyMergedRegionLoaded.LastRow);
+            Assert.AreEqual(copyColumnLoaded.ColumnNum, copyMergedRegionLoaded.FirstColumn);
+            Assert.AreEqual(copyColumnLoaded.ColumnNum + 1, copyMergedRegionLoaded.LastColumn);
+        }
+
+        [Test]
+        public void ShiftColumns_Shift2ColumnsWithCommentsAndFormulas_ColumnsShiftedCommentsShiftedFormulasAreUpdated()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFFormulaEvaluator fe = new XSSFFormulaEvaluator(wb);
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            XSSFDrawing dg = (XSSFDrawing)sheet.CreateDrawingPatriarch();
+            XSSFComment comment = (XSSFComment)dg.CreateCellComment(new XSSFClientAnchor());
+            comment.Author = "POI";
+            comment.String = new XSSFRichTextString("A new comment");
+
+            XSSFCell formulaCell = (XSSFCell)sheet.CreateColumn(1).CreateCell(0);
+            formulaCell.SetCellFormula("C1 + D1");
+            XSSFCell cell1 = (XSSFCell)sheet.CreateColumn(2).CreateCell(0);
+            cell1.SetCellValue(10);
+            cell1.CellComment = comment;
+            sheet.CreateColumn(3).CreateCell(0).SetCellValue(20);
+
+            fe.EvaluateAll();
+
+            Assert.AreEqual("POI", sheet.GetColumn(2).GetCell(0).CellComment.Author);
+            Assert.AreEqual(30, formulaCell.NumericCellValue);
+
+            sheet.ShiftColumns(2, 3, 4);
+            fe.EvaluateAll();
+
+            Assert.AreEqual(1, sheet.FirstColumnNum);
+            Assert.AreEqual(7, sheet.LastColumnNum);
+            Assert.AreEqual(10, sheet.GetColumn(6).GetCell(0).NumericCellValue);
+            Assert.AreEqual(20, sheet.GetColumn(7).GetCell(0).NumericCellValue);
+            cell1 = (XSSFCell)sheet.GetColumn(6).GetCell(0);
+            Assert.AreEqual("POI", cell1.CellComment.Author);
+            Assert.AreEqual("G1+H1", formulaCell.CellFormula);
+            Assert.AreEqual(30, formulaCell.NumericCellValue);
+
+            FileInfo file = TempFile.CreateTempFile("ShiftCols-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFFormulaEvaluator feLoaded = new XSSFFormulaEvaluator(wbLoaded);
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            XSSFCell formulaCellLoaded = (XSSFCell)sheetLoaded.GetColumn(1).GetCell(0);
+
+            feLoaded.EvaluateAll();
+
+            Assert.IsNull(sheetLoaded.GetColumn(2));
+            Assert.AreEqual(1, sheetLoaded.FirstColumnNum);
+            Assert.AreEqual(7, sheetLoaded.LastColumnNum);
+            Assert.AreEqual(10, sheetLoaded.GetColumn(6).GetCell(0).NumericCellValue);
+            Assert.AreEqual(20, sheetLoaded.GetColumn(7).GetCell(0).NumericCellValue);
+            Assert.AreEqual("POI", sheetLoaded.GetColumn(6).GetCell(0).CellComment.Author);
+            Assert.AreEqual("G1+H1", formulaCellLoaded.CellFormula);
+            Assert.AreEqual(30, formulaCellLoaded.NumericCellValue);
+        }
+
+        [Test]
+        public void ShiftColumns_Shift1ColumnWithCommentsAndFormulas_ColumnShiftedCommentShiftedFormulaUpdated()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFFormulaEvaluator fe = new XSSFFormulaEvaluator(wb);
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            XSSFDrawing dg = (XSSFDrawing)sheet.CreateDrawingPatriarch();
+            XSSFComment comment = (XSSFComment)dg.CreateCellComment(new XSSFClientAnchor());
+            comment.Author = "POI";
+            comment.String = new XSSFRichTextString("A new comment");
+
+            XSSFCell formulaCell = (XSSFCell)sheet.CreateColumn(1).CreateCell(0);
+            formulaCell.SetCellFormula("C1 + D1");
+            XSSFCell cell1 = (XSSFCell)sheet.CreateColumn(2).CreateCell(0);
+            cell1.SetCellValue(10);
+            cell1.CellComment = comment;
+            sheet.CreateColumn(3).CreateCell(0).SetCellValue(20);
+
+            fe.EvaluateAll();
+
+            Assert.AreEqual("POI", sheet.GetColumn(2).GetCell(0).CellComment.Author);
+            Assert.AreEqual(30, formulaCell.NumericCellValue);
+
+            sheet.ShiftColumns(2, 2, 4);
+            fe.EvaluateAll();
+
+            Assert.AreEqual(1, sheet.FirstColumnNum);
+            Assert.AreEqual(6, sheet.LastColumnNum);
+            Assert.AreEqual(10, sheet.GetColumn(6).GetCell(0).NumericCellValue);
+            Assert.AreEqual(20, sheet.GetColumn(3).GetCell(0).NumericCellValue);
+            cell1 = (XSSFCell)sheet.GetColumn(6).GetCell(0);
+            Assert.AreEqual("POI", cell1.CellComment.Author);
+            Assert.AreEqual("G1+D1", formulaCell.CellFormula);
+            Assert.AreEqual(30, formulaCell.NumericCellValue);
+
+            FileInfo file = TempFile.CreateTempFile("ShiftCols-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFFormulaEvaluator feLoaded = new XSSFFormulaEvaluator(wbLoaded);
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            XSSFCell formulaCellLoaded = (XSSFCell)sheetLoaded.GetColumn(1).GetCell(0);
+
+            feLoaded.EvaluateAll();
+
+            Assert.IsNull(sheetLoaded.GetColumn(2));
+            Assert.AreEqual(1, sheetLoaded.FirstColumnNum);
+            Assert.AreEqual(6, sheetLoaded.LastColumnNum);
+            Assert.AreEqual(10, sheetLoaded.GetColumn(6).GetCell(0).NumericCellValue);
+            Assert.AreEqual(20, sheetLoaded.GetColumn(3).GetCell(0).NumericCellValue);
+            Assert.AreEqual("POI", sheetLoaded.GetColumn(6).GetCell(0).CellComment.Author);
+            Assert.AreEqual("G1+D1", formulaCellLoaded.CellFormula);
+            Assert.AreEqual(30, formulaCellLoaded.NumericCellValue);
+        }
+
+        /// <summary>
+        /// This test trys to shift a column which doesn't exist, but there are
+        /// cells that would fall into that column. The expected behaviour is 
+        /// that system will create a column object, shift it updating formulas
+        /// and moving cell values and comments and then will destroy created
+        /// column objects, leaving cells in new places
+        /// </summary>
+        [Test]
+        public void ShiftColumns_ShiftNonExistingColumnWithCellsAndComments_CellsAreShiftedNocolumsCreated()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFFormulaEvaluator fe = new XSSFFormulaEvaluator(wb);
+            XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
+            XSSFDrawing dg = (XSSFDrawing)sheet.CreateDrawingPatriarch();
+            XSSFComment comment = (XSSFComment)dg.CreateCellComment(new XSSFClientAnchor());
+            comment.Author = "POI";
+            comment.String = new XSSFRichTextString("A new comment");
+
+            XSSFCell formulaCell = (XSSFCell)sheet.CreateColumn(1).CreateCell(0);
+            formulaCell.SetCellFormula("C1 + D2");
+            sheet.CreateColumn(2).CreateCell(0).SetCellValue(10);
+            XSSFRow row = (XSSFRow)sheet.CreateRow(1);
+            XSSFCell cell1 = (XSSFCell)row.CreateCell(3);
+            cell1.SetCellValue(20);
+            cell1.CellComment = comment;
+
+            fe.EvaluateAll();
+
+            Assert.AreEqual("POI", row.GetCell(3).CellComment.Author);
+            Assert.AreEqual(30, formulaCell.NumericCellValue);
+            Assert.AreEqual(1, sheet.FirstColumnNum);
+            Assert.AreEqual(2, sheet.LastColumnNum);
+
+            sheet.ShiftColumns(3, 3, 4);
+            fe.EvaluateAll();
+
+            Assert.AreEqual("POI", row.GetCell(7).CellComment.Author);
+            Assert.AreEqual("C1+H2", formulaCell.CellFormula);
+            Assert.AreEqual(30, formulaCell.NumericCellValue);
+            Assert.AreEqual(1, sheet.FirstColumnNum);
+            Assert.AreEqual(2, sheet.LastColumnNum);
+
+            FileInfo file = TempFile.CreateTempFile("ShiftCols-", ".xlsx");
+            Stream output = File.OpenWrite(file.FullName);
+            wb.Write(output);
+            output.Close();
+
+            XSSFWorkbook wbLoaded = new XSSFWorkbook(file.ToString());
+            XSSFFormulaEvaluator feLoaded = new XSSFFormulaEvaluator(wbLoaded);
+            XSSFSheet sheetLoaded = (XSSFSheet)wbLoaded.GetSheet("sheet1");
+            XSSFRow rowLoaded = (XSSFRow)sheet.GetRow(1);
+            XSSFCell formulaCellLoaded = (XSSFCell)sheet.GetRow(0).GetCell(1);
+
+            feLoaded.EvaluateAll();
+
+            Assert.AreEqual("POI", rowLoaded.GetCell(7).CellComment.Author);
+            Assert.AreEqual("C1+H2", formulaCellLoaded.CellFormula);
+            Assert.AreEqual(30, formulaCellLoaded.NumericCellValue);
+            Assert.AreEqual(1, sheetLoaded.FirstColumnNum);
+            Assert.AreEqual(2, sheetLoaded.LastColumnNum);
+        }//*/
+    }
+}

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFSheetColumns.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFSheetColumns.cs
@@ -39,7 +39,7 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
 
-            sheet.CreateColumn(10);
+            _ = sheet.CreateColumn(10);
 
             Assert.AreEqual(10, sheet.FirstColumnNum);
 
@@ -60,7 +60,7 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
 
-            sheet.CreateColumn(10);
+            _ = sheet.CreateColumn(10);
 
             Assert.AreEqual(10, sheet.LastColumnNum);
 
@@ -84,7 +84,7 @@ namespace TestCases.XSSF.UserModel
 
             for (int i = 0; i < colNumber; i++)
             {
-                sheet.CreateColumn(i);
+                _ = sheet.CreateColumn(i);
             }
 
             Assert.AreEqual(0, sheet.FirstColumnNum);
@@ -111,7 +111,7 @@ namespace TestCases.XSSF.UserModel
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
             int colIndex = 6;
 
-            sheet.CreateColumn(colIndex);
+            _ = sheet.CreateColumn(colIndex);
 
             IColumn column = sheet.GetColumn(colIndex);
 
@@ -171,7 +171,7 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
 
-            sheet.CreateColumn(10);
+            _ = sheet.CreateColumn(10);
             IColumn column = sheet.GetColumn(10);
 
             Assert.NotNull(column);
@@ -218,9 +218,9 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
 
-            sheet.CreateColumn(1);
-            sheet.CreateColumn(2);
-            sheet.CreateColumn(3);
+            _ = sheet.CreateColumn(1);
+            _ = sheet.CreateColumn(2);
+            _ = sheet.CreateColumn(3);
 
             Assert.NotNull(sheet.GetColumn(1));
             Assert.NotNull(sheet.GetColumn(2));
@@ -234,7 +234,7 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(1, sheet.FirstColumnNum);
             Assert.AreEqual(2, sheet.LastColumnNum);
 
-            sheet.CreateColumn(3);
+            _ = sheet.CreateColumn(3);
 
             sheet.RemoveColumn(sheet.GetColumn(1));
 
@@ -242,7 +242,7 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(2, sheet.FirstColumnNum);
             Assert.AreEqual(3, sheet.LastColumnNum);
 
-            sheet.CreateColumn(1);
+            _ = sheet.CreateColumn(1);
 
             Assert.NotNull(sheet.GetColumn(3));
             Assert.AreEqual(3, sheet.LastColumnNum);
@@ -272,9 +272,9 @@ namespace TestCases.XSSF.UserModel
             XSSFWorkbook wb = new XSSFWorkbook();
             XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("sheet1");
 
-            sheet.CreateColumn(1);
-            sheet.CreateColumn(2);
-            sheet.CreateColumn(3);
+            _ = sheet.CreateColumn(1);
+            _ = sheet.CreateColumn(2);
+            _ = sheet.CreateColumn(3);
 
             Assert.NotNull(sheet.GetColumn(1));
             Assert.NotNull(sheet.GetColumn(2));
@@ -282,7 +282,7 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(1, sheet.FirstColumnNum);
             Assert.AreEqual(3, sheet.LastColumnNum);
 
-            Assert.Throws<ArgumentException>(() => sheet.RemoveColumn(sheet.GetColumn(4)));
+            _ = Assert.Throws<ArgumentException>(() => sheet.RemoveColumn(sheet.GetColumn(4)));
         }
 
         /// <summary>
@@ -315,11 +315,11 @@ namespace TestCases.XSSF.UserModel
             sheet.CreateColumn(originalColIndex + 1).CreateCell(0).SetCellValue(10);
             sheet.CreateColumn(originalColIndex + 2).CreateCell(0).SetCellValue(20);
             originalColumn.CreateCell(mergedRegionFirstRow).SetCellValue("POI");
-            sheet.AddMergedRegion(
+            _ = sheet.AddMergedRegion(
                 new CellRangeAddress(
-                    mergedRegionFirstRow, 
-                    mergedRegionLastRow, 
-                    originalColumn.ColumnNum, 
+                    mergedRegionFirstRow,
+                    mergedRegionLastRow,
+                    originalColumn.ColumnNum,
                     originalColumn.ColumnNum + 1));
             CellRangeAddress originaMergedRegion = sheet.GetMergedRegion(0);
 
@@ -422,7 +422,7 @@ namespace TestCases.XSSF.UserModel
             sheet.CreateColumn(originalColIndex + 1).CreateCell(0).SetCellValue(10);
             sheet.CreateColumn(originalColIndex + 2).CreateCell(0).SetCellValue(20);
             originalColumn.CreateCell(mergedRegionFirstRow).SetCellValue("POI");
-            sheet.AddMergedRegion(
+            _ = sheet.AddMergedRegion(
                 new CellRangeAddress(
                     mergedRegionFirstRow,
                     mergedRegionLastRow,

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFTextRun.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFTextRun.cs
@@ -22,6 +22,7 @@ namespace TestCases.XSSF.UserModel
     using NPOI.XSSF.UserModel;
     using SixLabors.ImageSharp;
     using SixLabors.ImageSharp.PixelFormats;
+    using System.Threading;
 
     [TestFixture]
     public class TestXSSFTextRun
@@ -29,6 +30,7 @@ namespace TestCases.XSSF.UserModel
         [Test]
         public void TestXSSFTextParagraph()
         {
+            Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             XSSFWorkbook wb = new XSSFWorkbook();
             try
             {

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
@@ -65,12 +65,17 @@ namespace TestCases.XSSF.UserModel
             ISheet sheet1 = wb1.CreateSheet("sheet1");
             ISheet sheet2 = wb1.CreateSheet("sheet2");
             wb1.CreateSheet("sheet3");
+            ISheet sheet4 = wb1.CreateSheet("sheet4");
 
             IRichTextString rts = wb1.GetCreationHelper().CreateRichTextString("hello world");
 
             sheet1.CreateRow(0).CreateCell((short)0).SetCellValue(1.2);
             sheet1.CreateRow(1).CreateCell((short)0).SetCellValue(rts);
             sheet2.CreateRow(0);
+            ((XSSFSheet)sheet2).CreateColumn(0);
+
+            ((XSSFSheet)sheet4).CreateColumn(0).CreateCell(0).SetCellValue(1.2);
+            ((XSSFSheet)sheet4).CreateColumn(1).CreateCell(0).SetCellValue(rts);
 
             Assert.AreEqual(0, wb1.GetSheetAt(0).FirstRowNum);
             Assert.AreEqual(1, wb1.GetSheetAt(0).LastRowNum);
@@ -78,6 +83,17 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(0, wb1.GetSheetAt(1).LastRowNum);
             Assert.AreEqual(0, wb1.GetSheetAt(2).FirstRowNum);
             Assert.AreEqual(0, wb1.GetSheetAt(2).LastRowNum);
+            Assert.AreEqual(0, wb1.GetSheetAt(3).FirstRowNum);
+            Assert.AreEqual(0, wb1.GetSheetAt(3).LastRowNum);
+
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(0)).FirstColumnNum);
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(0)).LastColumnNum);
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(1)).FirstColumnNum);
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(1)).LastColumnNum);
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(2)).FirstColumnNum);
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(2)).LastColumnNum);
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(3)).FirstColumnNum);
+            Assert.AreEqual(1, ((XSSFSheet)wb1.GetSheetAt(3)).LastColumnNum);
 
             FileInfo file = TempFile.CreateTempFile("poi-", ".xlsx");
             Stream out1 = File.OpenWrite(file.FullName);
@@ -96,15 +112,16 @@ namespace TestCases.XSSF.UserModel
                 pkg.GetPart(PackagingUriHelper.CreatePartName("/xl/workbook.xml"));
             // Links to the three sheets, shared strings and styles
             Assert.IsTrue(wbPart.HasRelationships);
-            Assert.AreEqual(5, wbPart.Relationships.Size);
+            Assert.AreEqual(6, wbPart.Relationships.Size);
             wb1.Close();
 
             // Load back the XSSFWorkbook
             XSSFWorkbook wb2 = new XSSFWorkbook(pkg);
-            Assert.AreEqual(3, wb2.NumberOfSheets);
+            Assert.AreEqual(4, wb2.NumberOfSheets);
             Assert.IsNotNull(wb2.GetSheetAt(0));
             Assert.IsNotNull(wb2.GetSheetAt(1));
             Assert.IsNotNull(wb2.GetSheetAt(2));
+            Assert.IsNotNull(wb2.GetSheetAt(3));
 
             Assert.IsNotNull(wb2.GetSharedStringSource());
             Assert.IsNotNull(wb2.GetStylesSource());
@@ -115,15 +132,29 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual(0, wb2.GetSheetAt(1).LastRowNum);
             Assert.AreEqual(0, wb2.GetSheetAt(2).FirstRowNum);
             Assert.AreEqual(0, wb2.GetSheetAt(2).LastRowNum);
+            Assert.AreEqual(0, wb2.GetSheetAt(3).FirstRowNum);
+            Assert.AreEqual(0, wb2.GetSheetAt(3).LastRowNum);
+
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(0)).FirstColumnNum);
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(0)).LastColumnNum);
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(1)).FirstColumnNum);
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(1)).LastColumnNum);
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(2)).FirstColumnNum);
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(2)).LastColumnNum);
+            Assert.AreEqual(0, ((XSSFSheet)wb1.GetSheetAt(3)).FirstColumnNum);
+            Assert.AreEqual(1, ((XSSFSheet)wb1.GetSheetAt(3)).LastColumnNum);
 
             sheet1 = wb2.GetSheetAt(0);
             Assert.AreEqual(1.2, sheet1.GetRow(0).GetCell(0).NumericCellValue, 0.0001);
+            Assert.AreEqual(1.2, ((XSSFSheet)sheet4).GetColumn(0).GetCell(0).NumericCellValue, 0.0001);
             Assert.AreEqual("hello world", sheet1.GetRow(1).GetCell(0).RichStringCellValue.String);
+            Assert.AreEqual("hello world", ((XSSFSheet)sheet4).GetColumn(1).GetCell(0).RichStringCellValue.String);
 
             pkg.Close();
 
             Assert.AreEqual(0, Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.tmp").Length, "At Last: There are no temporary files.");
         }
+
         [Test]
         public void Existing()
         {

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFWorkbook.cs
@@ -873,6 +873,7 @@ namespace TestCases.XSSF.UserModel
         [Test]
         public void AddPivotTableToWorkbookWithLoadedPivotTable()
         {
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
             String fileName = "ooxml-pivottable.xlsx";
 
             XSSFWorkbook wb = new XSSFWorkbook();


### PR DESCRIPTION
# XSSFColumn class

This PR adds an `IColumn` interface (similar to an `IRow` interface) and implements it in a `XSSFColumn` object. `XSSFSheet` is refactored to use that new object for all operations on columns in a very similar way to the way operations on rows are done: copying, cuting, pasting, shifting (with attention to formulas), formatting (both styles and width, hidennes, un-/grouping), adding new columns, removing cells by column - pretty much all things that are possible for `XSSFRow`s are now possible with `XSSFColumn` with a more fluent and easy to use API, than the `ColumnHelper` had provided.

Major hurdle for this was the way columns are stored in the `sheet.xml` - `CT_Col` objects are not individual columns, but are "spans" of columns. If columns from 5 to 10 have the same style, width, hidden status and outline level - they will be represented as a `CT_Col` object with `min` field of 5 and `max` field of 10. So its one "span" of columns from 5 to 10, rather than 6 columns. This makes it hard to work with individual columns. For this reason this PR also changes the way `CT_Col` objects are parsed and stored in `XSSFSheet` - the "spans" are now broken down to individual `CT_Col` objects with `min` and `max` fields set to the same value, so that each `CT_Col` object represents a single column. This happens when a workbook is read from a file. When a workbook is written to a file, the `CT_Col` objects are again merged into "spans" of columns, depending on their style, width, hidden status and outline level, to match the way Excel stores columns in the `sheet.xml`.

This still had drawbacks - in case if **all** columns on the sheet had the same formatting all the way to the end of the sheet the last `CT_Col` object in the `sheet.xml` would have `max` field set to the maximum number of columns in Excel (16384). This would make the `sheet.xml` file very large and slow to parse. This happens even if only one column is actually used in the sheet. A compromise was made - if the last `CT_Col` object has `max` field set to the maximum number of columns in Excel - the `max` field is set to be a maximum of:

- `min` field + 1 of the last `CT_Col` object that has `max` field set to the maximum number of
columns in Excel
- column index of the cell with a maximum column index in the sheet

This is a compromise, because if that was done on a workbook where it was intended to have all columns formatted the same way - this information about the columns beyond this calculated `max` field will be lost. The good news is usually this is not intended and the `max` field of the last `CT_Col` object is set to the maximum number of columns in Excel is just a result of a hastily applied formatting to the whole sheet.

The PR comes with a lot of tests, that test the new `XSSFColumn` object and the refactored `XSSFSheet` object.
