### PR TITLE
Upgrade BouncyCastle.Cryptography to version 2.3.1

### DIFF
--- a/main/NPOI.Core.csproj
+++ b/main/NPOI.Core.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="ExtendedNumerics.BigDecimal" Version="2025.1000.2.122" />
     <PackageReference Include="MathNet.Numerics.Signed" Version="5.0.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.3.1" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="SixLabors.Fonts" Version="1.0.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />


### PR DESCRIPTION
There's a security vulnerability in 2.3.0: https://github.com/advisories/GHSA-v435-xc8x-wvr9

