### PR TITLE
fixed SXSSFWorkbook can not clear temp files when it called Dispose() on the IWorkbook interface.

### DIFF
--- a/ooxml/XSSF/Streaming/SXSSFWorkbook.cs
+++ b/ooxml/XSSF/Streaming/SXSSFWorkbook.cs
@@ -985,7 +985,7 @@ namespace NPOI.XSSF.Streaming
 
         void IDisposable.Dispose()
         {
-            this.Close();
+            this.Dispose();
         }
 
 


### PR DESCRIPTION
The floowing code generates 2 temp files and is not automatically cleaned. This change fixes the problem.
``` C#
IWorkbook workbook = new SXSSFWorkbook();
var sheet = workbook.CreateSheet();
var row = sheet.CreateRow(0);
row.CreateCell(0).SetCellValue("test");

var sheet2 = workbook.CreateSheet();
var row2 = sheet2.CreateRow(0);
row2.CreateCell(0).SetCellValue("test");

workbook.Dispose();
```