### PR TITLE
Update SixLabors.ImageSharp to 2.1.8. CVE-2024-32036

### DIFF
--- a/main/NPOI.Core.csproj
+++ b/main/NPOI.Core.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.7" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">


### PR DESCRIPTION
Update SixLabors.ImageSharp to 2.1.8 to address [CVE-2024-32036](https://nvd.nist.gov/vuln/detail/CVE-2024-32036)