### PR TITLE
Patches from poi 3.16

### DIFF
--- a/main/HSSF/UserModel/HSSFPicture.cs
+++ b/main/HSSF/UserModel/HSSFPicture.cs
@@ -225,11 +225,22 @@ namespace NPOI.HSSF.UserModel
         {
             get
             {
-                InternalWorkbook iwb = ((_patriarch.Sheet.Workbook) as HSSFWorkbook).Workbook;
+                HSSFPatriarch patriarch = Patriarch;
+                HSSFShape parent = Parent as HSSFShape;
+                while (patriarch == null && parent != null)
+                {
+                    patriarch = parent.Patriarch;
+                    parent = parent.Parent as HSSFShape;
+                }
+                if (patriarch == null)
+                {
+                    throw new InvalidOperationException("Could not find a patriarch for a HSSPicture");
+                }
+
+                InternalWorkbook iwb = (patriarch.Sheet.Workbook as HSSFWorkbook).Workbook;
                 EscherBSERecord bse = iwb.GetBSERecord(PictureIndex);
                 EscherBlipRecord blipRecord = bse.BlipRecord;
-                return new HSSFPictureData(blipRecord);
-            }
+                return new HSSFPictureData(blipRecord);            }
         }
 
 

--- a/main/HSSF/UserModel/HSSFPicture.cs
+++ b/main/HSSF/UserModel/HSSFPicture.cs
@@ -91,23 +91,22 @@ namespace NPOI.HSSF.UserModel
             Resize(scale, scale);
         }
 
-        /**
-     * Resize the image
-     * <p>
-     * Please note, that this method works correctly only for workbooks
-     * with default font size (Arial 10pt for .xls).
-     * If the default font is changed the resized image can be streched vertically or horizontally.
-     * </p>
-     * <p>
-     * <code>resize(1.0,1.0)</code> keeps the original size,<br/>
-     * <code>resize(0.5,0.5)</code> resize to 50% of the original,<br/>
-     * <code>resize(2.0,2.0)</code> resizes to 200% of the original.<br/>
-     * <code>resize({@link Double#MAX_VALUE},{@link Double#MAX_VALUE})</code> resizes to the dimension of the embedded image. 
-     * </p>
-     *
-     * @param scaleX the amount by which the image width is multiplied relative to the original width.
-     * @param scaleY the amount by which the image height is multiplied relative to the original height.
-     */
+        /// <summary>
+        /// <para>Resize the image</para>
+        /// <para>
+        /// Please note, that this method works correctly only for workbooks
+        /// with default font size (Arial 10pt for .xls).
+        /// If the default font is changed the resized image can be streched vertically or horizontally.
+        /// <list type="bullet">
+        /// <item><c>resize(1.0,1.0)</c> keeps the original size,</item>
+        /// <item><c>resize(0.5,0.5)</c> resize to 50% of the original,</item>
+        /// <item><c>resize(2.0,2.0)</c> resizes to 200% of the original.</item>
+        /// <item><c>resize(<see cref="double.MaxValue"/>,<see cref="double.MaxValue"/>)</c> resizes to the dimension of the embedded image. </item>
+        /// </list>
+        /// </para>
+        /// </summary>
+        /// <param name="scaleX">the amount by which the image width is multiplied relative to the original width.</param>
+        /// <param name="scaleY">the amount by which the image height is multiplied relative to the original height.</param>
         public void Resize(double scaleX, double scaleY)
         {
             HSSFClientAnchor anchor = (HSSFClientAnchor)ClientAnchor;
@@ -118,7 +117,7 @@ namespace NPOI.HSSF.UserModel
             int row2 = anchor.Row1 + (pref.Row2 - pref.Row1);
             int col2 = anchor.Col1 + (pref.Col2 - pref.Col1);
 
-            anchor.Col2=((short)col2);
+            anchor.Col2=((short) col2);
             // anchor.setDx1(0);
             anchor.Dx2=(pref.Dx2);
 
@@ -135,7 +134,7 @@ namespace NPOI.HSSF.UserModel
             get
             {
                 EscherSimpleProperty property = (EscherSimpleProperty)GetOptRecord().Lookup(EscherProperties.BLIP__BLIPTODISPLAY);
-                if (null == property)
+                if(null == property)
                 {
                     return -1;
                 }
@@ -146,17 +145,17 @@ namespace NPOI.HSSF.UserModel
                 SetPropertyValue(new EscherSimpleProperty(EscherProperties.BLIP__BLIPTODISPLAY, false, true, value));
             }
         }
