### PR TITLE
maxRows is usefull for AutoSizeColumn and GetColumnWidth

### DIFF
--- a/main/HSSF/UserModel/HSSFSheet.cs
+++ b/main/HSSF/UserModel/HSSFSheet.cs
@@ -2353,7 +2353,23 @@ namespace NPOI.HSSF.UserModel
         /// <param name="useMergedCells">whether to use the contents of merged cells when calculating the width of the column</param>
         public void AutoSizeColumn(int column, bool useMergedCells)
         {
-            double width = SheetUtil.GetColumnWidth(this, column, useMergedCells);
+            AutoSizeColumn(column, useMergedCells, maxRows: 0);
+        }
+
+        /// <summary>
+        /// Adjusts the column width to fit the contents.
+        /// This Process can be relatively slow on large sheets, so this should
+        /// normally only be called once per column, at the end of your
+        /// Processing.
+        /// You can specify whether the content of merged cells should be considered or ignored.
+        /// Default is to ignore merged cells.
+        /// </summary>
+        /// <param name="column">the column index</param>
+        /// <param name="useMergedCells">whether to use the contents of merged cells when calculating the width of the column</param>
+        /// <param name="maxRows">limit the scope to maxRows rows to speed up the function, or leave 0 (optional)</param>
+        public void AutoSizeColumn(int column, bool useMergedCells, int maxRows = 0)
+        {
+            double width = SheetUtil.GetColumnWidth(this, column, useMergedCells, maxRows);
             if (width != -1)
             {
                 width *= 256;

--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -565,11 +565,12 @@ namespace NPOI.SS.Util
          * @param sheet the sheet to calculate
          * @param column    0-based index of the column
          * @param useMergedCells    whether to use merged cells
+         * @param maxRows   limit the scope to maxRows rows to speed up the function, or leave 0 (optional)
          * @return  the width in pixels or -1 if all cells are empty
          */
-        public static double GetColumnWidth(ISheet sheet, int column, bool useMergedCells)
+        public static double GetColumnWidth(ISheet sheet, int column, bool useMergedCells, int maxRows = 0)
         {
-            return GetColumnWidth(sheet, column, useMergedCells, sheet.FirstRowNum, sheet.LastRowNum);
+            return GetColumnWidth(sheet, column, useMergedCells, sheet.FirstRowNum, sheet.LastRowNum, maxRows);
         }
         /**
          * Compute width of a column based on a subset of the rows and return the result


### PR DESCRIPTION
maxRows is usefull for AutoSizeColumn and GetColumnWidth from outside the library NPOI.
maxRows was added few years ago (https://github.com/nissl-lab/npoi/pull/723), but it is usefull for AutoSizeColumn and GetColumnWidth in fact.
The change also for AutoSizeColumn is needed in order to respect interface implementation: AutoSizeColumn(column, useMergedCells, maxRows: 0);