### PR TITLE
CT_CellFormula.Write: fix writing the si attribute

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet.cs
@@ -2701,7 +2701,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "r1", this.r1);
             XmlHelper.WriteAttribute(sw, "r2", this.r2);
             XmlHelper.WriteAttribute(sw, "ca", this.ca, false);
-            if(this.si!=0)
+            if(this.t == ST_CellFormulaType.shared || this.si!=0)
                 XmlHelper.WriteAttribute(sw, "si", this.si, true);
             XmlHelper.WriteAttribute(sw, "bx", this.bx, false);
             if (!string.IsNullOrEmpty(this.valueField))


### PR DESCRIPTION
`CT_CellFormula.Write` method ensure the `siField` is written into `fField`'s attributes on `Write` even when it has a default value for cases when the type of the formula is shared formula.

It seems that Excel expects this atribute to be written into xml even when it is of the default value for shared formulas. If not present - the xlsx file is flagged by it as broken and is repaired.

Not test is added because it is hard to test for Excel not trying to repair the file.