### PR TITLE
Do not include xfId in CellStyleXfs XML

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Styles/CT_CellStyleXfs.cs
+++ b/OpenXmlFormats/Spreadsheet/Styles/CT_CellStyleXfs.cs
@@ -44,7 +44,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             {
                 foreach (CT_Xf x in this.xf)
                 {
-                    x.Write(sw, "xf");
+                    x.Write(sw, "xf", true);
                 }
             }
             sw.Write(string.Format("</{0}>", nodeName));

--- a/OpenXmlFormats/Spreadsheet/Styles/CT_Xf.cs
+++ b/OpenXmlFormats/Spreadsheet/Styles/CT_Xf.cs
@@ -109,14 +109,15 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
 
 
-        internal void Write(StreamWriter sw, string nodeName)
+        internal void Write(StreamWriter sw, string nodeName, bool writingCellStyle=false)
         {
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "numFmtId", this.numFmtId, true);
             XmlHelper.WriteAttribute(sw, "fontId", this.fontId, true);
             XmlHelper.WriteAttribute(sw, "fillId", this.fillId, true);
             XmlHelper.WriteAttribute(sw, "borderId", this.borderId, true);
-            XmlHelper.WriteAttribute(sw, "xfId", this.xfId, true);
+            if (!writingCellStyle)
+                XmlHelper.WriteAttribute(sw, "xfId", this.xfId, true);
             XmlHelper.WriteAttribute(sw, "quotePrefix", this.quotePrefix,false);
             XmlHelper.WriteAttribute(sw, "pivotButton", this.pivotButton, false);
             if(this.applyNumberFormat)


### PR DESCRIPTION
This fix removes the `xfId` attribute from `xf` elements in the `cellStyleXfs` collection.

When writing the `styles.xml` file NPOI includes a `xfId` attribute in the `xf` elements of the cell style format collection

```xml
<cellStyleXfs count="1">
    <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
</cellStyleXfs>
```

The `xfId` attribute is meaningless in `cellStyleXfs` collections.  The `xf` record is also used in the `cellXfs` collection where `xfId` is an index into `cellStyleXfs`.

If you load a generated file into Excel and save it the `xfId` is stripped out of `cellStyleXfs` elements.

Unfortunately, inclusion of the `xfId` attribute in the `cellStyleXfs` collection can cause other applications to fail.  [Spotfire](spotfire.com) will not read a file created with NPOI.   Spotfire uses `Syncfusion.XlsIO.Implementation.XmlReaders.Excel2007Parse` which will crash if an `xfId` is present on `xf` records in a `cellStyleXfs` colllection.  Spotfire will read files once the fix in this PR is applied. 