-        /**
-         * Calculate the preferred size for this picture.
-         *
-         * @param scale the amount by which image dimensions are multiplied relative to the original size.
-         * @return HSSFClientAnchor with the preferred size for this image
-         * @since POI 3.0.2
-         */
+
+        /// <summary>
+        /// Calculate the preferred size for this picture.
+        /// </summary>
+        /// <param name="scale">the amount by which image dimensions are multiplied relative to the original size.</param>
+        /// <returns>HSSFClientAnchor with the preferred size for this image</returns>
         public IClientAnchor GetPreferredSize(double scale)
         {
             return GetPreferredSize(scale, scale);
         }
+
         /// <summary>
         /// Calculate the preferred size for this picture.
         /// </summary>
@@ -167,7 +166,7 @@ namespace NPOI.HSSF.UserModel
         {
             ImageUtils.SetPreferredSize(this, scaleX, scaleY);
             return ClientAnchor;
-            
+
         }
 
         /// <summary>
@@ -194,7 +193,7 @@ namespace NPOI.HSSF.UserModel
         {
             //int hdpi = 96, vdpi = 96;
             //double mm2inch = 25.4;
-            return new Size((int)r.Metadata.HorizontalResolution, (int)r.Metadata.VerticalResolution);
+            return new Size((int) r.Metadata.HorizontalResolution, (int) r.Metadata.VerticalResolution);
         }
 
         /// <summary>
@@ -208,31 +207,30 @@ namespace NPOI.HSSF.UserModel
             byte[] data = bse.BlipRecord.PictureData;
             //int type = bse.BlipTypeWin32;
 
-            using (MemoryStream ms = RecyclableMemory.GetStream(data))
+            using(MemoryStream ms = RecyclableMemory.GetStream(data))
             {
-                using (Image img = Image.Load(ms))
+                using(Image img = Image.Load(ms))
                 {
                     return img.Size();
                 }
             }
         }
-        /**
-         * Return picture data for this shape
-         *
-         * @return picture data for this shape
-         */
+
+        /// <summary>
+        /// Return picture data for this shape
+        /// </summary>
         public IPictureData PictureData
         {
             get
             {
                 HSSFPatriarch patriarch = Patriarch;
                 HSSFShape parent = Parent as HSSFShape;
-                while (patriarch == null && parent != null)
+                while(patriarch == null && parent != null)
                 {
                     patriarch = parent.Patriarch;
                     parent = parent.Parent as HSSFShape;
                 }
-                if (patriarch == null)
+                if(patriarch == null)
                 {
                     throw new InvalidOperationException("Could not find a patriarch for a HSSPicture");
                 }
@@ -240,7 +238,8 @@ namespace NPOI.HSSF.UserModel
                 InternalWorkbook iwb = (patriarch.Sheet.Workbook as HSSFWorkbook).Workbook;
                 EscherBSERecord bse = iwb.GetBSERecord(PictureIndex);
                 EscherBlipRecord blipRecord = bse.BlipRecord;
-                return new HSSFPictureData(blipRecord);            }
+                return new HSSFPictureData(blipRecord);
+            }
         }
 
 
@@ -248,7 +247,7 @@ namespace NPOI.HSSF.UserModel
         {
             EscherAggregate agg = patriarch.GetBoundAggregate();
             agg.AssociateShapeToObjRecord(GetEscherContainer().GetChildById(EscherClientDataRecord.RECORD_ID), GetObjRecord());
-            if (PictureIndex != -1)
+            if(PictureIndex != -1)
             {
                 EscherBSERecord bse =
                     (patriarch.Sheet.Workbook as HSSFWorkbook).Workbook.GetBSERecord(PictureIndex);
@@ -256,9 +255,9 @@ namespace NPOI.HSSF.UserModel
             }
         }
 
