### PR TITLE
Account for image resolution units other than pixels per inch

### DIFF
--- a/main/SS/Util/ImageUtils.cs
+++ b/main/SS/Util/ImageUtils.cs
@@ -22,7 +22,8 @@ namespace NPOI.SS.Util
     using NPOI.SS.UserModel;
     using NPOI.Util;
     using SixLabors.ImageSharp;
-
+    using SixLabors.ImageSharp.Metadata;
+    
     /**
      * @author Yegor Kozlov
      */

--- a/main/SS/Util/ImageUtils.cs
+++ b/main/SS/Util/ImageUtils.cs
@@ -103,7 +103,28 @@ namespace NPOI.SS.Util
          */
         public static int[] GetResolution(Image r)
         {
-            return new int[] { (int)r.Metadata.HorizontalResolution, (int)r.Metadata.VerticalResolution };
+            ImageMetadata imageMetadata = r.Metadata;
+
+            double horizontalResolution = 0;
+            double verticalResolution = 0;
+
+            if (imageMetadata.ResolutionUnits == PixelResolutionUnit.PixelsPerMeter)
+            {
+                horizontalResolution = imageMetadata.HorizontalResolution * 0.0254D;
+                verticalResolution = imageMetadata.VerticalResolution * 0.0254D;
+            }
+            else if (imageMetadata.ResolutionUnits == PixelResolutionUnit.PixelsPerCentimeter)
+            {
+                horizontalResolution = imageMetadata.HorizontalResolution * 2.54D;
+                verticalResolution = imageMetadata.VerticalResolution * 2.54D;
+            }
+            else
+            {
+                horizontalResolution = imageMetadata.HorizontalResolution;
+                verticalResolution = imageMetadata.VerticalResolution;
+            }
+
+            return new int[] { (int)Math.Round(horizontalResolution), (int)Math.Round(verticalResolution) };
         }
 
         /**


### PR DESCRIPTION
Added logic to convert the resolution to "pixels per inch" for images which have it specified as "pixels per meter" or "pixels per centimeter".