### PR TITLE
bug 59227: parse dates formatted in Japanese or Chinese. 

### DIFF
--- a/main/SS/UserModel/DateUtil.cs
+++ b/main/SS/UserModel/DateUtil.cs
@@ -50,11 +50,15 @@ namespace NPOI.SS.UserModel
         private static Regex date_ptrn1 = new Regex("^\\[\\$\\-.*?\\]", RegexOptions.Compiled);
         private static Regex date_ptrn2 = new Regex("^\\[[a-zA-Z]+\\]", RegexOptions.Compiled);
         private static Regex date_ptrn3a = new Regex("[yYmMdDhHsS]", RegexOptions.Compiled);
-        private static Regex date_ptrn3b = new Regex("^[\\[\\]yYmMdDhHsS\\-T/,. :\"\\\\]+0*[ampAMP/]*$", RegexOptions.Compiled);
+        // add "\u5e74 \u6708 \u65e5"（年月日） for Chinese/Japanese date format:2017年2月7日
+        private static Regex date_ptrn3b = new Regex("^[\\[\\]yYmMdDhHsS\\-T/\u5e74\u6708\u65e5,. :\"\\\\]+0*[ampAMP/]*$", RegexOptions.Compiled);
+
         //  elapsed time patterns: [h],[m] and [s]
         //private static Regex date_ptrn4 = new Regex("^\\[([hH]+|[mM]+|[sS]+)\\]", RegexOptions.Compiled);
         private static Regex date_ptrn4 = new Regex("^\\[([hH]+|[mM]+|[sS]+)\\]$", RegexOptions.Compiled);
 
+        // for format which start with "[DBNum1]" or "[DBNum2]" or "[DBNum3]" could be a Chinese date
+        private static Regex date_ptrn5 = new Regex("^\\[DBNum(1|2|3)\\]", RegexOptions.Compiled);
 
         /// <summary>
         /// Given a Calendar, return the number of days since 1899/12/31.
@@ -671,6 +675,10 @@ namespace NPOI.SS.UserModel
                     cached = true;
                     return true;
                 }
+
+                // If it starts with [DBNum1] or [DBNum2] or [DBNum3]
+                // then it could be a Chinese date 
+                fs = date_ptrn5.Replace(fs, "");
 
                 // If it starts with [$-...], then could be a date, but
                 //  who knows what that starting bit Is all about

--- a/testcases/main/SS/UserModel/TestDateUtil.cs
+++ b/testcases/main/SS/UserModel/TestDateUtil.cs
@@ -159,5 +159,36 @@ namespace TestCases.SS.UserModel
             Assert.AreEqual(expCal, actCal[2]);
             Assert.AreEqual(expCal, actCal[3]);
         }
+
+        [Test]
+        public void IsADateFormat()
+        {
+            // Cell content 2016-12-8 as an example
+            // Cell show "12/8/2016"
+            Assert.IsTrue(DateUtil.IsADateFormat(14, "m/d/yy"));
+            // Cell show "Thursday, December 8, 2016"
+            Assert.IsTrue(DateUtil.IsADateFormat(182, "[$-F800]dddd\\,\\ mmmm\\ dd\\,\\ yyyy"));
+            // Cell show "12/8"
+            Assert.IsTrue(DateUtil.IsADateFormat(183, "m/d;@"));
+            // Cell show "12/08/16"
+            Assert.IsTrue(DateUtil.IsADateFormat(184, "mm/dd/yy;@"));
+            // Cell show "8-Dec-16"
+            Assert.IsTrue(DateUtil.IsADateFormat(185, "[$-409]d\\-mmm\\-yy;@"));
+            // Cell show "D-16"
+            Assert.IsTrue(DateUtil.IsADateFormat(186, "[$-409]mmmmm\\-yy;@"));
+
+            // Cell show "2016年12月8日"
+            Assert.IsTrue(DateUtil.IsADateFormat(165, "yyyy\"年\"m\"月\"d\"日\";@"));
+            // Cell show "2016年12月"
+            Assert.IsTrue(DateUtil.IsADateFormat(164, "yyyy\"年\"m\"月\";@"));
+            // Cell show "12月8日"
+            Assert.IsTrue(DateUtil.IsADateFormat(168, "m\"月\"d\"日\";@"));
+            // Cell show "十二月八日"
+            Assert.IsTrue(DateUtil.IsADateFormat(181, "[DBNum1][$-404]m\"月\"d\"日\";@"));
+            // Cell show "贰零壹陆年壹拾贰月捌日"
+            Assert.IsTrue(DateUtil.IsADateFormat(177, "[DBNum2][$-804]yyyy\"年\"m\"月\"d\"日\";@"));
+            // Cell show "２０１６年１２月８日"
+            Assert.IsTrue(DateUtil.IsADateFormat(178, "[DBNum3][$-804]yyyy\"年\"m\"月\"d\"日\";@"));
+        }
     }
 }


### PR DESCRIPTION
bug 59227: parse dates formatted in Japanese or Chinese. Change javac source encoding from ASCII to UTF-8 (same as build.gradle). Patch from jzhao. This closes #48 on Github.