-        /**
-         * The color applied to the lines of this shape.
-         */
+        /// <summary>
+        /// The color applied to the lines of this shape.
+        /// </summary>
         public String FileName
         {
             get
@@ -282,11 +281,11 @@ namespace NPOI.HSSF.UserModel
             //int off = offset;      /* avoid getfield opcode */
             char[] val = value.ToCharArray();    /* avoid getfield opcode */
 
-            while ((st < end) && (val[st] <= ' '))
+            while((st < end) && (val[st] <= ' '))
             {
                 st++;
             }
-            while ((st < end) && (val[end - 1] <= ' '))
+            while((st < end) && (val[end - 1] <= ' '))
             {
                 end--;
             }
@@ -313,22 +312,22 @@ namespace NPOI.HSSF.UserModel
         }
 
 
-        /**
-         * @return the anchor that is used by this picture.
-         */
+        /// <summary>
+        /// the anchor that is used by this picture.
+        /// </summary>
         public IClientAnchor ClientAnchor
         {
             get
             {
                 HSSFAnchor a = Anchor as HSSFAnchor;
-                return (a is HSSFClientAnchor) ? (HSSFClientAnchor)a : null;
+                return (a is HSSFClientAnchor) ? (HSSFClientAnchor) a : null;
             }
         }
 
 
