### PR TITLE
[Bug 68237] CustomHeight attribute of row for SXSSFWorkbook is wrong 

### DIFF
--- a/ooxml/XSSF/Streaming/SheetDataWriter.cs
+++ b/ooxml/XSSF/Streaming/SheetDataWriter.cs
@@ -18,7 +18,6 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Text;
-using NPOI.OpenXmlFormats.Spreadsheet;
 using NPOI.SS.UserModel;
 using NPOI.SS.Util;
 using NPOI.Util;
@@ -29,7 +28,7 @@ namespace NPOI.XSSF.Streaming
 {
     public class SheetDataWriter
     {
-        private static POILogger logger = POILogFactory.GetLogger(typeof(SheetDataWriter));
+        private static readonly POILogger logger = POILogFactory.GetLogger(typeof(SheetDataWriter));
 
         protected FileInfo TemporaryFileInfo { get; set; }
         protected Stream OutputStream { get; private set; }
@@ -43,8 +42,8 @@ namespace NPOI.XSSF.Streaming
          * Table of strings shared across this workbook.
          * If two cells contain the same string, then the cell value is the same index into SharedStringsTable
          */
-        private SharedStringsTable _sharedStringSource;
-        private StreamWriter _outputWriter;
+        private readonly SharedStringsTable _sharedStringSource;
+        private readonly StreamWriter _outputWriter;
 
         public SheetDataWriter()
         {
@@ -79,7 +78,7 @@ namespace NPOI.XSSF.Streaming
         {
 
             FileStream fos = new FileStream(fd.FullName, FileMode.OpenOrCreate, FileAccess.ReadWrite);
-            Stream outputStream = null;
+            Stream outputStream;
             try
             {
                 outputStream = DecorateOutputStream(fos);
@@ -228,13 +227,13 @@ namespace NPOI.XSSF.Streaming
 
             if (row.HasCustomHeight())
             {
-                WriteAsBytes(" customHeight=\"true\" ht=\"");
+                WriteAsBytes(" customHeight=\"1\" ht=\"");
                 WriteAsBytes(row.HeightInPoints);
                 WriteAsBytes("\"");
             }
             if (row.ZeroHeight)
             {
-                WriteAsBytes(" hidden=\"true\"");
+                WriteAsBytes(" hidden=\"1\"");
             }
             if (row.IsFormatted)
             {

--- a/testcases/ooxml/XSSF/Streaming/SheetDataWriterTests.cs
+++ b/testcases/ooxml/XSSF/Streaming/SheetDataWriterTests.cs
@@ -65,8 +65,9 @@ namespace TestCases.XSSF.Streaming
         public void IfWritingRowWithCustomHeightShouldIncludeCustomHeightXml()
         {
             _objectToTest = new SheetDataWriter();
-            var row = new SXSSFRow(null);
-            row.Height = 1;
+            var row = new SXSSFRow(null) {
+                Height = 1
+            };
 
             _objectToTest.WriteRow(0, row);
             _objectToTest.Close();
@@ -74,7 +75,7 @@ namespace TestCases.XSSF.Streaming
             var lines = File.ReadAllLines(_objectToTest.TemporaryFilePath());
 
             Assert.True(lines.Length == 2);
-            Assert.AreEqual("<row r=\"" + 1 + "\" customHeight=\"true\" ht=\"" + row.HeightInPoints + "\">", lines[0]);
+            Assert.AreEqual("<row r=\"" + 1 + "\" customHeight=\"1\" ht=\"" + row.HeightInPoints.ToString().Replace(',', '.') + "\">", lines[0]);
             Assert.AreEqual("</row>", lines[1]);
 
 
@@ -94,7 +95,7 @@ namespace TestCases.XSSF.Streaming
             var lines = File.ReadAllLines(_objectToTest.TemporaryFilePath());
 
             Assert.True(lines.Length == 2);
-            Assert.AreEqual("<row r=\"" + 1 + "\" hidden=\"true\">", lines[0]);
+            Assert.AreEqual("<row r=\"" + 1 + "\" hidden=\"1\">", lines[0]);
             Assert.AreEqual("</row>", lines[1]);
 
 


### PR DESCRIPTION
Bugzilla url: https://bz.apache.org/bugzilla/show_bug.cgi?id=68237
SVN revision: https://svn.apache.org/viewvc?view=revision&revision=1914152