### PR TITLE
Add RemoveDataValidation method

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet.cs
@@ -7387,6 +7387,33 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             promptField = obj.promptField;
             sqrefField = obj.sqrefField;
         }
+
+        public override bool Equals(object obj)
+        {
+            CT_DataValidation o = (CT_DataValidation)obj;
+
+            if (o is null)
+            {
+                return false;
+            }
+
+            return formula1Field == o.formula1Field
+                && formula2Field == o.formula2Field
+                && typeField == o.typeField
+                && errorStyleField == o.errorStyleField
+                && imeModeField == o.imeModeField
+                && operatorField == o.operatorField
+                && allowBlankField == o.allowBlankField
+                && showDropDownField == o.showDropDownField
+                && showInputMessageField == o.showInputMessageField
+                && showErrorMessageField == o.showErrorMessageField
+                && errorTitleField == o.errorTitleField
+                && errorField == o.errorField
+                && promptTitleField == o.promptTitleField
+                && promptField == o.promptField
+                && sqrefField == o.sqrefField;
+        }
+
         [XmlElement(Order = 0)]
         public string formula1
         {

--- a/OpenXmlFormats/Spreadsheet/Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet.cs
@@ -7133,6 +7133,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         internal void Write(StreamWriter sw, string nodeName)
         {
+            if (this.countField == 0)
+                return;
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "disablePrompts", this.disablePrompts);
             XmlHelper.WriteAttribute(sw, "xWindow", this.xWindow);

--- a/main/HSSF/Record/Aggregates/DataValidityTable.cs
+++ b/main/HSSF/Record/Aggregates/DataValidityTable.cs
@@ -72,5 +72,11 @@ namespace NPOI.HSSF.Record.Aggregates
             _validationList.Add(dvRecord);
             _headerRec.DVRecNo = (_validationList.Count);
         }
+
+        public void RemoveDataValidation(DVRecord dvRecord)
+        {
+            _validationList.Remove(dvRecord);
+            _headerRec.DVRecNo = _validationList.Count;
+        }
     }
 }

--- a/main/HSSF/Record/DVRecord.cs
+++ b/main/HSSF/Record/DVRecord.cs
@@ -185,7 +185,36 @@ namespace NPOI.HSSF.Record
             set { this._option_flags = this.opt_data_type.SetValue(this._option_flags, value); }
         }
 
