### PR TITLE
Add support for bar grouping in bar and column charts

### DIFF
--- a/main/SS/UserModel/Charts/BarChartData.cs
+++ b/main/SS/UserModel/Charts/BarChartData.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace NPOI.SS.UserModel.Charts
 {
@@ -23,5 +21,11 @@ namespace NPOI.SS.UserModel.Charts
          * @return list of all series.
          */
         List<IBarChartSeries<Tx, Ty>> GetSeries();
+        
+        /// <summary>
+        /// Sets bar grouping
+        /// </summary>
+        /// <param name="grouping">The type of bar grouping</param>
+        void SetBarGrouping(BarGrouping grouping);
     }
 }

--- a/main/SS/UserModel/Charts/BarGrouping.cs
+++ b/main/SS/UserModel/Charts/BarGrouping.cs
@@ -1,0 +1,10 @@
+﻿namespace NPOI.SS.UserModel.Charts
+{
+    public enum BarGrouping
+    {
+        PercentStacked,
+        Clustered,
+        Standard,
+        Stacked
+    }
+}

--- a/main/SS/UserModel/Charts/ColumnChartData.cs
+++ b/main/SS/UserModel/Charts/ColumnChartData.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace NPOI.SS.UserModel.Charts
 {
@@ -21,5 +19,11 @@ namespace NPOI.SS.UserModel.Charts
         /// Returns list of all series.
         /// </summary>
         List<IColumnChartSeries<Tx, Ty>> GetSeries();
+
+        /// <summary>
+        /// Sets bar grouping
+        /// </summary>
+        /// <param name="grouping">The type of bar grouping</param>
+        void SetBarGrouping(BarGrouping grouping);
     }
 }

--- a/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
@@ -33,18 +33,15 @@ namespace NPOI.XSSF.UserModel.Charts
             private byte[] fillColor;
             private IChartDataSource<Tx> categories;
             private IChartDataSource<Ty> values;
-            private readonly BarGrouping grouping;
 
             internal Series(int id, int order,
                 IChartDataSource<Tx> categories,
-                IChartDataSource<Ty> values,
-                BarGrouping grouping)
+                IChartDataSource<Ty> values)
             {
                 this.id = id;
                 this.order = order;
                 this.categories = categories;
                 this.values = values;
-                this.grouping = grouping;
             }
 
             public void SetId(int id)
@@ -75,11 +72,11 @@ namespace NPOI.XSSF.UserModel.Charts
                 return values;
             }
 
-            internal void AddToChart(CT_BarChart ctBarChart)
+            internal void AddToChart(CT_BarChart ctBarChart, BarGrouping barGrouping)
             {
                 CT_BarSer ctBarSer = ctBarChart.AddNewSer();
                 CT_BarGrouping ctGrouping = ctBarChart.AddNewGrouping();
-                ctGrouping.val = grouping.ToST_BarGrouping();
+                ctGrouping.val = barGrouping.ToST_BarGrouping();
                 ctBarSer.AddNewIdx().val = (uint)id;
                 ctBarSer.AddNewOrder().val = (uint)order;
                 CT_Boolean ctNoInvertIfNegative = new CT_Boolean();
@@ -116,7 +113,7 @@ namespace NPOI.XSSF.UserModel.Charts
                 throw new ArgumentException("Value data source must be numeric.");
             }
             int numOfSeries = series.Count;
-            Series newSeries = new Series(numOfSeries, numOfSeries, categoryAxisData, values, grouping);
+            Series newSeries = new Series(numOfSeries, numOfSeries, categoryAxisData, values);
             series.Add(newSeries);
             return newSeries;
         }
@@ -148,7 +145,7 @@ namespace NPOI.XSSF.UserModel.Charts
                 Series s = (Series)series[i];
                 s.SetId(allSeriesCount + i);
                 s.SetOrder(allSeriesCount + i);
-                s.AddToChart(barChart);
+                s.AddToChart(barChart, grouping);
             }
 
             foreach (IChartAxis ax in axis)

--- a/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFBarChartData.cs
@@ -1,10 +1,10 @@
 ﻿using NPOI.OpenXmlFormats.Dml;
 using NPOI.OpenXmlFormats.Dml.Chart;
 using NPOI.SS.UserModel.Charts;
