### PR TITLE
Fix analyzer reported issues

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -76,7 +76,6 @@
     <NoWarn>$(NoWarn);CA1708</NoWarn> <!-- should differ by more than case -->
     <NoWarn>$(NoWarn);CA1710</NoWarn> <!-- Rename type name XXX so that it does not end in YYY -->
     <NoWarn>$(NoWarn);CA1711</NoWarn> <!-- Rename type name XXX so that it does not end in YYY -->
-    <NoWarn>$(NoWarn);CA1715</NoWarn> <!-- Prefix generic type parameter name with 'T' -->
     <NoWarn>$(NoWarn);CA1716</NoWarn> <!-- Rename type XXX so that it no longer conflicts with the reserved language keyword -->
     <NoWarn>$(NoWarn);CA1720</NoWarn> <!-- Identifier 'XXX' contains type name -->
     <NoWarn>$(NoWarn);CA1725</NoWarn> <!-- Change parameter name -->
@@ -87,13 +86,10 @@
     <NoWarn>$(NoWarn);CA1846</NoWarn> <!-- Prefer 'AsSpan' over 'Substring' when span-based overloads are available -->
     <NoWarn>$(NoWarn);CA1834</NoWarn> <!-- Member XXX is explicitly initialized to its default value -->
     <NoWarn>$(NoWarn);CA1845</NoWarn> <!-- Use span-based 'string.Concat' and 'AsSpan' instead of 'Substring' -->
-    <NoWarn>$(NoWarn);CA1847</NoWarn> <!-- Use 'string.Contains(char)' instead of 'string.Contains(string)' when searching for a single character -->
     <NoWarn>$(NoWarn);CA1850</NoWarn> <!-- Prefer static 'System.Security.Cryptography.MD5.HashData' method over 'ComputeHash' -->
-    <NoWarn>$(NoWarn);CA1852</NoWarn> <!-- Type 'XXX' can be sealed because it has no subtypes in its containing assembly and is not externally visible -->
     <NoWarn>$(NoWarn);CA1859</NoWarn> <!-- Change return type of method -->
     <NoWarn>$(NoWarn);CA1861</NoWarn> <!-- Prefer 'static readonly' fields over constant array arguments -->
     <NoWarn>$(NoWarn);CA1862</NoWarn> <!-- Prefer the string comparison method overload -->
-    <NoWarn>$(NoWarn);CA1864</NoWarn> <!-- To avoid double lookup, call 'TryAdd' instead of calling 'Add' with a 'ContainsKey' -->
     <NoWarn>$(NoWarn);CA1872</NoWarn> <!-- Prefer 'System.Convert.ToHexString(byte[])' over call chains based on 'System.BitConverter.ToString(byte[])' -->
     <NoWarn>$(NoWarn);CA2019</NoWarn> <!-- 'ThreadStatic' fields should not use inline initialization -->
     <NoWarn>$(NoWarn);CA2022</NoWarn> <!-- Avoid inexact read -->

--- a/main/HSSF/Record/EscherAggregate.cs
+++ b/main/HSSF/Record/EscherAggregate.cs
@@ -1264,10 +1264,7 @@ namespace NPOI.HSSF.Record
         /// <param name="objRecord">Obj or TextObj record</param>
         public void AssociateShapeToObjRecord(EscherRecord r, Record objRecord)
         {
-            if(!shapeToObj.ContainsKey(r))
-                shapeToObj.Add(r, objRecord);
-            else
-                shapeToObj[r]= objRecord;
+            shapeToObj[r] = objRecord;
         }
         /// <summary>
         /// Remove echerRecord and associated to it Obj or TextObj record

--- a/main/HSSF/UserModel/HSSFWorkbook.cs
+++ b/main/HSSF/UserModel/HSSFWorkbook.cs
@@ -1689,7 +1689,7 @@ namespace NPOI.HSSF.UserModel
             if (name == null)
                 name = workbook.CreateBuiltInName(NameRecord.BUILTIN_PRINT_AREA, sheetIndex + 1);
             //Adding one here because 0 indicates a global named region; doesnt make sense for print areas
