### PR TITLE
Remove System.Configuration.ConfigurationManager as NuGet dependency

### DIFF
--- a/main/NPOI.Core.csproj
+++ b/main/NPOI.Core.csproj
@@ -24,10 +24,6 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System.Configuration" />
   </ItemGroup>

--- a/main/Util/POILogFactory.cs
+++ b/main/Util/POILogFactory.cs
@@ -83,11 +83,18 @@ namespace NPOI.Util
             //  that our users can set the system property
             //  between class loading and first use
             if(_loggerClassName == null) {
+#if NETFRAMEWORK
         	    try {
         		    _loggerClassName = ConfigurationManager.AppSettings["loggername"];
         	    } catch(Exception) {}
-            	
-        	    // Use the default logger if none specified,
+#endif
+                if(_loggerClassName == null)
+                {
+                    // try environment
+                    _loggerClassName = Environment.GetEnvironmentVariable("NPOI_LOGGER_NAME");
+                }
+
+                // Use the default logger if none specified,
         	    //  or none could be fetched
         	    if(_loggerClassName == null) {
         		    _loggerClassName = _nullLogger.GetType().Name;

--- a/main/Util/SystemOutLogger.cs
+++ b/main/Util/SystemOutLogger.cs
@@ -77,9 +77,18 @@ namespace NPOI.Util
             int currentLevel;
             try
             {
-                string temp = ConfigurationManager.AppSettings["poi.log.level"];
-                if (string.IsNullOrEmpty(temp))
+                string temp = Environment.GetEnvironmentVariable("NPOI_LOG_LEVEL");
+#if NETFRAMEWORK
+                if (temp == null)
+                {
+                    temp = ConfigurationManager.AppSettings["poi.log.level"];
+                }
+#endif
+                if(string.IsNullOrEmpty(temp))
+                {
                     temp = WARN.ToString(CultureInfo.InvariantCulture);
+                }
+
                 currentLevel = int.Parse(temp, CultureInfo.InvariantCulture);
             }
             catch

--- a/testcases/main/NPOI.TestCases.Core.csproj
+++ b/testcases/main/NPOI.TestCases.Core.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* the dependency brings legacy packages (DLLs) with it to modern .NET
* usages are for advanced cases and I'd argue rarely used
* keep the support on full framework where .config files still are a thing
* allow configuration via environment variables on non-framework platforms