+using NPOI.XSSF.UserModel.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Text;
 
 namespace NPOI.XSSF.UserModel.Charts
 {
@@ -19,6 +19,7 @@ namespace NPOI.XSSF.UserModel.Charts
          * List of all data series.
          */
         private List<IBarChartSeries<Tx, Ty>> series;
+        private BarGrouping grouping = BarGrouping.Clustered;
 
         public XSSFBarChartData()
         {
@@ -32,15 +33,18 @@ namespace NPOI.XSSF.UserModel.Charts
             private byte[] fillColor;
             private IChartDataSource<Tx> categories;
             private IChartDataSource<Ty> values;
+            private readonly BarGrouping grouping;
 
             internal Series(int id, int order,
                 IChartDataSource<Tx> categories,
-                IChartDataSource<Ty> values)
+                IChartDataSource<Ty> values,
+                BarGrouping grouping)
             {
                 this.id = id;
                 this.order = order;
                 this.categories = categories;
                 this.values = values;
+                this.grouping = grouping;
             }
 
             public void SetId(int id)
@@ -75,7 +79,7 @@ namespace NPOI.XSSF.UserModel.Charts
             {
                 CT_BarSer ctBarSer = ctBarChart.AddNewSer();
                 CT_BarGrouping ctGrouping = ctBarChart.AddNewGrouping();
-                ctGrouping.val = ST_BarGrouping.clustered;
+                ctGrouping.val = grouping.ToST_BarGrouping();
                 ctBarSer.AddNewIdx().val = (uint)id;
                 ctBarSer.AddNewOrder().val = (uint)order;
                 CT_Boolean ctNoInvertIfNegative = new CT_Boolean();
@@ -112,7 +116,7 @@ namespace NPOI.XSSF.UserModel.Charts
                 throw new ArgumentException("Value data source must be numeric.");
             }
             int numOfSeries = series.Count;
-            Series newSeries = new Series(numOfSeries, numOfSeries, categoryAxisData, values);
+            Series newSeries = new Series(numOfSeries, numOfSeries, categoryAxisData, values, grouping);
             series.Add(newSeries);
             return newSeries;
         }
@@ -120,6 +124,11 @@ namespace NPOI.XSSF.UserModel.Charts
         public List<IBarChartSeries<Tx, Ty>> GetSeries()
         {
             return series;
+        }
+
+        public void SetBarGrouping(BarGrouping grouping)
+        {
+            this.grouping = grouping;
         }
 
         public void FillChart(SS.UserModel.IChart chart, params IChartAxis[] axis)

--- a/ooxml/XSSF/UserModel/Charts/XSSFColumnChartData.cs
+++ b/ooxml/XSSF/UserModel/Charts/XSSFColumnChartData.cs
@@ -1,6 +1,7 @@
 ﻿using NPOI.OpenXmlFormats.Dml;
 using NPOI.OpenXmlFormats.Dml.Chart;
 using NPOI.SS.UserModel.Charts;
+using NPOI.XSSF.UserModel.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -19,6 +20,7 @@ namespace NPOI.XSSF.UserModel.Charts
          * List of all data series.
          */
         private List<IColumnChartSeries<Tx, Ty>> series;
+        private BarGrouping grouping = BarGrouping.Clustered;
 
         public XSSFColumnChartData()
         {
@@ -71,11 +73,11 @@ namespace NPOI.XSSF.UserModel.Charts
                 return values;
             }
 
-            internal void AddToChart(CT_BarChart ctBarChart)
+            internal void AddToChart(CT_BarChart ctBarChart, BarGrouping grouping)
             {
                 CT_BarSer ctBarSer = ctBarChart.AddNewSer();
                 CT_BarGrouping ctGrouping = ctBarChart.AddNewGrouping();
-                ctGrouping.val = ST_BarGrouping.clustered;
+                ctGrouping.val = grouping.ToST_BarGrouping();
                 ctBarSer.AddNewIdx().val = (uint)id;
                 ctBarSer.AddNewOrder().val = (uint)order;
                 CT_Boolean ctNoInvertIfNegative = new CT_Boolean();
@@ -122,6 +124,11 @@ namespace NPOI.XSSF.UserModel.Charts
             return series;
         }
 