-            String[] parts = reference.Split(new char[]{','});
+            String[] parts = reference.Split(',');
             StringBuilder sb = new StringBuilder(32);
             for (int i = 0; i < parts.Length; i++)
             {

--- a/main/Polyfills.cs
+++ b/main/Polyfills.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace NPOI
 {
@@ -13,6 +14,21 @@ namespace NPOI
 
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
     internal static bool EndsWith(this string source, char c) => source.Length > 0 && source[source.Length - 1] == c;
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    internal static string[] Split(this string source, char c, StringSplitOptions options) => source.Split([c], options);
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    internal static bool TryAdd<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue value)
+    {
+        if(dictionary.ContainsKey(key))
+        {
+            return false;
+        }
+
+        dictionary[key] = value;
+        return true;
+    }
 #endif
 
 #if NETFRAMEWORK

--- a/main/SS/Format/CellFormatPart.cs
+++ b/main/SS/Format/CellFormatPart.cs
@@ -77,32 +77,22 @@ namespace NPOI.SS.Format
             NAMED_COLORS = new Dictionary<String, Color>(CASE_INSENSITIVE_ORDER);
 
             var colors = HSSFColor.GetIndexHash();
-            foreach (object v in colors.Values)
+            foreach (HSSFColor hc in colors.Values)
             {
-                HSSFColor hc = (HSSFColor)v;
                 Type type = hc.GetType();
                 String name = type.Name;
                 if (name.Equals(name.ToUpper()))
                 {
                     byte[] rgb = hc.RGB;
                     Color c = Color.FromRgb(rgb[0], rgb[1], rgb[2]);
-                    if (!NAMED_COLORS.ContainsKey(name))
-                    {
-                        NAMED_COLORS.Add(name, c);
-                    }
+                    NAMED_COLORS.TryAdd(name, c);
                     if (name.IndexOf('_') > 0)
                     {
-                        if (!NAMED_COLORS.ContainsKey(name.Replace('_', ' ')))
-                        {
-                            NAMED_COLORS.Add(name.Replace('_', ' '), c);
-                        }
+                        NAMED_COLORS.TryAdd(name.Replace('_', ' '), c);
                     }
-                    if (name.IndexOf("_PERCENT") > 0)
+                    if (name.IndexOf("_PERCENT", StringComparison.Ordinal) > 0)
                     {
-                        if (!NAMED_COLORS.ContainsKey(name.Replace("_PERCENT", "%").Replace('_', ' ')))
-                        {
-                            NAMED_COLORS.Add(name.Replace("_PERCENT", "%").Replace('_', ' '), c);
-                        }
+                        NAMED_COLORS.TryAdd(name.Replace("_PERCENT", "%").Replace('_', ' '), c);
                     }
                 }
             }

--- a/main/SS/Formula/Atp/AnalysisToolPak.cs
+++ b/main/SS/Formula/Atp/AnalysisToolPak.cs
@@ -292,10 +292,7 @@ namespace NPOI.SS.Formula.Atp
                 throw new ArgumentException("POI already implememts " + name +
                         ". You cannot override POI's implementations of Excel functions");
             }
-            if (_functionsByName.ContainsKey(name))
-                _functionsByName[name] = func;
-            else
-                _functionsByName.Add(name, func);
+            _functionsByName[name] = func;
         }
     }
 }

--- a/main/SS/Formula/Eval/Forked/ForkedEvaluationSheet.cs
+++ b/main/SS/Formula/Eval/Forked/ForkedEvaluationSheet.cs
@@ -79,10 +79,7 @@ namespace NPOI.SS.Formula.Eval.Forked
                             + cr.FormatAsString() + "' is missing in master sheet.");
                 }
                 result = new ForkedEvaluationCell(this, mcell);
-                if (_sharedCellsByRowCol.ContainsKey(key))
-                    _sharedCellsByRowCol[key] = result;
-                else
-                    _sharedCellsByRowCol.Add(key, result);
+                _sharedCellsByRowCol[key] = result;
             }
             return result;
         }

--- a/main/SS/Formula/Eval/Forked/ForkedEvaluationWorkbook.cs
+++ b/main/SS/Formula/Eval/Forked/ForkedEvaluationWorkbook.cs
@@ -62,16 +62,8 @@ namespace NPOI.SS.Formula.Eval.Forked
                 result = value;
             if (result == null)
             {
-                result = new ForkedEvaluationSheet(_masterBook.GetSheet(_masterBook
-                        .GetSheetIndex(sheetName)));
-                if (_sharedSheetsByName.ContainsKey(sheetName))
-                {
-                    _sharedSheetsByName[sheetName] = result;
-                }
-                else
-                {
-                    _sharedSheetsByName.Add(sheetName, result);
-                }
+                result = new ForkedEvaluationSheet(_masterBook.GetSheet(_masterBook.GetSheetIndex(sheetName)));
+                _sharedSheetsByName[sheetName] = result;
             }
             return result;
         }

--- a/main/SS/UserModel/DataFormatter.cs
+++ b/main/SS/UserModel/DataFormatter.cs
@@ -330,10 +330,8 @@ namespace NPOI.SS.UserModel
             // For now, if we detect 2+ parts, we call out to CellFormat to handle it
             // TODO Going forward, we should really merge the logic between the two classes
 
