### PR TITLE
Use Directory.Build.props as single source of version information

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -9,7 +8,7 @@
     <DebugType>portable</DebugType>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
-    <VersionPrefix>2.7.0</VersionPrefix>
+    <VersionPrefix>2.7.1</VersionPrefix>
     <Title>NPOI</Title>
     <Authors>Tony Qu,NPOI Contributors</Authors>
     <Owners>Nissl Lab</Owners>

--- a/OpenXmlFormats/Properties/AssemblyInfo.cs
+++ b/OpenXmlFormats/Properties/AssemblyInfo.cs
@@ -1,41 +1,6 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
 using System.Security;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("NPOI OpenXmlFormats")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Nissl")]
-[assembly: AssemblyProduct("NPOI")]
-[assembly: AssemblyCopyright("Apache 2.0")]
-[assembly: AssemblyTrademark("NPOI")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("c67494d1-2eff-42d6-b0e5-063c750e4f2f")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.7.1.0")]
-[assembly: AssemblyFileVersion("2.7.1.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER || NETSTANDARD2_0 || NET40
 [assembly: AllowPartiallyTrustedCallers]
 #endif

--- a/build/Build.GitHubAction.cs
+++ b/build/Build.GitHubAction.cs
@@ -3,7 +3,7 @@ using Nuke.Common.CI.GitHubActions;
 [GitHubActions("CI",
     GitHubActionsImage.WindowsLatest,
     GitHubActionsImage.UbuntuLatest,
-    OnPushBranches = new[] { "main", "master", "release*" },
+    OnPushBranches = new[] { "main", "master", "release*", "poi/*" },
     InvokedTargets = new[] { nameof(Clean), nameof(Test), nameof(Pack) },
     TimeoutMinutes = 20,
     CacheKeyFiles = new string[0]

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -106,6 +106,10 @@ partial class Build : NukeBuild
                 // need to use escaped separator in order for this to work
                 .AddProperty("NoWarn", string.Join("%3B", new [] { 169, 612, 618, 1591, 1587, 1570, 1572, 1573, 1574 }))
                 .SetProjectFile(Solution)
+                // ensure we don't generate too much output in CI run
+                // 0  Turns off emission of all warning messages
+                // 1  Displays severe warning messages
+                .SetWarningLevel(IsServerBuild ? 0 : 1)
             );
 
             // copy files from projects in order to get them to be part of pack
@@ -158,7 +162,11 @@ partial class Build : NukeBuild
                     // obsolete missing XML documentation comment, XML comment on not valid language element, XML comment has badly formed XML, no matching tag in XML comment
                     // need to use escaped separator in order for this to work
                     .AddProperty("NoWarn", string.Join("%3B", new[] { 169, 612, 618, 1591, 1587, 1570, 1572, 1573, 1574 }))
-                    .SetProperty("EnablePackageValidation", "false");
+                    .SetProperty("EnablePackageValidation", "false")
+                    // ensure we don't generate too much output in CI run
+                    // 0  Turns off emission of all warning messages
+                    // 1  Displays severe warning messages
+                    .SetWarningLevel(IsServerBuild ? 0 : 1);
 
                 if (IsPublishBuild)
                 {

--- a/main/Properties/AssemblyInfo.cs
+++ b/main/Properties/AssemblyInfo.cs
@@ -1,41 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
 using System.Security;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("NPOI")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Nissl")]
-[assembly: AssemblyProduct("NPOI")]
-[assembly: AssemblyCopyright("Apache 2.0")]
-[assembly: AssemblyTrademark("NPOI")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("9bf85b73-8802-42ad-b83f-0ab48190b835")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.7.1.0")]
-[assembly: AssemblyFileVersion("2.7.1.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
 
 [assembly: InternalsVisibleTo("NPOI.TestCases, PublicKey=002400000480000094000000060200000024000052534131000400000100010095ccd95af3b39d8bc20544d3f47fd24b53ebc5ccb693eaed116290629f8cd882c827ebd511ad59449224f0718d3f9d03b64945a6c8b6644266001b8c8426185330e3d96da70ae16d4acc21b8d4d480f1385c7e924273179375aa88f81380a72fb115712a313379d16aed4aa36208ee3b4a5dd785b06a07b2d868e3227f4495b5", AllInternalsVisible = true)]
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER || NETSTANDARD2_0 || NET40

--- a/ooxml/Properties/AssemblyInfo.cs
+++ b/ooxml/Properties/AssemblyInfo.cs
@@ -1,43 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
 using System.Security;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("NPOI OOXML")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Nissl")]
-[assembly: AssemblyProduct("NPOI")]
-[assembly: AssemblyCopyright("Apache 2.0")]
-[assembly: AssemblyTrademark("NPOI")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("cc03d84d-498a-4561-97c1-e39d5d7780a0")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below: 
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.7.1.0")]
-[assembly: AssemblyFileVersion("2.7.1.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
-
-//[assembly: InternalsVisibleTo("ooxml.Testcases")]
 
 [assembly: InternalsVisibleTo("NPOI.OOXML.TestCases, PublicKey=002400000480000094000000060200000024000052534131000400000100010095ccd95af3b39d8bc20544d3f47fd24b53ebc5ccb693eaed116290629f8cd882c827ebd511ad59449224f0718d3f9d03b64945a6c8b6644266001b8c8426185330e3d96da70ae16d4acc21b8d4d480f1385c7e924273179375aa88f81380a72fb115712a313379d16aed4aa36208ee3b4a5dd785b06a07b2d868e3227f4495b5", AllInternalsVisible = true)]
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER || NETSTANDARD2_0 || NET40

--- a/openxml4Net/Properties/AssemblyInfo.cs
+++ b/openxml4Net/Properties/AssemblyInfo.cs
@@ -1,41 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Security;
+﻿using System.Security;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("NPOI OpenXml4Net")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Nissl")]
-[assembly: AssemblyProduct("NPOI")]
-[assembly: AssemblyCopyright("Apache 2.0")]
-[assembly: AssemblyTrademark("NPOI")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("13f2a810-331a-40b6-8d7a-1322b405fab7")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.7.1.0")]
-[assembly: AssemblyFileVersion("2.7.1.0")]
-[assembly: AssemblyInformationalVersion("2.0.0.0")]
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER || NETSTANDARD2_0 || NET40
 [assembly: AllowPartiallyTrustedCallers]
 #endif


### PR DESCRIPTION
Now `Directory.Build.props`'s version number in `<VersionPrefix>` is the single source of truth for the version (and other metadata) information. No need to copy paste and sync multiple files.

This is what the DLL metadata looks with local (Release) build:

![image](https://github.com/nissl-lab/npoi/assets/171892/16cce1b1-e51f-4b38-89a4-9a4a4b21c5ef)

fixes #1372 