+        public void SetBarGrouping(BarGrouping grouping)
+        {
+            this.grouping = grouping;
+        }
+
         public void FillChart(SS.UserModel.IChart chart, params IChartAxis[] axis)
         {
             if (chart is not XSSFChart xssfChart)
@@ -139,7 +146,7 @@ namespace NPOI.XSSF.UserModel.Charts
                 Series s = (Series)series[i];
                 s.SetId(allSeriesCount + i);
                 s.SetOrder(allSeriesCount + i);
-                s.AddToChart(barChart);
+                s.AddToChart(barChart, grouping);
             }
 
             foreach (IChartAxis ax in axis)

--- a/ooxml/XSSF/UserModel/Extensions/BarGroupingMapper.cs
+++ b/ooxml/XSSF/UserModel/Extensions/BarGroupingMapper.cs
@@ -1,0 +1,20 @@
+﻿using NPOI.OpenXmlFormats.Dml.Chart;
+using NPOI.SS.UserModel.Charts;
+using System;
+
+namespace NPOI.XSSF.UserModel.Extensions
+{
+    internal static class BarGroupingMapper
+    {
+        public static ST_BarGrouping ToST_BarGrouping(this BarGrouping barGrouping)
+        {
+            return barGrouping switch {
+                BarGrouping.Clustered => ST_BarGrouping.clustered,
+                BarGrouping.Standard => ST_BarGrouping.standard,
+                BarGrouping.PercentStacked => ST_BarGrouping.percentStacked,
+                BarGrouping.Stacked => ST_BarGrouping.stacked,
+                _ => throw new NotSupportedException()
+            };
+        }
+    }
+}

--- a/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFBarChartData.cs
+++ b/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFBarChartData.cs
@@ -1,0 +1,79 @@
+﻿using NPOI.OpenXmlFormats.Dml.Chart;
+using NPOI.SS.UserModel;
+using NPOI.SS.UserModel.Charts;
+using NPOI.SS.Util;
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System.Linq;
+
+namespace TestCases.XSSF.UserModel.Charts
+{
+    public class TestXSSFBarChartData
+    {
+        private static readonly object[][] plotData = new object[][]
+        {
+            ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"], 
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        };
+        
+        [TestCase(BarGrouping.Stacked, ST_BarGrouping.stacked)]
+        [TestCase(BarGrouping.Clustered, ST_BarGrouping.clustered)]
+        [TestCase(BarGrouping.Standard, ST_BarGrouping.standard)]
+        [TestCase(BarGrouping.PercentStacked, ST_BarGrouping.percentStacked)]
+        public void TestSettingBarGrouping(BarGrouping barGrouping, ST_BarGrouping expectedBarGrouping)
+        {
+            using IWorkbook wb = new XSSFWorkbook();
+            ISheet sheet = new SheetBuilder(wb, plotData).Build();
+            IDrawing drawing = sheet.CreateDrawingPatriarch();
+            IClientAnchor anchor = drawing.CreateAnchor(0, 0, 0, 0, 1, 1, 10, 30);
+            IChart chart = drawing.CreateChart(anchor);
+
+            IChartAxis bottomAxis = chart.ChartAxisFactory.CreateCategoryAxis(AxisPosition.Bottom);
+            IChartAxis leftAxis = chart.ChartAxisFactory.CreateValueAxis(AxisPosition.Left);
+
+            IBarChartData<string, double> barChartData = chart.ChartDataFactory.CreateBarChartData<string, double>();
+
+            IChartDataSource<string> xs = DataSources.FromStringCellRange(sheet, CellRangeAddress.ValueOf("A1:J1"));
+            IChartDataSource<double> ys = DataSources.FromNumericCellRange(sheet, CellRangeAddress.ValueOf("A2:J2"));
+            barChartData.AddSeries(xs, ys);
+            
+            barChartData.SetBarGrouping(barGrouping);
+            
+            chart.Plot(barChartData, bottomAxis, leftAxis);
+            
+            ClassicAssert.IsInstanceOf<XSSFChart>(chart);
+            XSSFChart xssfChart = (XSSFChart)chart;
+            CT_BarChart ctBarChart = xssfChart.GetCTChart().plotArea.barChart.FirstOrDefault();
+            ClassicAssert.NotNull(ctBarChart);
+            ClassicAssert.AreEqual(expectedBarGrouping, ctBarChart!.grouping.val);
+        }
+        
+        [Test]
+        public void TestBarGroupingBeClusteredWhenNoBarGroupingIsSet()
+        {
+            using IWorkbook wb = new XSSFWorkbook();
+            ISheet sheet = new SheetBuilder(wb, plotData).Build();
+            IDrawing drawing = sheet.CreateDrawingPatriarch();
+            IClientAnchor anchor = drawing.CreateAnchor(0, 0, 0, 0, 1, 1, 10, 30);
+            IChart chart = drawing.CreateChart(anchor);
+
+            IChartAxis bottomAxis = chart.ChartAxisFactory.CreateCategoryAxis(AxisPosition.Bottom);
+            IChartAxis leftAxis = chart.ChartAxisFactory.CreateValueAxis(AxisPosition.Left);
+
+            IBarChartData<string, double> barChartData = chart.ChartDataFactory.CreateBarChartData<string, double>();
+
+            IChartDataSource<string> xs = DataSources.FromStringCellRange(sheet, CellRangeAddress.ValueOf("A1:J1"));
+            IChartDataSource<double> ys = DataSources.FromNumericCellRange(sheet, CellRangeAddress.ValueOf("A2:J2"));
+            barChartData.AddSeries(xs, ys);
+            
+            chart.Plot(barChartData, bottomAxis, leftAxis);
+            
+            ClassicAssert.IsInstanceOf<XSSFChart>(chart);
+            XSSFChart xssfChart = (XSSFChart)chart;
+            CT_BarChart ctBarChart = xssfChart.GetCTChart().plotArea.barChart.FirstOrDefault();
+            ClassicAssert.NotNull(ctBarChart);
+            ClassicAssert.AreEqual(ST_BarGrouping.clustered, ctBarChart!.grouping.val);
+        }
+    }
+}