-            if (formatStr.IndexOf(';') != -1 &&
-                (formatStr.IndexOf(';') != formatStr.LastIndexOf(';')
-                 || rangeConditionalPattern.IsMatch(formatStr)
-                ))
+            int firstSemiColon = formatStr.IndexOf(';');
+            if (firstSemiColon != -1 && (firstSemiColon != formatStr.LastIndexOf(';') || rangeConditionalPattern.IsMatch(formatStr)))
             {
                 try
                 {
@@ -342,7 +340,7 @@ namespace NPOI.SS.UserModel
                     // CellFormat requires callers to identify date vs not, so do so
                     object cellValueO = (cellValue);
                     if (DateUtil.IsADateFormat(formatIndex, formatStr) &&
-                        // don't try to handle Date value 0, let a 3 or 4-part format take care of it 
+                        // don't try to handle Date value 0, let a 3 or 4-part format take care of it
                         (double)cellValueO != 0.0)
                     {
                         cellValueO = DateUtil.GetJavaDate(cellValue);
@@ -358,7 +356,7 @@ namespace NPOI.SS.UserModel
 
             // Excel supports positive/negative/zero, but java
             // doesn't, so we need to do it specially
-            int firstAt = formatStr.IndexOf(';');
+            int firstAt = firstSemiColon;
             int lastAt = formatStr.LastIndexOf(';');
             // p and p;n are ok by default. p;n;z and p;n;z;s need to be fixed.
             if (firstAt != -1 && firstAt != lastAt)
@@ -389,7 +387,7 @@ namespace NPOI.SS.UserModel
             }
 
             // Excel's # with value 0 will output empty where Java will output 0. This hack removes the # from the format.
-            if (emulateCSV && cellValue == 0.0 && formatStr.Contains("#") && !formatStr.Contains("0"))
+            if (emulateCSV && cellValue == 0.0 && formatStr.Contains('#') && !formatStr.Contains('0'))
             {
                 formatStr = formatStr.Replace("#", "");
             }
@@ -995,7 +993,7 @@ namespace NPOI.SS.UserModel
                 result = numberFormat.Format(decimal.Parse(textValue));
             }
             // Complete scientific notation by adding the missing +.
-            if (result.Contains("E") && !result.Contains("E-"))
+            if (result.Contains('E') && !result.Contains("E-"))
             {
                 result = result.Replace("E", "E+");
             }

--- a/main/SS/Util/CellRangeAddressList.cs
+++ b/main/SS/Util/CellRangeAddressList.cs
@@ -52,7 +52,7 @@ namespace NPOI.SS.Util
             {
                 throw new ArgumentException("cell range cannot be null or empty");
             }
-            var ranges = cellRanges.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            var ranges = cellRanges.Split(',', StringSplitOptions.RemoveEmptyEntries);
             var list = new CellRangeAddressList();
             foreach(var range in ranges)
             {

--- a/main/SS/Util/Format.cs
+++ b/main/SS/Util/Format.cs
@@ -191,7 +191,7 @@ namespace NPOI.SS.Util
 
         public DecimalFormat(string pattern)
         {
-            if (pattern.Contains("'"))
+            if (pattern.Contains('\''))
                 throw new ArgumentException("invalid pattern");
             this._pattern = pattern;
         }
@@ -220,7 +220,7 @@ namespace NPOI.SS.Util
                 culture.NumberFormat = _formatInfo;
             }
                 
-            if (_pattern.Contains("'"))
+            if (_pattern.Contains('\''))
             {
                 return Convert.ToDouble(obj, CultureInfo.InvariantCulture).ToString(culture);
             }

--- a/main/SS/Util/SSCellRange.cs
+++ b/main/SS/Util/SSCellRange.cs
@@ -76,15 +76,16 @@ namespace NPOI.SS.Util
             int flatIndex = _width * relativeRowIndex + relativeColumnIndex;
             return _flattenedArray[flatIndex];
         }
-        internal sealed class ArrayIterator<D> :IEnumerator<D>
+
+        internal sealed class ArrayIterator<T> :IEnumerator<T>
         {
 
-            private readonly D[] _array;
+            private readonly T[] _array;
             private int _index;
 
-            public ArrayIterator(D[] array)
+            public ArrayIterator(T[] array)
             {
-                _array = (D[])array.Clone();
+                _array = (T[])array.Clone();
                 _index = 0;
             }
 
@@ -103,7 +104,7 @@ namespace NPOI.SS.Util
             { 
             }
 
-            public D Current
+            public T Current
             {
                 get
                 {

--- a/main/Util/IntMapper.cs
+++ b/main/Util/IntMapper.cs
@@ -62,14 +62,7 @@ namespace NPOI.Util
         {
             int index = elements.Count;
             elements.Add(value);
-            if (valueKeyMap.ContainsKey(value))
-            {
-                valueKeyMap[value] = index;
-            }
-            else
-            {
-                valueKeyMap.Add(value, index);
-            }
+            valueKeyMap[value] = index;
             return true;
         }
         /// <summary>

--- a/openxml4Net/OPC/PackageRelationshipCollection.cs
+++ b/openxml4Net/OPC/PackageRelationshipCollection.cs
@@ -64,7 +64,8 @@ namespace NPOI.OpenXml4Net.OPC
             relationshipsByID = new SortedList<String, PackageRelationship>();
             internalRelationshipsByTargetName = new SortedList<string, PackageRelationship>();
         }
-        class DuplicateComparer : IComparer<string>
+
+        private sealed class DuplicateComparer : IComparer<string>
         {
 
             #region IComparer<string> Members


### PR DESCRIPTION
* Use 'string.Contains(char)' instead of 'string.Contains(string)' when searching for a single character
* Type 'XXX' can be sealed because it has no subtypes in its containing assembly and is not externally visible
* To avoid double lookup, call 'TryAdd' instead of calling 'Add' with a 'ContainsKey'
* Prefix generic type parameter name with 'T'

Added polyfill for `Dictionary.TryAdd` and `string.Split(char c, StringSplitOptions options)`