### PR TITLE
FindAndReplaceText will now also work for tables within a documents h…

### DIFF
--- a/ooxml/XWPF/Usermodel/XWPFDocument.cs
+++ b/ooxml/XWPF/Usermodel/XWPFDocument.cs
@@ -1958,12 +1958,21 @@ namespace NPOI.XWPF.UserModel
                 {
                     FindAndReplaceTextInParagraph(paragraph, oldValue, newValue);
                 }
+                foreach(var table in footer.Tables)
+                {
+                    FindAndReplaceTextInTable(table, oldValue, newValue);
+                }
             }
+
             foreach (var header in this.HeaderList)
             {
                 foreach (var paragraph in header.Paragraphs)
                 {
                     FindAndReplaceTextInParagraph(paragraph, oldValue, newValue);
+                }
+                foreach(var table in header.Tables)
+                {
+                    FindAndReplaceTextInTable(table, oldValue, newValue);
                 }
             }
         }


### PR DESCRIPTION
…eader and footer

Previously FindAndReplaceText would miss text within tables, if located in XWPFDocument's header or footer