### PR TITLE
Fix pattern formatting - return correct field for pattern fill foreground

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFPatternFormatting.cs
+++ b/ooxml/XSSF/UserModel/XSSFPatternFormatting.cs
@@ -67,7 +67,7 @@ namespace NPOI.XSSF.UserModel
             {
                 if (!_fill.IsSetPatternFill() || !_fill.GetPatternFill().IsSetFgColor())
                     return null;
-                return new XSSFColor(_fill.GetPatternFill().bgColor);
+                return new XSSFColor(_fill.GetPatternFill().fgColor);
             }
             set
             {


### PR DESCRIPTION
The class used to create conditional a formatting pattern is returning the wrong backing field for the FillForegroundColorColor property (it returns the background instead of the foreground).