### PR TITLE
Reduce warning output during build and treat new warnings as errors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,10 +22,38 @@
     <PackageReleaseNotes>https://github.com/nissl-lab/npoi/discussions/1422</PackageReleaseNotes>
     <Copyright>Nissl LLC</Copyright>
     <PackageTags>xlsx xls Excel Word docx office ole</PackageTags>
+
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+  <PropertyGroup Label="XML Documentation" Condition=" '$(Configuration)' == 'Release' ">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS0419</NoWarn> <!-- Ambiguous reference in cref attribute -->
+    <NoWarn>$(NoWarn);CS1570</NoWarn> <!-- XML comment has badly formed XML -->
+    <NoWarn>$(NoWarn);CS1572</NoWarn> <!-- XML comment has a param tag for XXX, but there is no parameter by that name -->
+    <NoWarn>$(NoWarn);CS1573</NoWarn> <!-- Parameter XXX has no matching param tag in the XML comment -->
+    <NoWarn>$(NoWarn);CS1574</NoWarn> <!-- XML comment has cref attribute xxx that could not be resolved -->
+    <NoWarn>$(NoWarn);CS1584</NoWarn> <!-- XML comment has syntactically incorrect cref attribute -->
+    <NoWarn>$(NoWarn);CS1587</NoWarn> <!-- XML comment is not placed on a valid language element -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn> <!-- Missing XML comment for publicly visible type or member -->
+    <NoWarn>$(NoWarn);CS1734</NoWarn> <!-- XML comment on XXX has a paramref tag for YYY, but there is no parameter by that name -->
+  </PropertyGroup>
+
+  <PropertyGroup Label="Code Analysis">
+    <NoWarn>$(NoWarn);CS0108</NoWarn> <!-- XXX hides inherited member -->
+    <NoWarn>$(NoWarn);CS0114</NoWarn> <!-- XXX hides inherited member -->
+    <NoWarn>$(NoWarn);CS0162</NoWarn> <!-- Unreachable code detected -->
+    <NoWarn>$(NoWarn);CS0168</NoWarn> <!-- The variable XXX is declared but never used -->
+    <NoWarn>$(NoWarn);CS0169</NoWarn> <!-- Unreachable code detected -->
+    <NoWarn>$(NoWarn);CS0414</NoWarn> <!-- The field XXX is assigned but its value is never used -->
+    <NoWarn>$(NoWarn);CS0628</NoWarn> <!-- new protected member declared in sealed type -->
+    <NoWarn>$(NoWarn);CS0649</NoWarn> <!-- Field XXX is never assigned to -->
+    <NoWarn>$(NoWarn);CS0659</NoWarn> <!-- XXX overrides Object.Equals(object o) but does not override Object.GetHashCode() -->
+
+    <NoWarn>$(NoWarn);CS0612</NoWarn> <!-- XXX is obsolete -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn> <!-- XXX is obsolete: deprecated POI XYZ -->
+
+    <NoWarn>$(NoWarn);SYSLIB0021;SYSLIB0051</NoWarn> <!-- Deprecated API usage -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/benchmarks/NPOI.Benchmarks/NPOI.Benchmarks.csproj
+++ b/benchmarks/NPOI.Benchmarks/NPOI.Benchmarks.csproj
@@ -4,6 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
+        <NoWarn>$(NoWarn);SYSLIB0014</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/main/HPSF/Section.cs
+++ b/main/HPSF/Section.cs
@@ -565,7 +565,7 @@ namespace NPOI.HPSF
                     }
                     catch(HPSFRuntimeException ex)
                     {
-                        throw ex;
+                        throw;
                     }
                     catch(Exception ex)
                     {

--- a/testcases/Directory.Build.props
+++ b/testcases/Directory.Build.props
@@ -7,4 +7,12 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup Label="Code Analysis">
+    <NoWarn>$(NoWarn);CS0612</NoWarn> <!-- XXX is obsolete -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn> <!-- XXX is obsolete: deprecated POI XYZ -->
+    <NoWarn>$(NoWarn);CS0162</NoWarn> <!-- Unreachable code detected -->
+    <NoWarn>$(NoWarn);CA2200</NoWarn> <!-- Re-throwing caught exception changes stack information -->
+    <NoWarn>$(NoWarn);SYSLIB0014</NoWarn> <!-- obsolete -->
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
This will improve future code quality and existing problems can be handled with new PRs targeting specific warnings that can be then removed from ignore list (NoWarn). As an example invalid exception re-throw in Section.cs now gave compilation error and needed to be fixed before compilation succeeded.