--- a/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFColumnChartData.cs
+++ b/testcases/ooxml/XSSF/UserModel/Charts/TestXSSFColumnChartData.cs
@@ -1,0 +1,75 @@
+﻿using NPOI.OpenXmlFormats.Dml.Chart;
+using NPOI.SS.UserModel;
+using NPOI.SS.UserModel.Charts;
+using NPOI.SS.Util;
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System.Linq;
+
+namespace TestCases.XSSF.UserModel.Charts
+{
+    public class TestXSSFColumnChartData
+    {
+        private static readonly object[][] plotData = new object[][] { ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], };
+
+        [TestCase(BarGrouping.Stacked, ST_BarGrouping.stacked)]
+        [TestCase(BarGrouping.Clustered, ST_BarGrouping.clustered)]
+        [TestCase(BarGrouping.Standard, ST_BarGrouping.standard)]
+        [TestCase(BarGrouping.PercentStacked, ST_BarGrouping.percentStacked)]
+        public void TestSettingBarGrouping(BarGrouping barGrouping, ST_BarGrouping expectedBarGrouping)
+        {
+            using IWorkbook wb = new XSSFWorkbook();
+            ISheet sheet = new SheetBuilder(wb, plotData).Build();
+            IDrawing drawing = sheet.CreateDrawingPatriarch();
+            IClientAnchor anchor = drawing.CreateAnchor(0, 0, 0, 0, 1, 1, 10, 30);
+            IChart chart = drawing.CreateChart(anchor);
+
+            IChartAxis bottomAxis = chart.ChartAxisFactory.CreateCategoryAxis(AxisPosition.Bottom);
+            IChartAxis leftAxis = chart.ChartAxisFactory.CreateValueAxis(AxisPosition.Left);
+
+            IColumnChartData<string, double> columnChartData = chart.ChartDataFactory.CreateColumnChartData<string, double>();
+
+            IChartDataSource<string> xs = DataSources.FromStringCellRange(sheet, CellRangeAddress.ValueOf("A1:J1"));
+            IChartDataSource<double> ys = DataSources.FromNumericCellRange(sheet, CellRangeAddress.ValueOf("A2:J2"));
+            columnChartData.AddSeries(xs, ys);
+
+            columnChartData.SetBarGrouping(barGrouping);
+
+            chart.Plot(columnChartData, bottomAxis, leftAxis);
+
+            ClassicAssert.IsInstanceOf<XSSFChart>(chart);
+            XSSFChart xssfChart = (XSSFChart) chart;
+            CT_BarChart ctBarChart = xssfChart.GetCTChart().plotArea.barChart.FirstOrDefault();
+            ClassicAssert.NotNull(ctBarChart);
+            ClassicAssert.AreEqual(expectedBarGrouping, ctBarChart!.grouping.val);
+        }
+
+        [Test]
+        public void TestBarGroupingBeClusteredWhenNoBarGroupingIsSet()
+        {
+            using IWorkbook wb = new XSSFWorkbook();
+            ISheet sheet = new SheetBuilder(wb, plotData).Build();
+            IDrawing drawing = sheet.CreateDrawingPatriarch();
+            IClientAnchor anchor = drawing.CreateAnchor(0, 0, 0, 0, 1, 1, 10, 30);
+            IChart chart = drawing.CreateChart(anchor);
+
+            IChartAxis bottomAxis = chart.ChartAxisFactory.CreateCategoryAxis(AxisPosition.Bottom);
+            IChartAxis leftAxis = chart.ChartAxisFactory.CreateValueAxis(AxisPosition.Left);
+
+            IColumnChartData<string, double> columnChartData = chart.ChartDataFactory.CreateColumnChartData<string, double>();
+
+            IChartDataSource<string> xs = DataSources.FromStringCellRange(sheet, CellRangeAddress.ValueOf("A1:J1"));
+            IChartDataSource<double> ys = DataSources.FromNumericCellRange(sheet, CellRangeAddress.ValueOf("A2:J2"));
+            columnChartData.AddSeries(xs, ys);
+
+            chart.Plot(columnChartData, bottomAxis, leftAxis);
+
+            ClassicAssert.IsInstanceOf<XSSFChart>(chart);
+            XSSFChart xssfChart = (XSSFChart) chart;
+            CT_BarChart ctBarChart = xssfChart.GetCTChart().plotArea.barChart.FirstOrDefault();
+            ClassicAssert.NotNull(ctBarChart);
+            ClassicAssert.AreEqual(ST_BarGrouping.clustered, ctBarChart!.grouping.val);
+        }
+    }
+}

