### PR TITLE
Inconsistent formatting when reading multiple XLS files concurrently (#1469)

### DIFF
--- a/benchmarks/NPOI.Benchmarks/DataFormatReadBenchmark.cs
+++ b/benchmarks/NPOI.Benchmarks/DataFormatReadBenchmark.cs
@@ -1,0 +1,79 @@
+﻿using BenchmarkDotNet.Attributes;
+using NPOI.HSSF.UserModel;
+using NPOI.SS.UserModel;
+
+namespace NPOI.Benchmarks;
+
+[SimpleJob]
+public class DataFormatReadBenchmark
+{
+    private const string dateFormat = "yyyy/MM/dd";
+    private const string timeFormat = "HH:mm:ss";
+
+    private HSSFWorkbook workbook;
+    private ISheet sheet1;
+
+    [Params(1_000)]
+    public int RowCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        workbook = new HSSFWorkbook();
+        Write(workbook);
+    }
+
+    private void Write(HSSFWorkbook wb)
+    {
+        var time = DateTime.UtcNow.AddYears(-1);
+
+        IDataFormat df = wb.CreateDataFormat();
+        var dateStyle = wb.CreateCellStyle();
+        dateStyle.DataFormat = df.GetFormat(dateFormat);
+        var timeStyle = wb.CreateCellStyle();
+        timeStyle.DataFormat = df.GetFormat(timeFormat);
+
+        ISheet sheet = wb.CreateSheet();
+
+        for(var i = 0; i<RowCount; i++)
+        {
+            IRow row = sheet.CreateRow(i);
+
+            ICell cellA = row.CreateCell(0);
+            cellA.SetCellValue(time);
+            cellA.CellStyle = dateStyle;
+
+            ICell cellB = row.CreateCell(1);
+            cellB.SetCellValue(time);
+            cellB.CellStyle = timeStyle;
+
+            time = time.AddHours(1);
+        }
+    }
+
+    [Benchmark]
+    public void Read()
+    {
+        DataFormatter df = new DataFormatter();
+        ISheet sheet = workbook.GetSheetAt(0);
+        var numRows = sheet.LastRowNum;
+        for(var r = 0; r<=numRows; r++)
+        {
+            IRow row = sheet.GetRow(r);
+            var numCells = row.LastCellNum;
+            var readRow = new string[numCells];
+            for(var c = 0; c<numCells; c++)
+            {
+                ICell cell = row.GetCell(c);
+                if(cell is null) continue;
+                readRow[c] = df.FormatCellValue(cell);
+            }
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        workbook.Dispose();
+    }
+}

--- a/main/HSSF/UserModel/HSSFCellStyle.cs
+++ b/main/HSSF/UserModel/HSSFCellStyle.cs
@@ -101,9 +101,7 @@ namespace NPOI.HSSF.UserModel
             get { return _format.FormatIndex; }
             set { _format.FormatIndex = (value); }
         }
-        private static short lastDateFormat = short.MinValue;
-        private static List<FormatRecord> lastFormats = null;
-        private static String getDataFormatStringCache = null;
+
         /// <summary>
         /// Get the contents of the format string, by looking up
         /// the DataFormat against the bound workbook
@@ -111,23 +109,8 @@ namespace NPOI.HSSF.UserModel
         /// <returns></returns>
         public String GetDataFormatString()
         {
-            //HSSFDataFormat format = new HSSFDataFormat(workbook);
-            //return format.GetFormat(DataFormat);
-
-            if (getDataFormatStringCache != null)
-            {
-                if (lastDateFormat == DataFormat && _workbook.Formats.Equals(lastFormats))
-                {
-                    return getDataFormatStringCache;
-                }
-            }
-
-            lastFormats = _workbook.Formats;
-            lastDateFormat = DataFormat;
-
-            getDataFormatStringCache = GetDataFormatString(_workbook);
-
-            return getDataFormatStringCache;
+            HSSFDataFormat format = new HSSFDataFormat(_workbook);
+            return format.GetFormat(DataFormat);
         }
 
         /// <summary>
@@ -593,9 +576,6 @@ namespace NPOI.HSSF.UserModel
             // Handle matching things if we cross workbooks
             if (_workbook != source._workbook)
             {
-                lastDateFormat = short.MinValue;
-                lastFormats = null;
-                getDataFormatStringCache = null;
                 // Then we need to clone the format string,
                 //  and update the format record for this
                 short fmt = (short)_workbook.CreateFormat(


### PR DESCRIPTION
Fixes #1469 by using AsyncLocal for static cache values.

# Benchmark

```
BenchmarkDotNet v0.13.12, Windows 10 (10.0.19045.5247/22H2/2022Update)
AMD Ryzen 5 1600X, 1 CPU, 12 logical and 6 physical cores
.NET SDK 9.0.101
  [Host]     : .NET 6.0.36 (6.0.3624.51421), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.36 (6.0.3624.51421), X64 RyuJIT AVX2
```

## Initial

| Method | RowCount | Mean     | Error     | StdDev    |
|------- |--------- |---------:|----------:|----------:|
| Read   | 1000     | 7.045 ms | 0.1364 ms | 0.1675 ms |

## Undo of 96186d6fd73f5b1e678ad0345696c002593e48b5

| Method | RowCount | Mean     | Error     | StdDev    |
|------- |--------- |---------:|----------:|----------:|
| Read   | 1000     | 9.296 ms | 0.1820 ms | 0.2302 ms |

## AsyncLocal Implementation

| Method | RowCount | Mean     | Error     | StdDev    |
|------- |--------- |---------:|----------:|----------:|
| Read   | 1000     | 7.294 ms | 0.0258 ms | 0.0229 ms |