### PR TITLE
Fix int overflowing in ExcelGeneralNumberFormat

### DIFF
--- a/main/SS/UserModel/ExcelGeneralNumberFormat.cs
+++ b/main/SS/UserModel/ExcelGeneralNumberFormat.cs
@@ -92,7 +92,7 @@ namespace NPOI.SS.UserModel
             int digits = 10;
             if (Math.Abs(value) > 1)
             {
-                int len = (int)Math.Log10((int)Math.Abs(value)) + 1;
+                int len = (int)Math.Log10((long)Math.Abs(value)) + 1;
                 digits -= len;
             }
             double rounded = Math.Round(value, digits, MidpointRounding.AwayFromZero);


### PR DESCRIPTION
We're seeing this _An unhandled exception of type 'System.ArgumentOutOfRangeException' occurred in mscorlib.dll Additional information: Rounding digits must be between 0 and 15, inclusive._ coming from ExcelGeneralNumberFormat [line 98](https://github.com/nissl-lab/npoi/blob/master/main/SS/UserModel/ExcelGeneralNumberFormat.cs#L98). 

This is caused by a wrong data type used in the digits counting algorithm. When calculating the len on [line 96](https://github.com/nissl-lab/npoi/blob/master/main/SS/UserModel/ExcelGeneralNumberFormat.cs#L95):
`int len = (int)Math.Log10((**int**)Math.Abs(value)) + 1;`
Casting a double to an int, you can easily end up with int overflow. When this happens, you end up with len like _-2147483647_.

Numbers higher than 10,000,000,000 are handled correctly [line 77](https://github.com/nissl-lab/npoi/blob/master/main/SS/UserModel/ExcelGeneralNumberFormat.cs#L77). But there is plenty of numbers between max int 2,147,483,647 and 10,000,000,000 that trigger the overflow.