-        /**
-         * @return the sheet which contains the picture shape
-         */
+        /// <summary>
+        /// the sheet which contains the picture shape
+        /// </summary>
         public ISheet Sheet
         {
             get

--- a/testcases/main/POITestCase.cs
+++ b/testcases/main/POITestCase.cs
@@ -32,31 +32,58 @@ namespace TestCases
      */
     public class POITestCase
     {
-        public static void AssertContains(String haystack, String needle)
+        public static void AssertStartsWith(String actual, String prefix)
         {
-            Assert.IsTrue(
-                  haystack.Contains(needle),
-                  "Unable to find expected text '" + needle + "' in text:\n" + haystack
-            );
-        }
-        public static void AssertContainsIgnoreCase(String haystack, String needle, CultureInfo locale)
-        {
-            Assert.IsNotNull(haystack);
-            Assert.IsNotNull(needle);
-            String hay = haystack.ToLower(locale);
-            String n = needle.ToLower(locale);
-            Assert.IsTrue(hay.Contains(n), "Unable to find expected text '" + needle + "' in1 text:\n" + haystack);
-        }
-        public static void AssertContainsIgnoreCase(String haystack, String needle)
-        {
-            AssertContainsIgnoreCase(haystack, needle, CultureInfo.CurrentCulture);
+            Assert.IsNotNull(actual);
+            Assert.IsNotNull(prefix);
+            StringAssert.StartsWith(prefix, actual);
         }
 
-        public static void AssertNotContained(String haystack, String needle)
+        public static void AssertStartsWith(String message, String actual, String prefix)
         {
-            Assert.IsFalse(haystack.Contains(needle),
-                  "Unexpectedly found text '" + needle + "' in text:\n" + haystack
-            );
+            Assert.IsNotNull(message, actual);
+            Assert.IsNotNull(message, prefix);
+            StringAssert.StartsWith(prefix, actual, message);
+        }
+
+        public static void AssertEndsWith(String actual, String suffix)
+        {
+            Assert.IsNotNull(actual);
+            Assert.IsNotNull(suffix);
+            StringAssert.EndsWith(suffix, actual);
+        }
+
+        public static void AssertContains(String actual, String expected)
+        {
+            Assert.IsNotNull(actual);
+            Assert.IsNotNull(expected);
+            StringAssert.Contains(expected, actual);
+        }
+        public static void AssertContains(String message, String actual, String expected)
+        {
+            Assert.IsNotNull(actual, message);
+            Assert.IsNotNull(expected, message);
+            StringAssert.Contains(expected, actual, message);
+        }
+
+        public static void AssertContainsIgnoreCase(String actual, String expected, CultureInfo locale)
+        {
+            Assert.IsNotNull(actual);
+            Assert.IsNotNull(expected);
+            string hay = actual.ToLower(locale);
+            string n = expected.ToLower(locale);
+            StringAssert.Contains(n, hay, "Unable to find expected text '" + expected + "' in1 text:\n" + actual);
+        }
+        public static void AssertContainsIgnoreCase(String actual, String expected)
+        {
+            AssertContainsIgnoreCase(actual, expected, CultureInfo.CurrentCulture);
+        }
+
+        public static void AssertNotContained(String actual, String expected)
+        {
+            Assert.IsNotNull(actual);
+            Assert.IsNotNull(expected);
+            StringAssert.DoesNotContain(expected, actual, "Unexpectedly found text '" + expected + "' in text:\n" + actual);
         }
 
         /**
@@ -65,7 +92,7 @@ namespace TestCases
          */
         public static void AssertContains<TKey, TValue>(Dictionary<TKey, TValue> map, TKey key)
         {
-            if (map.ContainsKey(key))
+            if(map.ContainsKey(key))
             {
                 return;
             }
@@ -74,7 +101,7 @@ namespace TestCases
         public static void AssertEquals<T>(T[] expected, T[] actual)
         {
             Assert.AreEqual(expected.Length, actual.Length, "Non-matching lengths");
-            for (int i = 0; i < expected.Length; i++)
+            for(int i = 0; i < expected.Length; i++)
             {
                 Assert.AreEqual(expected[i], actual[i], "Mis-match at offset " + i);
             }
@@ -82,7 +109,7 @@ namespace TestCases
         public static void AssertEquals(byte[] expected, byte[] actual)
         {
             Assert.AreEqual(expected.Length, actual.Length, "Non-matching lengths");
-            for (int i = 0; i < expected.Length; i++)
+            for(int i = 0; i < expected.Length; i++)
             {
                 Assert.AreEqual(expected[i], actual[i], "Mis-match at offset " + i);
             }
@@ -90,9 +117,9 @@ namespace TestCases
         public static void AssertContains<T>(T needle, T[] haystack)
         {
             // Check
-            foreach (T thing in haystack)
+            foreach(T thing in haystack)
             {
-                if (thing.Equals(needle))
+                if(thing.Equals(needle))
                 {
                     return;
                 }
@@ -101,7 +128,7 @@ namespace TestCases
             // Failed, try to build a nice error
             StringBuilder sb = new StringBuilder();
             sb.Append("Unable to find ").Append(needle).Append(" in [");
-            foreach (T thing in haystack)
+            foreach(T thing in haystack)
             {
                 sb.Append(" ").Append(thing.ToString()).Append(" ,");
             }
@@ -112,7 +139,7 @@ namespace TestCases
 
         public static void AssertContains<T>(T needle, IList<T> haystack)
         {
-            if (haystack.Contains(needle))
+            if(haystack.Contains(needle))
             {
                 return;
             }
@@ -125,10 +152,10 @@ namespace TestCases
             try
             {
                 FieldInfo fieldInfo = clazz.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance);
-                return (R)fieldInfo.GetValue(instance);
+                return (R) fieldInfo.GetValue(instance);
 
             }
-            catch (Exception pae)
+            catch(Exception pae)
             {
                 throw new RuntimeException("Cannot access field '" + fieldName + "' of class " + clazz, pae.InnerException);
             }

--- a/testcases/main/TestPOITestCase.cs
+++ b/testcases/main/TestPOITestCase.cs
@@ -29,6 +29,22 @@ namespace TestCases
     public class TestPOITestCase
     {
         [Test]
+        public void AssertStartsWith()
+        {
+            POITestCase.AssertStartsWith("Apache POI", "");
+            POITestCase.AssertStartsWith("Apache POI", "Apache");
+            POITestCase.AssertStartsWith("Apache POI", "Apache POI");
+        }
+
+        [Test]
+        public void AssertEndsWith()
+        {
+            POITestCase.AssertEndsWith("Apache POI", "");
+            POITestCase.AssertEndsWith("Apache POI", "POI");
+            POITestCase.AssertEndsWith("Apache POI", "Apache POI");
+        }
+
+        [Test]
         public void AssertContains()
         {
             POITestCase.AssertContains("There is a needle in this haystack", "needle");


### PR DESCRIPTION
- Fix issue found via large corpus tests: HSSFPicture in a HSSFShapeGroup might not have a patriarch set, so let's walk up the parents to try to find one.

- Test for another type of xml-bomb

- use assertStartsWith and assertEndsWith for better unit test error messages