### PR TITLE
Use NET 9 SDK in GitHub Actions to compile solution

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@
 #
 #     - To turn off auto-generation set:
 #
-#         [GitHubActions (AutoGenerate = false)]
+#         [CustomGitHubActions (AutoGenerate = false)]
 #
 #     - To trigger manual generation invoke:
 #
@@ -30,6 +30,11 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0
+            9.0
       - uses: actions/checkout@v4
       - name: 'Run: Clean, Test, Pack'
         run: ./build.cmd Clean Test Pack
@@ -44,6 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0
+            9.0
       - uses: actions/checkout@v4
       - name: 'Run: Clean, Test, Pack'
         run: ./build.cmd Clean Test Pack

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -5,7 +5,7 @@
 #
 #     - To turn off auto-generation set:
 #
-#         [GitHubActions (AutoGenerate = false)]
+#         [CustomGitHubActions (AutoGenerate = false)]
 #
 #     - To trigger manual generation invoke:
 #
@@ -28,6 +28,11 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0
+            9.0
       - uses: actions/checkout@v4
       - name: 'Run: Clean, Test, Pack'
         run: ./build.cmd Clean Test Pack
@@ -42,6 +47,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0
+            9.0
       - uses: actions/checkout@v4
       - name: 'Run: Clean, Test, Pack'
         run: ./build.cmd Clean Test Pack

--- a/build/Build.GitHubAction.cs
+++ b/build/Build.GitHubAction.cs
@@ -1,6 +1,10 @@
 using Nuke.Common.CI.GitHubActions;
+using Nuke.Common.CI.GitHubActions.Configuration;
+using Nuke.Common.Execution;
+using Nuke.Common.Utilities;
+using System.Collections.Generic;
 
-[GitHubActions("CI",
+[CustomGitHubActions("CI",
     GitHubActionsImage.WindowsLatest,
     GitHubActionsImage.UbuntuLatest,
     OnPushBranches = ["main", "master", "release*", "poi/*"],
@@ -9,7 +13,7 @@ using Nuke.Common.CI.GitHubActions;
     CacheKeyFiles = [],
     PublishCondition = "runner.os == 'Windows'"
 )]
-[GitHubActions("PR",
+[CustomGitHubActions("PR",
     GitHubActionsImage.WindowsLatest,
     GitHubActionsImage.UbuntuLatest,
     On = [GitHubActionsTrigger.PullRequest],
@@ -21,3 +25,52 @@ using Nuke.Common.CI.GitHubActions;
 )]
 partial class Build;
 
+class CustomGitHubActionsAttribute : GitHubActionsAttribute
+{
+    public CustomGitHubActionsAttribute(string name, GitHubActionsImage image, params GitHubActionsImage[] images) : base(name, image, images)
+    {
+    }
+
+    protected override GitHubActionsJob GetJobs(GitHubActionsImage image, IReadOnlyCollection<ExecutableTarget> relevantTargets)
+    {
+        var job = base.GetJobs(image, relevantTargets);
+
+        var newSteps = new List<GitHubActionsStep>(job.Steps);
+
+        newSteps.Insert(0, new GitHubActionsSetupDotNetStep(["8.0", "9.0"]));
+
+        job.Steps = newSteps.ToArray();
+        return job;
+    }
+}
+
+class GitHubActionsSetupDotNetStep : GitHubActionsStep
+{
+    public GitHubActionsSetupDotNetStep(string[] versions)
+    {
+        Versions = versions;
+    }
+
+    string[] Versions { get; }
+
+    public override void Write(CustomFileWriter writer)
+    {
+        writer.WriteLine("- uses: actions/setup-dotnet@v4");
+
+        using (writer.Indent())
+        {
+            writer.WriteLine("with:");
+            using (writer.Indent())
+            {
+                writer.WriteLine("dotnet-version: |");
+                using (writer.Indent())
+                {
+                    foreach (var version in Versions)
+                    {
+                        writer.WriteLine(version);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/main/SS/UserModel/DataFormatter.cs
+++ b/main/SS/UserModel/DataFormatter.cs
@@ -331,10 +331,8 @@ using Cysharp.Text;
             // For now, if we detect 2+ parts, we call out to CellFormat to handle it
             // TODO Going forward, we should really merge the logic between the two classes
 
-            if (formatStr.IndexOf(';') != -1 &&
-                (formatStr.IndexOf(';') != formatStr.LastIndexOf(';')
-                 || rangeConditionalPattern.IsMatch(formatStr)
-                ))
+            int firstSemiColon = formatStr.IndexOf(';');
+            if (firstSemiColon != -1 && (firstSemiColon != formatStr.LastIndexOf(';') || rangeConditionalPattern.IsMatch(formatStr)))
             {
                 try
                 {
@@ -343,7 +341,7 @@ using Cysharp.Text;
                     // CellFormat requires callers to identify date vs not, so do so
                     object cellValueO = (cellValue);
                     if (DateUtil.IsADateFormat(formatIndex, formatStr) &&
-                        // don't try to handle Date value 0, let a 3 or 4-part format take care of it 
+                        // don't try to handle Date value 0, let a 3 or 4-part format take care of it
                         (double)cellValueO != 0.0)
                     {
                         cellValueO = DateUtil.GetJavaDate(cellValue);
@@ -359,7 +357,7 @@ using Cysharp.Text;
 
             // Excel supports positive/negative/zero, but java
             // doesn't, so we need to do it specially
-            int firstAt = formatStr.IndexOf(';');
+            int firstAt = firstSemiColon;
             int lastAt = formatStr.LastIndexOf(';');
             // p and p;n are ok by default. p;n;z and p;n;z;s need to be fixed.
             if (firstAt != -1 && firstAt != lastAt)


### PR DESCRIPTION
NET 9 has more analysis rules can currently fail build with NET 9 SDK locally where it still compiles under GH Actions. NET 9 SDK more advanced and can also generate better code (especially for collection expressions).