--- a/testcases/ooxml/XSSF/UserModel/Extensions/TestBarGroupingMapper.cs
+++ b/testcases/ooxml/XSSF/UserModel/Extensions/TestBarGroupingMapper.cs
@@ -1,0 +1,23 @@
+﻿using NPOI.OpenXmlFormats.Dml.Chart;
+using NPOI.SS.UserModel.Charts;
+using NPOI.XSSF.UserModel.Extensions;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+
+namespace TestCases.XSSF.UserModel.Extensions
+{
+    [TestFixture]
+    public sealed class TestBarGroupingMapper
+    {
+        [TestCase(BarGrouping.Clustered, ST_BarGrouping.clustered)]
+        [TestCase(BarGrouping.Stacked, ST_BarGrouping.stacked)]
+        [TestCase(BarGrouping.Standard, ST_BarGrouping.standard)]
+        [TestCase(BarGrouping.PercentStacked, ST_BarGrouping.percentStacked)]
+        public void TestMappingBarGroupingToST_BarGrouping(BarGrouping barGrouping, ST_BarGrouping expected)
+        {
+            ST_BarGrouping actual = barGrouping.ToST_BarGrouping();
+            
+            ClassicAssert.AreEqual(actual, expected);
+        }
+    }
+}

--- a/testcases/ooxml/XSSF/UserModel/Extensions/TestBarGroupingMapper.cs
+++ b/testcases/ooxml/XSSF/UserModel/Extensions/TestBarGroupingMapper.cs
@@ -17,7 +17,7 @@ namespace TestCases.XSSF.UserModel.Extensions
         {
             ST_BarGrouping actual = barGrouping.ToST_BarGrouping();
             
-            ClassicAssert.AreEqual(actual, expected);
+            ClassicAssert.AreEqual(expected, actual);
         }
     }
 }


### PR DESCRIPTION
Bar charts and column charts were Clustered with no option to change them to Standard, Stacked, Percent Stacked. This adds support for Standard, Stacked, Percent Stacked charts while maintaining the old behavior of creating Clustered charts when no `BarGrouping` is set explicitly.