+        public override bool Equals(object obj)
+        {
+            if (obj == null || !(obj is DVRecord))
+            {
+                return false;
+            }
 
+            DVRecord dv = (DVRecord)obj;
+            return DataType == dv.DataType
+                && ErrorStyle == dv.ErrorStyle
+                && EmptyCellAllowed == dv.EmptyCellAllowed
+                && ShowErrorOnInvalidValue == dv.ShowErrorOnInvalidValue
+                && ShowPromptOnCellSelected == dv.ShowPromptOnCellSelected
+                && SuppressDropdownArrow == dv.SuppressDropdownArrow
+                && ListExplicitFormula == dv.ListExplicitFormula
+                && ConditionOperator == dv.ConditionOperator
+                && PromptTitle == dv.PromptTitle
+                && PromptText == dv.PromptText
+                && ErrorTitle == dv.ErrorTitle
+                && ErrorText == dv.ErrorText
+                && ((Formula1 == null && dv.Formula1 == null) 
+                    || Formula1 != null && dv.Formula1 != null 
+                    && Formula1.ToString() == dv.Formula1.ToString())
+                && ((Formula2 == null && dv.Formula2 == null) 
+                    || Formula2 != null && dv.Formula2 != null 
+                    && Formula2.ToString() == dv.Formula2.ToString())
+                && (CellRangeAddress == null && dv.CellRangeAddress == null
+                    || CellRangeAddress != null && dv.CellRangeAddress != null 
+                    && CellRangeAddress.ToString() == dv.CellRangeAddress.ToString());
+        }
 
         /**
          * Get the condition error style

--- a/main/HSSF/UserModel/HSSFSheet.cs
+++ b/main/HSSF/UserModel/HSSFSheet.cs
@@ -548,7 +548,7 @@ namespace NPOI.HSSF.UserModel
             dvt.AddDataValidation(dvRecord);
         }
 
-        public void RemoveValidationData(IDataValidation dataValidation)
+        public void RemoveDataValidation(IDataValidation dataValidation)
         {
             if (dataValidation == null)
             {

--- a/main/HSSF/UserModel/HSSFSheet.cs
+++ b/main/HSSF/UserModel/HSSFSheet.cs
@@ -548,6 +548,20 @@ namespace NPOI.HSSF.UserModel
             dvt.AddDataValidation(dvRecord);
         }
 
+        public void RemoveValidationData(IDataValidation dataValidation)
+        {
+            if (dataValidation == null)
+            {
+                throw new ArgumentException("objValidation must not be null");
+            }
+
+            HSSFDataValidation hssfDataValidation = (HSSFDataValidation)dataValidation;
+            DataValidityTable dvt = _sheet.GetOrCreateDataValidityTable();
+
+            DVRecord dvRecord = hssfDataValidation.CreateDVRecord(this);
+            dvt.RemoveDataValidation(dvRecord);
+        }
+
         /// <summary>
         /// Get the visibility state for a given column.F:\Gloria\�о�\�ļ���ʽ\NPOI\src\NPOI\HSSF\Util\HSSFDataValidation.cs
         /// </summary>

--- a/main/SS/UserModel/Sheet.cs
+++ b/main/SS/UserModel/Sheet.cs
@@ -841,6 +841,12 @@ namespace NPOI.SS.UserModel
         void AddValidationData(IDataValidation dataValidation);
 
         /// <summary>
+        /// Removes a data validation object
+        /// </summary>
+        /// <param name="dataValidation">The data validation object settings</param>
+        void RemoveValidationData(IDataValidation dataValidation);
+
+        /// <summary>
         /// Enable filtering for a range of cells
         /// </summary>
         /// <param name="range">the range of cells to filter</param>

--- a/main/SS/UserModel/Sheet.cs
+++ b/main/SS/UserModel/Sheet.cs
@@ -844,7 +844,7 @@ namespace NPOI.SS.UserModel
         /// Removes a data validation object
         /// </summary>
         /// <param name="dataValidation">The data validation object settings</param>
-        void RemoveValidationData(IDataValidation dataValidation);
+        void RemoveDataValidation(IDataValidation dataValidation);
 
         /// <summary>
         /// Enable filtering for a range of cells

--- a/ooxml/XSSF/Streaming/SXSSFSheet.cs
+++ b/ooxml/XSSF/Streaming/SXSSFSheet.cs
@@ -500,9 +500,9 @@ namespace NPOI.XSSF.Streaming
             _sh.AddValidationData(dataValidation);
         }
 
-        public void RemoveValidationData(IDataValidation dataValidation)
+        public void RemoveDataValidation(IDataValidation dataValidation)
         {
-            _sh.RemoveValidationData(dataValidation);
+            _sh.RemoveDataValidation(dataValidation);
         }
         
         /**

--- a/ooxml/XSSF/Streaming/SXSSFSheet.cs
+++ b/ooxml/XSSF/Streaming/SXSSFSheet.cs
@@ -495,11 +495,16 @@ namespace NPOI.XSSF.Streaming
             _sh.ValidateMergedRegions();
         }
 
-
         public void AddValidationData(IDataValidation dataValidation)
         {
             _sh.AddValidationData(dataValidation);
         }
+
+        public void RemoveValidationData(IDataValidation dataValidation)
+        {
+            _sh.RemoveValidationData(dataValidation);
+        }
+        
         /**
          * Adjusts the column width to fit the contents.
          *

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -3328,7 +3328,7 @@ namespace NPOI.XSSF.UserModel
             dataValidations.count = (uint)currentCount + 1;
         }
 
-        public void RemoveValidationData(IDataValidation dataValidation)
+        public void RemoveDataValidation(IDataValidation dataValidation)
         {
             XSSFDataValidation xssfDataValidation = (XSSFDataValidation)dataValidation;
             CT_DataValidations dataValidations = worksheet.dataValidations;

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -3326,7 +3326,31 @@ namespace NPOI.XSSF.UserModel
             CT_DataValidation newval = dataValidations.AddNewDataValidation();
             newval.Set(xssfDataValidation.GetCTDataValidation());
             dataValidations.count = (uint)currentCount + 1;
+        }
 
+        public void RemoveValidationData(IDataValidation dataValidation)
+        {
+            XSSFDataValidation xssfDataValidation = (XSSFDataValidation)dataValidation;
+            CT_DataValidations dataValidations = worksheet.dataValidations;
+
+            if (dataValidations is null)
+            {
+                return;
+            }
+            
+            int currentCount = dataValidations.sizeOfDataValidationArray();
+
+            for (int i = 0; i < currentCount; i++)
+            {
+                CT_DataValidation ctDataValidation = dataValidations.dataValidation[i];
+                
+                if (ctDataValidation.Equals(xssfDataValidation.GetCTDataValidation()))
+                {
+                    dataValidations.dataValidation.RemoveAt(i);
+                    dataValidations.count = (uint)currentCount - 1;
+                    return;
+                }
+            }
         }
 
         public IAutoFilter SetAutoFilter(CellRangeAddress range)

--- a/testcases/main/HSSF/UserModel/TestDataValidation.cs
+++ b/testcases/main/HSSF/UserModel/TestDataValidation.cs
@@ -465,7 +465,7 @@ namespace TestCases.HSSF.UserModel
         }
 
         [Test]
-        public void TestRemoveValidationData()
+        public void TestRemoveDataValidation()
         {
             
             HSSFWorkbook wb = new HSSFWorkbook();
@@ -482,7 +482,7 @@ namespace TestCases.HSSF.UserModel
             list = sheet.GetDataValidations();
             Assert.AreEqual(1, list.Count);
 
-            sheet.RemoveValidationData(validation);
+            sheet.RemoveDataValidation(validation);
 
             list = sheet.GetDataValidations();
             Assert.AreEqual(0, list.Count);

--- a/testcases/main/HSSF/UserModel/TestDataValidation.cs
+++ b/testcases/main/HSSF/UserModel/TestDataValidation.cs
@@ -464,6 +464,28 @@ namespace TestCases.HSSF.UserModel
             Assert.AreEqual(double.NaN, c.Value2);
         }
 
-    }
+        [Test]
+        public void TestRemoveValidationData()
+        {
+            
+            HSSFWorkbook wb = new HSSFWorkbook();
+            HSSFSheet sheet = wb.CreateSheet() as HSSFSheet;
+            List<IDataValidation> list = sheet.GetDataValidations();
+            Assert.AreEqual(0, list.Count);
 
+            IDataValidationHelper dataValidationHelper = sheet.GetDataValidationHelper();
+            IDataValidationConstraint constraint = dataValidationHelper.CreateCustomConstraint("A2:A3");
+            CellRangeAddressList AddressList = new CellRangeAddressList(0, 0, 0, 0);
+            IDataValidation validation = dataValidationHelper.CreateValidation(constraint, AddressList);
+            sheet.AddValidationData(validation);
+
+            list = sheet.GetDataValidations();
+            Assert.AreEqual(1, list.Count);
+
+            sheet.RemoveValidationData(validation);
+
+            list = sheet.GetDataValidations();
+            Assert.AreEqual(0, list.Count);
+        }
+    }
 }

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFDataValidation.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFDataValidation.cs
@@ -373,7 +373,7 @@ namespace TestCases.XSSF.UserModel
         }
 
         [Test]
-        public void TestRemoveValidationData()
+        public void TestRemoveDataValidation()
         {
             XSSFWorkbook wb = new XSSFWorkbook();
             try {
@@ -389,7 +389,7 @@ namespace TestCases.XSSF.UserModel
 
                 Assert.AreEqual(1, sheet.GetDataValidations().Count);
 
-                sheet.RemoveValidationData(dataValidation);
+                sheet.RemoveDataValidation(dataValidation);
 
                 Assert.AreEqual(0, sheet.GetDataValidations().Count);
             }

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFDataValidation.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFDataValidation.cs
@@ -372,6 +372,32 @@ namespace TestCases.XSSF.UserModel
             }
         }
 
+        [Test]
+        public void TestRemoveValidationData()
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            try {
+                XSSFSheet sheet = wb.CreateSheet() as XSSFSheet;
+                IDataValidationHelper dataValidationHelper = sheet.GetDataValidationHelper();
+                IDataValidationConstraint constraint = dataValidationHelper.CreateExplicitListConstraint(new string[] { "A" });
+                CellRangeAddressList cellRangeAddressList = new CellRangeAddressList();
+                cellRangeAddressList.AddCellRangeAddress(0, 0, 0, 0);
+                cellRangeAddressList.AddCellRangeAddress(0, 1, 0, 1);
+                cellRangeAddressList.AddCellRangeAddress(0, 2, 0, 2);
+                XSSFDataValidation dataValidation = dataValidationHelper.CreateValidation(constraint, cellRangeAddressList) as XSSFDataValidation;
+                sheet.AddValidationData(dataValidation);
+
+                Assert.AreEqual(1, sheet.GetDataValidations().Count);
+
+                sheet.RemoveValidationData(dataValidation);
+
+                Assert.AreEqual(0, sheet.GetDataValidations().Count);
+            }
+            finally {
+                wb.Close();
+            }
+        }
+
         private XSSFDataValidation CreateValidation(XSSFSheet sheet)
         {
             //create the cell that will have the validation applied
@@ -387,5 +413,3 @@ namespace TestCases.XSSF.UserModel
 
     }
 }
-
-


### PR DESCRIPTION
This PR adds a `RemoveDataValidation` to the `ISheet` implementations to allow the removal of a data validation rule.