### PR TITLE
Fix analysis errors related to non-concrete type usage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -87,7 +87,6 @@
     <NoWarn>$(NoWarn);CA1834</NoWarn> <!-- Member XXX is explicitly initialized to its default value -->
     <NoWarn>$(NoWarn);CA1845</NoWarn> <!-- Use span-based 'string.Concat' and 'AsSpan' instead of 'Substring' -->
     <NoWarn>$(NoWarn);CA1850</NoWarn> <!-- Prefer static 'System.Security.Cryptography.MD5.HashData' method over 'ComputeHash' -->
-    <NoWarn>$(NoWarn);CA1859</NoWarn> <!-- Change return type of method -->
     <NoWarn>$(NoWarn);CA1861</NoWarn> <!-- Prefer 'static readonly' fields over constant array arguments -->
     <NoWarn>$(NoWarn);CA1862</NoWarn> <!-- Prefer the string comparison method overload -->
     <NoWarn>$(NoWarn);CA1872</NoWarn> <!-- Prefer 'System.Convert.ToHexString(byte[])' over call chains based on 'System.BitConverter.ToString(byte[])' -->

--- a/main/DDF/AbstractEscherOptRecord.cs
+++ b/main/DDF/AbstractEscherOptRecord.cs
@@ -155,11 +155,9 @@ namespace NPOI.DDF
          */
         public void SetEscherProperty(EscherProperty value)
         {
-            List<EscherProperty> toRemove = new List<EscherProperty>();
-            for (IEnumerator<EscherProperty> iterator =
-                          properties.GetEnumerator(); iterator.MoveNext(); )
+            List<EscherProperty> toRemove = [];
+            foreach (var prop in properties)
             {
-                EscherProperty prop = iterator.Current;
                 if (prop.Id == value.Id)
                 {
                     //iterator.Remove();
@@ -174,18 +172,20 @@ namespace NPOI.DDF
 
         public void RemoveEscherProperty(int num)
         {
-            List<EscherProperty> toRemove = new List<EscherProperty>();
-            for (IEnumerator<EscherProperty> iterator = EscherProperties.GetEnumerator(); iterator.MoveNext(); )
+            List<EscherProperty> toRemove = [];
+            foreach(var prop in EscherProperties)
             {
-                EscherProperty prop = iterator.Current;
                 if (prop.PropertyNumber == num)
                 {
                     //iterator.Remove();
                     toRemove.Add(prop);
                 }
             }
-            foreach (EscherProperty e in toRemove)
+
+            foreach(EscherProperty e in toRemove)
+            {
                 EscherProperties.Remove(e);
+            }
         }
 
         /**

--- a/main/DDF/EscherContainerRecord.cs
+++ b/main/DDF/EscherContainerRecord.cs
@@ -211,10 +211,9 @@ using Cysharp.Text;
         {
             get
             {
-                IList<EscherContainerRecord> containers = new List<EscherContainerRecord>();
-                for (IEnumerator iterator = ChildRecords.GetEnumerator(); iterator.MoveNext(); )
+                List<EscherContainerRecord> containers = [];
+                foreach (EscherRecord r in ChildRecords)
                 {
-                    EscherRecord r = (EscherRecord)iterator.Current;
                     if (r is EscherContainerRecord record)
                     {
                         containers.Add(record);
@@ -344,9 +343,8 @@ using Cysharp.Text;
         {
             StringBuilder builder = new StringBuilder();
             builder.Append(tab).Append(FormatXmlRecordHeader(RecordName, HexDump.ToHex(RecordId), HexDump.ToHex(Version), HexDump.ToHex(Instance)));
-            for (IEnumerator<EscherRecord> iterator = _childRecords.GetEnumerator(); iterator.MoveNext(); )
+            foreach (var record in _childRecords)
             {
-                EscherRecord record = iterator.Current;
                 builder.Append(record.ToXml(tab + "\t"));
             }
             builder.Append(tab).Append("</").Append(RecordName).Append(">\n");

--- a/main/DDF/EscherDump.cs
+++ b/main/DDF/EscherDump.cs
@@ -48,7 +48,7 @@ namespace NPOI.DDF
         /// <param name="size">The number of bytes to Read.</param>
         public void Dump(byte[] data, int offset, int size)
         {
-            IEscherRecordFactory recordFactory = new DefaultEscherRecordFactory();
+            DefaultEscherRecordFactory recordFactory = new();
             int pos = offset;
             while (pos < offset + size)
             {

--- a/main/DDF/UnknownEscherRecord.cs
+++ b/main/DDF/UnknownEscherRecord.cs
@@ -222,11 +222,12 @@ using Cysharp.Text;
             builder.Append(tab).Append(FormatXmlRecordHeader(GetType().Name, HexDump.ToHex(RecordId), HexDump.ToHex(Version), HexDump.ToHex(Instance)))
                     .Append(tab).Append("\t").Append("<IsContainer>").Append(IsContainerRecord).Append("</IsContainer>\n")
                     .Append(tab).Append("\t").Append("<Numchildren>").Append(HexDump.ToHex(_childRecords.Count)).Append("</Numchildren>\n");
-            for (IEnumerator<EscherRecord> iterator = _childRecords.GetEnumerator(); iterator.MoveNext(); )
+
+            foreach (EscherRecord record in _childRecords)
             {
-                EscherRecord record = iterator.Current;
                 builder.Append(record.ToXml(tab + "\t"));
             }
+
             builder.Append(theDumpHex).Append("\n");
             builder.Append(tab).Append("</").Append(GetType().Name).Append(">\n");
             return builder.ToString();

--- a/main/HPSF/CustomProperties.cs
+++ b/main/HPSF/CustomProperties.cs
@@ -64,7 +64,8 @@ namespace NPOI.HPSF
         /// </summary>
         //private TreeBidiDictionary<long, string> dictionary = new TreeBidiDictionary<long, string>();
 
-        private BidirectionalDictionary<long, string> dictionary = new();
+        private readonly BidirectionalDictionary<long, string> dictionary = new();
+
         /// <summary>
         /// Tells whether this object is pure or not.
         /// </summary>
@@ -129,7 +130,7 @@ namespace NPOI.HPSF
         /// <param name="customProperty">customProperty</param>
         /// <return>there was already a property with the same name, the old property</return>
         /// <exception cref="ClassCastException">ClassCastException</exception>
-        private object Put(CustomProperty customProperty)
+        private CustomProperty Put(CustomProperty customProperty)
         {
             string name = customProperty.Name;
 

--- a/main/HPSF/PropertySetFactory.cs
+++ b/main/HPSF/PropertySetFactory.cs
@@ -25,14 +25,14 @@
  * 
  * ==============================================================*/
 
+using System;
+
+using NPOI.HPSF.Wellknown;
+using NPOI.POIFS.FileSystem;
 using NPOI.Util;
 
 namespace NPOI.HPSF
 {
-    using System.IO;
-    using NPOI.HPSF.Wellknown;
-    using System;
-    using NPOI.POIFS.FileSystem;
 
     /// <summary>
     /// Factory class To Create instances of {@link SummaryInformation},
@@ -63,7 +63,7 @@ namespace NPOI.HPSF
          */
         public static PropertySet Create(DirectoryEntry dir, String name)
         {
-            InputStream inp = null;
+            DocumentInputStream inp = null;
             try
             {
                 DocumentEntry entry = (DocumentEntry)dir.GetEntry(name);

--- a/main/HPSF/Section.cs
+++ b/main/HPSF/Section.cs
@@ -26,8 +26,7 @@ namespace NPOI.HPSF
     using System.Collections.Generic;
     using System.Linq;
     using System.IO;
-    using System.Text; 
-using Cysharp.Text;
+    using Cysharp.Text;
 
     /// <summary>
     /// Represents a section in a {@link PropertySet}.
@@ -956,7 +955,7 @@ using Cysharp.Text;
         /// <param name="codepage">The codepage to be used to write the dictionary items.</param>
         /// <return>number of bytes written</return>
         /// <exception name="IOException">if an I/O exception occurs.</exception>
-        private static int WriteDictionary(Stream out1, IDictionary dictionary, int codepage)
+        private static int WriteDictionary(MemoryStream out1, IDictionary dictionary, int codepage)
         {
             int length = TypeWriter.WriteUIntToStream(out1, (uint)dictionary.Count);
             foreach(DictionaryEntry ls in dictionary)

--- a/main/HPSF/Variant.cs
+++ b/main/HPSF/Variant.cs
@@ -25,12 +25,11 @@
  * 
  * ==============================================================*/
 
+using System;
+using System.Collections.Generic;
+
 namespace NPOI.HPSF
 {
-    using System;
-    using System.Collections;
-
-
     /// <summary>
     /// The <em>Variant</em> types as defined by Microsoft's COM. I
     /// found this information in <a href="http://www.marin.clara.net/COM/variant_type_definitions.htm">
@@ -358,9 +357,9 @@ namespace NPOI.HPSF
          * Maps the numbers denoting the variant types To their corresponding
          * variant type names.
          */
-        private static IDictionary numberToName;
+        private static readonly Dictionary<long, string> numberToName;
 
-        private static IDictionary numberToLength;
+        private static readonly Dictionary<long, int> numberToLength;
 
         /**
          * Denotes a variant type with a Length that is unknown To HPSF yet.
@@ -397,7 +396,7 @@ namespace NPOI.HPSF
         static Variant()
         {
             /* Initialize the number-to-name map: */
-            Hashtable tm1 = new Hashtable();
+            Dictionary<long, string> tm1 = [];
             tm1[0] = "VT_EMPTY";
             tm1[1] = "VT_NULL";
             tm1[2] = "VT_I2";
@@ -442,7 +441,7 @@ namespace NPOI.HPSF
             numberToName = tm1;
 
             /* Initialize the number-to-Length map: */
-            Hashtable tm2 = new Hashtable();
+            Dictionary<long, int> tm2 = [];
             tm2[0] = Length_0;
             tm2[1] = Length_UNKNOWN;
             tm2[2] = Length_2;
@@ -497,8 +496,11 @@ namespace NPOI.HPSF
         /// <returns>The variant type name or the string "unknown variant type"</returns>
         public static String GetVariantName(long variantType)
         {
-            String name = (String)numberToName[variantType];
-            return name != null ? name : "unknown variant type";
+            if (!numberToName.TryGetValue(variantType, out string name))
+            {
+                return "unknown variant type";
+            }
+            return name;
         }
 
         /// <summary>
@@ -512,11 +514,13 @@ namespace NPOI.HPSF
         public static int GetVariantLength(long variantType)
         {
             long key = (int)variantType;
-            if (numberToLength.Contains(key))
-                return -2;
-            long Length = (long)numberToLength[key];
-            return Convert.ToInt32(Length);
-        }
 
+            if(!numberToLength.TryGetValue(key, out int value))
+            {
+                return -2;
+            }
+
+            return Convert.ToInt32((long) value);
+        }
     }
 }

--- a/main/HSSF/Extractor/EventBasedExcelExtractor.cs
+++ b/main/HSSF/Extractor/EventBasedExcelExtractor.cs
@@ -18,9 +18,8 @@
 namespace NPOI.HSSF.Extractor
 {
     using System;
+    using System.Collections.Generic;
     using System.Text;
-    using System.IO;
-    using System.Collections;
 
     using NPOI.HSSF.UserModel;
     using NPOI.HSSF.Record;
@@ -160,7 +159,7 @@ namespace NPOI.HSSF.Extractor
             public FormatTrackingHSSFListener ft;
             private SSTRecord sstRecord;
 
-            private IList sheetNames = new ArrayList();
+            private List<string> sheetNames = [];
             public StringBuilder text = new StringBuilder();
             private int sheetNum = -1;
             private int rowNum;

--- a/main/HSSF/Model/DrawingManager2.cs
+++ b/main/HSSF/Model/DrawingManager2.cs
@@ -15,11 +15,12 @@
    limitations Under the License.
 ==================================================================== */
 
+using System.Collections.Generic;
+
+using NPOI.DDF;
+
 namespace NPOI.HSSF.Model
 {
-    using NPOI.DDF;
-    using System.Collections;
-
     /// <summary>
     /// Provides utilities to manage drawing Groups.
     /// </summary>
@@ -28,8 +29,8 @@ namespace NPOI.HSSF.Model
     /// </remarks>
     public class DrawingManager2
     {
-        EscherDggRecord dgg;
-        IList drawingGroups = new ArrayList();
+        private readonly EscherDggRecord dgg;
+        private readonly List<EscherDgRecord> drawingGroups = [];
 
 
         public DrawingManager2(EscherDggRecord dgg)

--- a/main/HSSF/Model/HSSFFormulaParser.cs
+++ b/main/HSSF/Model/HSSFFormulaParser.cs
@@ -32,7 +32,7 @@ namespace NPOI.HSSF.Model
     public class HSSFFormulaParser
     {
 
-        private static IFormulaParsingWorkbook CreateParsingWorkbook(HSSFWorkbook book)
+        private static HSSFEvaluationWorkbook CreateParsingWorkbook(HSSFWorkbook book)
         {
             return HSSFEvaluationWorkbook.Create(book);
         }

--- a/main/HSSF/Model/InternalSheet.cs
+++ b/main/HSSF/Model/InternalSheet.cs
@@ -20,7 +20,7 @@ namespace NPOI.HSSF.Model
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Text;
+
     using NPOI.HSSF.Record;
     using NPOI.HSSF.Record.Aggregates;
     using NPOI.SS.Formula;
@@ -461,9 +461,12 @@ namespace NPOI.HSSF.Model
                 _records.Add(r);
             }
         }
-        private static void SpillAggregate(RecordAggregate ra, List<RecordBase> recs) {
+
+        private static void SpillAggregate(ChartSubstreamRecordAggregate ra, List<RecordBase> recs)
+        {
             ra.VisitContainedRecords(new RecordVisitor1(recs));
         }
+
         /// <summary>
         /// Creates a sheet with all the usual records minus values and the "index"
         /// record (not required).  Sets the location pointer to where the first value
@@ -2079,14 +2082,16 @@ namespace NPOI.HSSF.Model
          */
         public void ShiftBreaks(PageBreakRecord breaks, short start, short stop, int count)
         {
-
             if (rowBreaks == null)
+            {
                 return;
-            IEnumerator iterator = breaks.GetBreaksEnumerator();
-            IList ShiftedBreak = new ArrayList();
+            }
+
+            IEnumerator<PageBreakRecord.Break> iterator = breaks.GetBreaksEnumerator();
+            List<PageBreakRecord.Break> ShiftedBreak = [];
             while (iterator.MoveNext())
             {
-                PageBreakRecord.Break breakItem = (PageBreakRecord.Break)iterator.Current;
+                PageBreakRecord.Break breakItem = iterator.Current;
                 int breakLocation = breakItem.main;
                 bool inStart = (breakLocation >= start);
                 bool inEnd = (breakLocation <= stop);
@@ -2097,7 +2102,7 @@ namespace NPOI.HSSF.Model
             iterator = ShiftedBreak.GetEnumerator();
             while (iterator.MoveNext())
             {
-                PageBreakRecord.Break breakItem = (PageBreakRecord.Break)iterator.Current;
+                PageBreakRecord.Break breakItem = iterator.Current;
                 breaks.RemoveBreak(breakItem.main);
                 breaks.AddBreak(breakItem.main + count, breakItem.subFrom, breakItem.subTo);
             }

--- a/main/HSSF/Model/InternalWorkbook.cs
+++ b/main/HSSF/Model/InternalWorkbook.cs
@@ -1261,7 +1261,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a BOFRecord
          */
 
-        private static Record CreateBOF()
+        private static BOFRecord CreateBOF()
         {
             BOFRecord retval = new BOFRecord();
 
@@ -1299,7 +1299,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a MMSRecord
          */
 
-        private static Record CreateMMS()
+        private static MMSRecord CreateMMS()
         {
             MMSRecord retval = new MMSRecord();
 
@@ -1328,7 +1328,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a WriteAccessRecord
          */
 
-        private static Record CreateWriteAccess()
+        private static WriteAccessRecord CreateWriteAccess()
         {
             WriteAccessRecord retval = new WriteAccessRecord();
             String defaultUserName = "NPOI";
@@ -1356,7 +1356,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a CodepageRecord
          */
 
-        private static Record CreateCodepage()
+        private static CodepageRecord CreateCodepage()
         {
             CodepageRecord retval = new CodepageRecord();
 
@@ -1371,7 +1371,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a DSFRecord
          */
 
-        private static Record CreateDSF()
+        private static DSFRecord CreateDSF()
         {
             return new DSFRecord(false); // we don't even support double stream files
         }
@@ -1383,15 +1383,10 @@ namespace NPOI.HSSF.Model
          * @see org.apache.poi.hssf.record.Record
          * @return record containing a TabIdRecord
          */
-
-        private static Record CreateTabId()
+        private static TabIdRecord CreateTabId()
         {
-            TabIdRecord retval = new TabIdRecord();
-            short[] tabidarray = {
-            0
-        };
-
-            retval.SetTabIdArray(tabidarray);
+            TabIdRecord retval = new();
+            retval.SetTabIdArray([0]);
             return retval;
         }
 
@@ -1402,12 +1397,12 @@ namespace NPOI.HSSF.Model
          * @return record containing a FnGroupCountRecord
          */
 
-        private static Record CreateFnGroupCount()
+        private static FnGroupCountRecord CreateFnGroupCount()
         {
-            FnGroupCountRecord retval = new FnGroupCountRecord();
-
-            retval.Count=(short)14;
-            return retval;
+            return new FnGroupCountRecord
+            {
+                Count = 14
+            };
         }
 
         /**
@@ -1417,7 +1412,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a WindowProtectRecord
          */
 
-        private static Record CreateWindowProtect()
+        private static WindowProtectRecord CreateWindowProtect()
         {
             // by default even when we support it we won't
             // want it to be protected
@@ -1443,7 +1438,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a PasswordRecord
          */
 
-        private static Record CreatePassword()
+        private static PasswordRecord CreatePassword()
         {
             return new PasswordRecord(0x0000); // no password by default!
         }
@@ -1467,7 +1462,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a PasswordRev4Record
          */
 
-        private static Record CreatePasswordRev4()
+        private static PasswordRev4Record CreatePasswordRev4()
         {
             return new PasswordRev4Record(0x0000);
         }
@@ -1488,7 +1483,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a WindowOneRecord
          */
 
-        private static Record CreateWindowOne()
+        private static WindowOneRecord CreateWindowOne()
         {
             WindowOneRecord retval = new WindowOneRecord();
 
@@ -1511,7 +1506,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a BackupRecord
          */
 
-        private static Record CreateBackup()
+        private static BackupRecord CreateBackup()
         {
             BackupRecord retval = new BackupRecord();
 
@@ -1526,7 +1521,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a HideObjRecord
          */
 
-        private static Record CreateHideObj()
+        private static HideObjRecord CreateHideObj()
         {
             HideObjRecord retval = new HideObjRecord();
 
@@ -1541,7 +1536,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a DateWindow1904Record
          */
 
-        private static Record CreateDateWindow1904()
+        private static DateWindow1904Record CreateDateWindow1904()
         {
             DateWindow1904Record retval = new DateWindow1904Record();
 
@@ -1556,7 +1551,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a PrecisionRecord
          */
 
-        private static Record CreatePrecision()
+        private static PrecisionRecord CreatePrecision()
         {
             PrecisionRecord retval = new PrecisionRecord();
 
@@ -1571,7 +1566,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a RefreshAllRecord
          */
 
-        private static Record CreateRefreshAll()
+        private static RefreshAllRecord CreateRefreshAll()
         {
             return new RefreshAllRecord(false);
         }
@@ -1583,12 +1578,12 @@ namespace NPOI.HSSF.Model
          * @return record containing a BookBoolRecord
          */
 
-        private static Record CreateBookBool()
+        private static BookBoolRecord CreateBookBool()
         {
-            BookBoolRecord retval = new BookBoolRecord();
-
-            retval.SaveLinkValues=(short)0;
-            return retval;
+            return new BookBoolRecord
+            {
+                SaveLinkValues = 0
+            };
         }
 
         /**
@@ -1605,7 +1600,7 @@ namespace NPOI.HSSF.Model
          * @return record containing a FontRecord
          */
 
-        private static Record CreateFont()
+        private static FontRecord CreateFont()
         {
             FontRecord retval = new FontRecord();
 
@@ -1699,7 +1694,7 @@ namespace NPOI.HSSF.Model
          * @see org.apache.poi.hssf.record.Record
          */
 
-        private static Record CreateExtendedFormat(int id)
+        private static ExtendedFormatRecord CreateExtendedFormat(int id)
         {   // we'll need multiple editions
             ExtendedFormatRecord retval = new ExtendedFormatRecord();
 
@@ -2090,7 +2085,7 @@ namespace NPOI.HSSF.Model
          * @see org.apache.poi.hssf.record.Record
          */
 
-        private static Record CreateStyle(int id)
+        private static StyleRecord CreateStyle(int id)
         {   // we'll need multiple editions
             StyleRecord retval = new StyleRecord();
 
@@ -2169,7 +2164,7 @@ namespace NPOI.HSSF.Model
          * @see org.apache.poi.hssf.record.Record
          */
 
-        private static Record CreateBoundSheet(int id)
+        private static BoundSheetRecord CreateBoundSheet(int id)
         {   
             return new BoundSheetRecord("Sheet" + (id + 1));
         }
@@ -2182,8 +2177,9 @@ namespace NPOI.HSSF.Model
          * @see org.apache.poi.hssf.record.Record
          */
 
-        private static Record CreateCountry()
-        {   // what a novel idea, Create your own!
+        private static CountryRecord CreateCountry()
+        {
+            // what a novel idea, Create your own!
             CountryRecord retval = new CountryRecord();
 
             retval.DefaultCountry=((short)1);
@@ -2211,12 +2207,12 @@ namespace NPOI.HSSF.Model
          * @see org.apache.poi.hssf.record.Record
          */
 
-        private static Record CreateExtendedSST()
+        private static ExtSSTRecord CreateExtendedSST()
         {
-            ExtSSTRecord retval = new ExtSSTRecord();
-
-            retval.NumStringsPerBucket=((short)0x8);
-            return retval;
+            return new ExtSSTRecord
+            {
+                NumStringsPerBucket = 0x8
+            };
         }
 
         /**

--- a/main/HSSF/Model/LinkTable.cs
+++ b/main/HSSF/Model/LinkTable.cs
@@ -321,12 +321,8 @@ namespace NPOI.HSSF.Model
 
         public NameRecord GetSpecificBuiltinRecord(byte builtInCode, int sheetNumber)
         {
-
-            IEnumerator<NameRecord> iterator = _definedNames.GetEnumerator();
-            while (iterator.MoveNext())
+            foreach (var record in _definedNames)
             {
-                NameRecord record = iterator.Current;
-
                 //print areas are one based
                 if (record.BuiltInName == builtInCode && record.SheetNumber == sheetNumber)
                 {

--- a/main/HSSF/Record/AbstractEscherHolderRecord.cs
+++ b/main/HSSF/Record/AbstractEscherHolderRecord.cs
@@ -91,7 +91,7 @@ namespace NPOI.HSSF.Record
         private void ConvertToEscherRecords(int offset, int size, byte[] data)
         {
             escherRecords.Clear();
-            IEscherRecordFactory recordFactory = new DefaultEscherRecordFactory();
+            DefaultEscherRecordFactory recordFactory = new();
             int pos = offset;
             while (pos < offset + size)
             {

--- a/main/HSSF/Record/Aggregates/ConditionalFormattingTable.cs
+++ b/main/HSSF/Record/Aggregates/ConditionalFormattingTable.cs
@@ -36,7 +36,7 @@ namespace NPOI.HSSF.Record.Aggregates
     public class ConditionalFormattingTable : RecordAggregate
     {
 
-        private readonly IList<CFRecordsAggregate> _cfHeaders;
+        private readonly List<CFRecordsAggregate> _cfHeaders;
 
         /**
          * Creates an empty ConditionalFormattingTable

--- a/main/HSSF/Record/Aggregates/DataValidityTable.cs
+++ b/main/HSSF/Record/Aggregates/DataValidityTable.cs
@@ -15,13 +15,12 @@
    limitations under the License.
 ==================================================================== */
 
+using System.Collections.Generic;
+
+using NPOI.HSSF.Model;
+
 namespace NPOI.HSSF.Record.Aggregates
 {
-    using System.Collections;
-
-    using NPOI.HSSF.Model;
-    using NPOI.HSSF.Record;
-
     /// <summary>
     /// Manages the DVALRecord and DVRecords for a single sheet
     /// See OOO excelfileformat.pdf section 4.14
@@ -35,15 +34,15 @@ namespace NPOI.HSSF.Record.Aggregates
          * The list of data validations for the current sheet.
          * Note - this may be empty (contrary to OOO documentation)
          */
-        private readonly IList _validationList;
+        private readonly List<DVRecord> _validationList;
 
         public DataValidityTable(RecordStream rs)
         {
             _headerRec = (DVALRecord)rs.GetNext();
-            IList temp = new ArrayList();
+            List<DVRecord> temp = new();
             while (rs.PeekNextClass() == typeof(DVRecord))
             {
-                temp.Add(rs.GetNext());
+                temp.Add((DVRecord) rs.GetNext());
             }
             _validationList = temp;
         }
@@ -51,7 +50,7 @@ namespace NPOI.HSSF.Record.Aggregates
         public DataValidityTable()
         {
             _headerRec = new DVALRecord();
-            _validationList = new ArrayList();
+            _validationList = new List<DVRecord>();
         }
 
         public override void VisitContainedRecords(RecordVisitor rv)

--- a/main/HSSF/Record/Aggregates/PageSettingsBlock.cs
+++ b/main/HSSF/Record/Aggregates/PageSettingsBlock.cs
@@ -468,27 +468,28 @@ namespace NPOI.HSSF.Record.Aggregates
          * @param stop Ending "main" value to shift breaks
          * @param count number of units (rows/columns) to shift by
          */
-        private static void ShiftBreaks(PageBreakRecord breaks, int start, int stop, int count) {
+        private static void ShiftBreaks(PageBreakRecord breaks, int start, int stop, int count)
+        {
+            IEnumerator iterator = breaks.GetBreaksEnumerator();
+            List<PageBreakRecord.Break> shiftedBreak = [];
+            while(iterator.MoveNext())
+            {
+                PageBreakRecord.Break breakItem = (PageBreakRecord.Break) iterator.Current;
+                int breakLocation = breakItem.main;
+                bool inStart = (breakLocation >= start);
+                bool inEnd = (breakLocation <= stop);
+                if(inStart && inEnd)
+                    shiftedBreak.Add(breakItem);
+            }
 
-		IEnumerator iterator = breaks.GetBreaksEnumerator();
-		IList shiftedBreak = new ArrayList();
-		while(iterator.MoveNext())
-		{
-			PageBreakRecord.Break breakItem = (PageBreakRecord.Break)iterator.Current;
-			int breakLocation = breakItem.main;
-			bool inStart = (breakLocation >= start);
-			bool inEnd = (breakLocation <= stop);
-			if(inStart && inEnd)
-				shiftedBreak.Add(breakItem);
-		}
-
-		iterator = shiftedBreak.GetEnumerator();
-		while (iterator.MoveNext()) {
-			PageBreakRecord.Break breakItem = (PageBreakRecord.Break)iterator.Current;
-			breaks.RemoveBreak(breakItem.main);
-			breaks.AddBreak((short)(breakItem.main+count), breakItem.subFrom, breakItem.subTo);
-		}
-	}
+            iterator = shiftedBreak.GetEnumerator();
+            while(iterator.MoveNext())
+            {
+                PageBreakRecord.Break breakItem = (PageBreakRecord.Break) iterator.Current;
+                breaks.RemoveBreak(breakItem.main);
+                breaks.AddBreak((short) (breakItem.main + count), breakItem.subFrom, breakItem.subTo);
+            }
+        }
 
 
         /**

--- a/main/HSSF/Record/Crypto/Biff8EncryptionKey.cs
+++ b/main/HSSF/Record/Crypto/Biff8EncryptionKey.cs
@@ -50,30 +50,27 @@ namespace NPOI.HSSF.Record.Crypto
                 passwordData[i * 2 + 1] = (byte)((ch << 8) & 0xFF);
             }
 
-            byte[] kd;
-            using (MD5 md5 = new MD5CryptoServiceProvider())
+            using MD5CryptoServiceProvider md5 = new();
+            byte[] passwordHash = md5.ComputeHash(passwordData);
+
+            md5.Initialize();
+
+            byte[] data = new byte[PASSWORD_HASH_NUMBER_OF_BYTES_USED * 16 + docIdData.Length * 16];
+
+            int offset = 0;
+            for (int i = 0; i < 16; i++)
             {
-                byte[] passwordHash = md5.ComputeHash(passwordData);
-
-                md5.Initialize();
-
-                byte[] data = new byte[PASSWORD_HASH_NUMBER_OF_BYTES_USED * 16 + docIdData.Length * 16];
-
-                int offset = 0;
-                for (int i = 0; i < 16; i++)
-                {
-                    Array.Copy(passwordHash, 0, data, offset, PASSWORD_HASH_NUMBER_OF_BYTES_USED);
-                    offset += PASSWORD_HASH_NUMBER_OF_BYTES_USED;// passwordHash.Length;
-                    Array.Copy(docIdData, 0, data, offset, docIdData.Length);
-                    offset += docIdData.Length;
-                }
-                kd = md5.ComputeHash(data);
-                byte[] result = new byte[KEY_DIGEST_LENGTH];
-                Array.Copy(kd, 0, result, 0, KEY_DIGEST_LENGTH);
-                md5.Clear();
-
-                return result;
+                Array.Copy(passwordHash, 0, data, offset, PASSWORD_HASH_NUMBER_OF_BYTES_USED);
+                offset += PASSWORD_HASH_NUMBER_OF_BYTES_USED;// passwordHash.Length;
+                Array.Copy(docIdData, 0, data, offset, docIdData.Length);
+                offset += docIdData.Length;
             }
+            byte[] kd = md5.ComputeHash(data);
+            byte[] result = new byte[KEY_DIGEST_LENGTH];
+            Array.Copy(kd, 0, result, 0, KEY_DIGEST_LENGTH);
+            md5.Clear();
+
+            return result;
         }
 
         /**

--- a/main/HSSF/Record/EmbeddedObjectRefSubRecord.cs
+++ b/main/HSSF/Record/EmbeddedObjectRefSubRecord.cs
@@ -183,19 +183,17 @@ namespace NPOI.HSSF.Record
 
         private static Ptg ReadRefPtg(byte[] formulaRawBytes)
         {
-            using (MemoryStream ms = RecyclableMemory.GetStream(formulaRawBytes))
+            using MemoryStream ms = RecyclableMemory.GetStream(formulaRawBytes);
+            LittleEndianInputStream in1 = new LittleEndianInputStream(ms);
+            byte ptgSid = (byte)in1.ReadByte();
+            switch (ptgSid)
             {
-                ILittleEndianInput in1 = new LittleEndianInputStream(ms);
-                byte ptgSid = (byte)in1.ReadByte();
-                switch (ptgSid)
-                {
-                    case AreaPtg.sid: return new AreaPtg(in1);
-                    case Area3DPtg.sid: return new Area3DPtg(in1);
-                    case RefPtg.sid: return new RefPtg(in1);
-                    case Ref3DPtg.sid: return new Ref3DPtg(in1);
-                }
-                return null;
+                case AreaPtg.sid: return new AreaPtg(in1);
+                case Area3DPtg.sid: return new Area3DPtg(in1);
+                case RefPtg.sid: return new RefPtg(in1);
+                case Ref3DPtg.sid: return new Ref3DPtg(in1);
             }
+            return null;
         }
 
         private static byte[] ReadRawData(ILittleEndianInput in1, int size)

--- a/main/HSSF/Record/EscherAggregate.cs
+++ b/main/HSSF/Record/EscherAggregate.cs
@@ -432,8 +432,8 @@ namespace NPOI.HSSF.Record
         {
             // Keep track of any shape records Created so we can match them back to the object id's.
             // Textbox objects are also treated as shape objects.
-            List<EscherRecord> shapeRecords = new List<EscherRecord>();
-            IEscherRecordFactory recordFactory = new CustomEscherRecordFactory(shapeRecords);
+            List<EscherRecord> shapeRecords = [];
+            CustomEscherRecordFactory recordFactory = new(shapeRecords);
 
             // Create one big buffer
             using (MemoryStream stream = RecyclableMemory.GetStream())

--- a/main/HSSF/Record/ExternSheetRecord.cs
+++ b/main/HSSF/Record/ExternSheetRecord.cs
@@ -16,17 +16,14 @@
    limitations Under the License.
 ==================================================================== */
 
+using System;
+using System.Text;
+using System.Collections.Generic;
+
+using NPOI.Util;
 
 namespace NPOI.HSSF.Record
 {
-
-    using System;
-    using System.Text;
-    using System.Collections;
-    using NPOI.Util;
-    using System.Collections.Generic;
-
-
     public class RefSubRecord
     {
         public const int ENCODED_SIZE = 6;
@@ -114,14 +111,11 @@ namespace NPOI.HSSF.Record
     public class ExternSheetRecord : StandardRecord
     {
         public const short sid = 0x17;
-        private readonly IList<RefSubRecord> _list;
-
-
-
+        private readonly List<RefSubRecord> _list;
 
         public ExternSheetRecord()
         {
-            _list = new List<RefSubRecord>();
+            _list = [];
         }
 
         /**

--- a/main/HSSF/Record/HyperlinkRecord.cs
+++ b/main/HSSF/Record/HyperlinkRecord.cs
@@ -232,7 +232,8 @@ namespace NPOI.HSSF.Record
                 Console.WriteLine(HexDump.ToHex(in1.ReadRemainder()));
             }
         }
-        private static byte[] ReadTail(byte[] expectedTail, ILittleEndianInput in1)
+
+        private static byte[] ReadTail(byte[] expectedTail, RecordInputStream in1)
         {
             byte[] result = new byte[TAIL_SIZE];
             in1.ReadFully(result);
@@ -249,6 +250,7 @@ namespace NPOI.HSSF.Record
             //}
             return result;
         }
+
         private static void WriteTail(byte[] tail, ILittleEndianOutput out1)
         {
             out1.Write(tail);

--- a/main/HSSF/Record/LbsDataSubRecord.cs
+++ b/main/HSSF/Record/LbsDataSubRecord.cs
@@ -269,16 +269,16 @@ namespace NPOI.HSSF.Record
         }
         private static Ptg ReadRefPtg(byte[] formulaRawBytes)
         {
-            ILittleEndianInput in1 = new LittleEndianByteArrayInputStream(formulaRawBytes);
+            LittleEndianByteArrayInputStream in1 = new(formulaRawBytes);
             byte ptgSid = (byte)in1.ReadByte();
-            switch (ptgSid)
+            return ptgSid switch
             {
-                case AreaPtg.sid: return new AreaPtg(in1);
-                case Area3DPtg.sid: return new Area3DPtg(in1);
-                case RefPtg.sid: return new RefPtg(in1);
-                case Ref3DPtg.sid: return new Ref3DPtg(in1);
-            }
-            return null;
+                AreaPtg.sid => new AreaPtg(in1),
+                Area3DPtg.sid => new Area3DPtg(in1),
+                RefPtg.sid => new RefPtg(in1),
+                Ref3DPtg.sid => new Ref3DPtg(in1),
+                _ => null
+            };
         }
         public override Object Clone()
         {

--- a/main/HSSF/Record/NameCommentRecord.cs
+++ b/main/HSSF/Record/NameCommentRecord.cs
@@ -103,7 +103,7 @@ namespace NPOI.HSSF.Record
          */
         public NameCommentRecord(RecordInputStream ris)
         {
-            ILittleEndianInput in1 = ris;
+            RecordInputStream in1 = ris;
             field_1_record_type = in1.ReadShort();
             field_2_frt_cell_ref_flag = in1.ReadShort();
             field_3_reserved = in1.ReadLong();

--- a/main/HSSF/Record/NameRecord.cs
+++ b/main/HSSF/Record/NameRecord.cs
@@ -170,7 +170,7 @@ namespace NPOI.HSSF.Record
         public NameRecord(RecordInputStream ris)
         {
             byte[] remainder = ris.ReadAllContinuedRemainder();
-            ILittleEndianInput in1 = new LittleEndianByteArrayInputStream(remainder);
+            LittleEndianByteArrayInputStream in1 = new LittleEndianByteArrayInputStream(remainder);
             field_1_option_flag                 = in1.ReadShort();
 		    field_2_keyboard_shortcut           = (byte)in1.ReadByte();
 		    int field_3_length_name_text        = in1.ReadByte();
@@ -545,7 +545,7 @@ namespace NPOI.HSSF.Record
         }
 
 
-        private static Ptg CreateNewPtg()
+        private static Area3DPtg CreateNewPtg()
         {
             return new Area3DPtg("A1:A1", 0); // TODO - change to not be partially initialised
         }

--- a/main/HSSF/UserModel/EvaluationCycleDetector.cs
+++ b/main/HSSF/UserModel/EvaluationCycleDetector.cs
@@ -106,7 +106,7 @@ namespace NPOI.HSSF.UserModel
             }
         }
 
-        private readonly IList _evaluationFrames;
+        private readonly ArrayList _evaluationFrames;
 
         public EvaluationCycleDetector()
         {

--- a/main/HSSF/UserModel/HSSFCell.cs
+++ b/main/HSSF/UserModel/HSSFCell.cs
@@ -19,7 +19,6 @@
 namespace NPOI.HSSF.UserModel
 {
     using System;
-    using System.Collections;
     using System.IO;
     using NPOI.HSSF.Model;
     using NPOI.HSSF.Record;
@@ -31,7 +30,6 @@ namespace NPOI.HSSF.UserModel
     using NPOI.SS.Formula;
     using System.Globalization;
     using System.Collections.Generic;
-    using NPOI.Util;
     using NPOI.SS.Formula.Eval;
 
     /// <summary>
@@ -831,7 +829,7 @@ namespace NPOI.HSSF.UserModel
         /// <param name="actualTypeCode">The actual type code.</param>
         /// <param name="isFormulaCell">if set to <c>true</c> [is formula cell].</param>
         /// <returns></returns>
-        private static Exception TypeMismatch(CellType expectedTypeCode, CellType actualTypeCode, bool isFormulaCell)
+        private static InvalidOperationException TypeMismatch(CellType expectedTypeCode, CellType actualTypeCode, bool isFormulaCell)
         {
             String msg = "Cannot get a "
                 + HSSFCell.GetCellTypeName(expectedTypeCode) + " value from a "
@@ -1358,9 +1356,8 @@ namespace NPOI.HSSF.UserModel
         public void RemoveHyperlink()
         {
             RecordBase toRemove = null;
-            for (IEnumerator<RecordBase> it = _sheet.Sheet.Records.GetEnumerator(); it.MoveNext(); )
+            foreach (var rec in _sheet.Sheet.Records)
             {
-                RecordBase rec = it.Current;
                 if (rec is HyperlinkRecord link)
                 {
                     if (link.FirstColumn == _record.Column && link.FirstRow == _record.Row)

--- a/main/HSSF/UserModel/HSSFChart.cs
+++ b/main/HSSF/UserModel/HSSFChart.cs
@@ -1108,7 +1108,7 @@ namespace NPOI.HSSF.UserModel
                 return series;
             }
 
-            private static CellRangeAddressBase GetCellRange(LinkedDataRecord linkedDataRecord)
+            private static CellRangeAddress GetCellRange(LinkedDataRecord linkedDataRecord)
             {
                 if (linkedDataRecord == null)
                 {

--- a/main/HSSF/UserModel/HSSFRichTextString.cs
+++ b/main/HSSF/UserModel/HSSFRichTextString.cs
@@ -15,15 +15,14 @@
    limitations Under the License.
 ==================================================================== */
 
+using System;
+using System.Collections.Generic;
+
+using NPOI.HSSF.Record;
+using NPOI.HSSF.Model;
+
 namespace NPOI.HSSF.UserModel
 {
-    using System;
-    using System.Collections;
-
-    using NPOI.HSSF.Record;
-    using NPOI.HSSF.Model;
-    using System.Collections.Generic;
-
     /// <summary>
     /// Rich text Unicode string.  These strings can have fonts applied to
     /// arbitary parts of the string.
@@ -145,15 +144,13 @@ namespace NPOI.HSSF.UserModel
 
             //Need to clear the current formatting between the startIndex and endIndex
             _string = CloneStringIfRequired();
-            System.Collections.Generic.List<UnicodeString.FormatRun> formatting = _string.FormatIterator();
+            List<UnicodeString.FormatRun> formatting = _string.FormatIterator();
 
-            ArrayList deletedFR = new ArrayList();
+            List<UnicodeString.FormatRun> deletedFR = [];
             if (formatting != null)
             {
-                IEnumerator<UnicodeString.FormatRun> formats = formatting.GetEnumerator();
-                while (formats.MoveNext())
+                foreach (var r in formatting)
                 {
-                    UnicodeString.FormatRun r = formats.Current;
                     if ((r.CharacterPos >= startIndex) && (r.CharacterPos < endIndex))
                     {
                         deletedFR.Add(r);

--- a/main/HSSF/UserModel/HSSFShapeGroup.cs
+++ b/main/HSSF/UserModel/HSSFShapeGroup.cs
@@ -387,7 +387,7 @@ namespace NPOI.HSSF.UserModel
             throw new NotImplementedException("Use method cloneShape(HSSFPatriarch patriarch)");
         }
 
-        internal HSSFShape CloneShape(HSSFPatriarch patriarch)
+        internal HSSFShapeGroup CloneShape(HSSFPatriarch patriarch)
         {
             EscherContainerRecord spgrContainer = new EscherContainerRecord();
             spgrContainer.RecordId = (EscherContainerRecord.SPGR_CONTAINER);

--- a/main/HSSF/UserModel/HSSFSheet.cs
+++ b/main/HSSF/UserModel/HSSFSheet.cs
@@ -15,13 +15,13 @@
    limitations Under the License.
 ==================================================================== */
 
-using System.Collections.ObjectModel;
-
 namespace NPOI.HSSF.UserModel
 {
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Globalization;
+
     using NPOI.DDF;
     using NPOI.HSSF.Model;
     using NPOI.HSSF.Record;
@@ -33,13 +33,10 @@ namespace NPOI.HSSF.UserModel
     using NPOI.SS.Formula.PTG;
     using NPOI.SS.UserModel;
     using NPOI.SS.Util;
-    using System.Globalization;
-    using NPOI.Util;
     using NPOI.SS.UserModel.Helpers;
     using NPOI.HSSF.UserModel.helpers;
+
     using SixLabors.Fonts;
-
-
 
     /// <summary>
     /// High level representation of a worksheet.
@@ -2243,7 +2240,7 @@ namespace NPOI.HSSF.UserModel
         /// <summary>
         /// Also creates cells if they don't exist.
         /// </summary>
-        private ICellRange<ICell> GetCellRange(CellRangeAddress range)
+        private SSCellRange<ICell> GetCellRange(CellRangeAddress range)
         {
             int firstRow = range.FirstRow;
             int firstColumn = range.FirstColumn;
@@ -2283,7 +2280,7 @@ namespace NPOI.HSSF.UserModel
             // make sure the formula parses OK first
             int sheetIndex = _workbook.GetSheetIndex(this);
             Ptg[] ptgs = HSSFFormulaParser.Parse(formula, _workbook, FormulaType.Array, sheetIndex);
-            ICellRange<ICell> cells = GetCellRange(range);
+            SSCellRange<ICell> cells = GetCellRange(range);
 
             foreach (HSSFCell c in cells)
             {
@@ -2631,14 +2628,14 @@ namespace NPOI.HSSF.UserModel
         {
             get
             {
-                IList dvRecords = new ArrayList();
-                IList records = _sheet.Records;
+                List<DVRecord> dvRecords = [];
+                List<RecordBase> records = _sheet.Records;
 
                 for (int index = 0; index < records.Count; index++)
                 {
-                    if (records[index] is DVRecord)
+                    if (records[index] is DVRecord dvRecord)
                     {
-                        dvRecords.Add(records[index]);
+                        dvRecords.Add(dvRecord);
                     }
                 }
                 return dvRecords;

--- a/main/HSSF/UserModel/HSSFWorkbook.cs
+++ b/main/HSSF/UserModel/HSSFWorkbook.cs
@@ -614,7 +614,7 @@ namespace NPOI.HSSF.UserModel
                 ValidateSheetIndex(index);
             }
             // ignore duplicates
-            ISet<int> set = new HashSet<int>(indexes);
+            HashSet<int> set = new(indexes);
             int nSheets = _sheets.Count;
             for (int i = 0; i < nSheets; i++)
             {

--- a/main/POIFS/Crypt/Standard/StandardEncryptor.cs
+++ b/main/POIFS/Crypt/Standard/StandardEncryptor.cs
@@ -15,16 +15,15 @@
    limitations under the License.
 ==================================================================== */
 
+using System;
+using System.IO;
+
+using NPOI.POIFS.EventFileSystem;
+using NPOI.POIFS.FileSystem;
+using NPOI.Util;
+
 namespace NPOI.POIFS.Crypt.Standard
 {
-    using System;
-    using System.IO;
-    using System.Security.AccessControl;
-    using NPOI.POIFS.Crypt;
-    using NPOI.POIFS.EventFileSystem;
-    using NPOI.POIFS.FileSystem;
-    using NPOI.Util;
-
     public class StandardEncryptor : Encryptor
     {
         private StandardEncryptionInfoBuilder builder;
@@ -109,8 +108,8 @@ namespace NPOI.POIFS.Crypt.Standard
             protected long countBytes;
             protected FileInfo fileOut;
             protected DirectoryNode dir;
-            ByteArrayOutputStream out1;
-            FileStream rawStream;// maybe has memory leak problem.
+            private readonly CipherOutputStream out1;
+            private readonly FileStream rawStream;// maybe has memory leak problem.
 
             protected internal StandardCipherOutputStream(DirectoryNode dir, StandardEncryptor encryptor)
             {

--- a/main/POIFS/FileSystem/OPOIFSFileSystem.cs
+++ b/main/POIFS/FileSystem/OPOIFSFileSystem.cs
@@ -67,7 +67,7 @@ namespace NPOI.POIFS.FileSystem
         }
 
         private PropertyTable _property_table;
-        private IList<OPOIFSDocument>  _documents;
+        private List<OPOIFSDocument>  _documents;
         private DirectoryNode _root;
         /**
  * What big block size the file uses. Most files

--- a/main/POIFS/Macros/VBAMacroReader.cs
+++ b/main/POIFS/Macros/VBAMacroReader.cs
@@ -218,7 +218,7 @@ namespace NPOI.POIFS.Macros
          * @throws IOException
          */
 
-        private static String ReadString(InputStream stream, int length, Encoding charset)
+        private static String ReadString(RLEDecompressingInputStream stream, int length, Encoding charset)
         {
             byte[] buffer = new byte[length];
             int count = stream.Read(buffer);
@@ -254,9 +254,8 @@ namespace NPOI.POIFS.Macros
             else
             {
                 // Decompress a previously found module and store the decompressed result into module.buf
-                InputStream stream = new RLEDecompressingInputStream(
-                        new MemoryStream(module.buf, moduleOffset, module.buf.Length - moduleOffset)
-                );
+                using MemoryStream memoryStream = new(module.buf, moduleOffset, module.buf.Length - moduleOffset);
+                using RLEDecompressingInputStream stream = new(memoryStream);
                 module.Read(stream);
                 stream.Close();
             }
@@ -287,7 +286,7 @@ namespace NPOI.POIFS.Macros
                 {
                     throw new IOException("tried to skip " + module.offset + " bytes, but actually skipped " + skippedBytes + " bytes");
                 }
-                InputStream stream = new RLEDecompressingInputStream(dis);
+                using RLEDecompressingInputStream stream = new(dis);
                 module.Read(stream);
                 stream.Close();
             }
@@ -299,7 +298,7 @@ namespace NPOI.POIFS.Macros
           * @throws IOException
           */
 
-        private static void TrySkip(InputStream in1, long n)
+        private static void TrySkip(RLEDecompressingInputStream in1, long n)
         {
             long skippedBytes = in1.Skip(n);
             if (skippedBytes != n)

--- a/main/POIFS/Storage/SmallBlockTableWriter.cs
+++ b/main/POIFS/Storage/SmallBlockTableWriter.cs
@@ -43,7 +43,7 @@ namespace NPOI.POIFS.Storage
     public class SmallBlockTableWriter : BlockWritable, BATManaged
     {
         private readonly BlockAllocationTableWriter _sbat;
-        private readonly IList<SmallDocumentBlock>  _small_blocks;
+        private readonly List<SmallDocumentBlock>  _small_blocks;
         private readonly int                        _big_block_count;
         private readonly RootProperty               _root;
 

--- a/main/SS/Format/CellDateFormatter.cs
+++ b/main/SS/Format/CellDateFormatter.cs
@@ -33,15 +33,14 @@ namespace NPOI.SS.Format
         private bool amPmUpper;
         private bool ShowM;
         private bool ShowAmPm;
-        private readonly FormatBase dateFmt;
+        private readonly SimpleDateFormat dateFmt;
         private String sFmt;
         private int millisecondPartLength = 0;
 
         private static readonly TimeSpan EXCEL_EPOCH_TIME;
         private static readonly DateTime EXCEL_EPOCH_DATE;
 
-        private static readonly CellFormatter SIMPLE_DATE = new CellDateFormatter(
-                "mm/d/y");
+        private static readonly CellDateFormatter SIMPLE_DATE = new CellDateFormatter("mm/d/y");
 
         static CellDateFormatter()
         {

--- a/main/SS/Format/CellNumberFormatter.cs
+++ b/main/SS/Format/CellNumberFormatter.cs
@@ -14,17 +14,16 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 ==================================================================== */
+
+using System;
+using System.Text;
+using System.Collections.Generic;
+
+using NPOI.SS.Util;
+using System.Collections;
+
 namespace NPOI.SS.Format
 {
-    using System;
-    using System.Text.RegularExpressions;
-    using System.Text;
-    using System.Collections.Generic;
-    using NPOI.SS.Util;
-    using System.Collections;
-    using NPOI.Util;
-
-
     /**
      * This class : printing out a value using a number format.
      *
@@ -56,9 +55,9 @@ namespace NPOI.SS.Format
         private DecimalFormat decimalFmt;
         private static List<Special> EmptySpecialList = new List<Special>();
 
-        private static readonly CellFormatter SIMPLE_NUMBER = new SimpleNumberCellFormatter("General");
-        private static readonly CellFormatter SIMPLE_INT = new CellNumberFormatter("#");
-        private static readonly CellFormatter SIMPLE_FLOAT = new CellNumberFormatter("#.#");
+        private static readonly SimpleNumberCellFormatter SIMPLE_NUMBER = new SimpleNumberCellFormatter("General");
+        private static readonly CellNumberFormatter SIMPLE_INT = new CellNumberFormatter("#");
+        private static readonly CellNumberFormatter SIMPLE_FLOAT = new CellNumberFormatter("#.#");
 
         /// <summary>
         /// The CellNumberFormatter.simpleValue() method uses the SIMPLE_NUMBER
@@ -409,7 +408,7 @@ namespace NPOI.SS.Format
         {
             if (pos >= specials.Count)
                 return EmptySpecialList;
-            IEnumerator<Special> it = specials.GetRange(pos + takeFirst, specials.Count - pos - takeFirst).GetEnumerator();
+            List<Special>.Enumerator it = specials.GetRange(pos + takeFirst, specials.Count - pos - takeFirst).GetEnumerator();
             //.ListIterator(pos + takeFirst);
             it.MoveNext();
             Special last = it.Current;
@@ -461,12 +460,8 @@ namespace NPOI.SS.Format
             if (idx != -1)
             {
                 // skip over the decimal point itself
-                IEnumerator<Special> it = specials.GetRange(idx + 1, specials.Count - idx - 1).GetEnumerator();//.ListIterator(specials.IndexOf(decimalPoint));
-                //if (it.HasNext())
-                //     it.Next();  // skip over the decimal point itself
-                while (it.MoveNext())
+                foreach (Special s in specials.GetRange(idx + 1, specials.Count - idx - 1))
                 {
-                    Special s = it.Current;
                     if (!IsDigitFmt(s))
                     {
                         break;
@@ -524,12 +519,10 @@ namespace NPOI.SS.Format
             }
 
             // Now strip them out -- we only need their interpretation, not their presence
-            IEnumerator<Special> it = specials.GetEnumerator();
             int Removed = 0;
-            List<Special> toRemove = new List<Special>();
-            while (it.MoveNext())
+            List<Special> toRemove = [];
+            foreach (var s in specials)
             {
-                Special s = it.Current;
                 s.pos -= Removed;
                 if (s.ch == ',')
                 {
@@ -797,7 +790,7 @@ namespace NPOI.SS.Format
             }
 
             // Now the result lines up like it is supposed to with the specials' indexes
-            IEnumerator<Special> it = exponentSpecials.GetEnumerator();//.ListIterator(1);
+            List<Special>.Enumerator it = exponentSpecials.GetEnumerator();//.ListIterator(1);
             it.MoveNext();
             it.MoveNext();
             Special expSign = it.Current;//.Next();

--- a/main/SS/Format/CellTextFormatter.cs
+++ b/main/SS/Format/CellTextFormatter.cs
@@ -28,10 +28,11 @@ namespace NPOI.SS.Format
      */
     public class CellTextFormatter : CellFormatter
     {
-        private int[] textPos;
-        private String desc;
+        private readonly int[] textPos;
+        private readonly string desc;
 
-        internal static CellFormatter SIMPLE_TEXT = new CellTextFormatter("@");
+        internal static readonly CellTextFormatter SIMPLE_TEXT = new CellTextFormatter("@");
+
         private sealed class PartHandler : CellFormatPart.IPartHandler
         {
             private int numplace;

--- a/main/SS/Formula/CacheAreaEval.cs
+++ b/main/SS/Formula/CacheAreaEval.cs
@@ -33,8 +33,7 @@ namespace NPOI.SS.Formula
         int relFirstColIx, int relLastColIx)
         {
 
-            AreaI area = new OffsetArea(FirstRow, FirstColumn,
-                    relFirstRowIx, relLastRowIx, relFirstColIx, relLastColIx);
+            OffsetArea area = new(FirstRow, FirstColumn, relFirstRowIx, relLastRowIx, relFirstColIx, relLastColIx);
 
             int height = area.LastRow - area.FirstRow + 1;
             int width = area.LastColumn - area.FirstColumn + 1;

--- a/main/SS/Formula/CellEvaluationFrame.cs
+++ b/main/SS/Formula/CellEvaluationFrame.cs
@@ -15,32 +15,31 @@
    limitations under the License.
 ==================================================================== */
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using NPOI.SS.Formula.Eval;
+
 namespace NPOI.SS.Formula
 {
-
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using NPOI.SS.Formula.Eval;
-
     /**
      * Stores details about the current evaluation of a cell.<br/>
      */
-    class CellEvaluationFrame
+    internal sealed class CellEvaluationFrame
     {
-
         private readonly FormulaCellCacheEntry _cce;
-        private readonly ISet<CellCacheEntry> _sensitiveInputCells;
+        private readonly HashSet<CellCacheEntry> _sensitiveInputCells;
         private FormulaUsedBlankCellSet _usedBlankCellGroup;
 
         public CellEvaluationFrame(FormulaCellCacheEntry cce)
         {
             _cce = cce;
-            _sensitiveInputCells = new HashSet<CellCacheEntry>();
+            _sensitiveInputCells = [];
         }
-        public CellCacheEntry GetCCE()
+
+        public FormulaCellCacheEntry GetCCE()
         {
             return _cce;
         }

--- a/main/SS/Formula/Constant/ConstantValueParser.cs
+++ b/main/SS/Formula/Constant/ConstantValueParser.cs
@@ -81,7 +81,7 @@ namespace NPOI.SS.Formula.Constant
             throw new Exception("Unknown grbit value (" + grbit + ")");
         }
 
-        private static Object ReadBoolean(ILittleEndianInput in1)
+        private static bool ReadBoolean(ILittleEndianInput in1)
         {
             byte val = (byte)in1.ReadLong(); // 7 bytes 'not used'
             switch (val)

--- a/main/SS/Formula/Eval/ConcatEval.cs
+++ b/main/SS/Formula/Eval/ConcatEval.cs
@@ -54,7 +54,7 @@ using Cysharp.Text;
             return new StringEval(sb.ToString());
         }
 
-        private static Object GetText(ValueEval ve)
+        private static string GetText(ValueEval ve)
         {
             if (ve is StringValueEval sve)
             {
@@ -64,8 +64,7 @@ using Cysharp.Text;
             {
                 return "";
             }
-            throw new InvalidOperationException("Unexpected value type ("
-                        + ve.GetType().Name + ")");
+            throw new InvalidOperationException($"Unexpected value type ({ve.GetType().Name})");
         }
     }
 }

--- a/main/SS/Formula/EvaluationTracker.cs
+++ b/main/SS/Formula/EvaluationTracker.cs
@@ -15,15 +15,13 @@
    limitations under the License.
 ==================================================================== */
 
+using System;
+using System.Collections.Generic;
+
+using NPOI.SS.Formula.Eval;
+
 namespace NPOI.SS.Formula
 {
-
-    using System;
-    using System.Collections;
-    using System.Collections.Generic;
-    using NPOI.SS.Formula.Eval;
-    
-
     /// <summary>
     /// Instances of this class keep track of multiple dependent cell evaluations due
     /// To recursive calls To <see cref="WorkbookEvaluator.Evaluate"/>
@@ -37,15 +35,15 @@ namespace NPOI.SS.Formula
     public class EvaluationTracker
     {
         // TODO - consider deleting this class and letting CellEvaluationFrame take care of itself
-        private readonly IList<CellEvaluationFrame> _evaluationFrames;
-        private readonly ISet<FormulaCellCacheEntry> _currentlyEvaluatingCells;
+        private readonly List<CellEvaluationFrame> _evaluationFrames;
+        private readonly HashSet<FormulaCellCacheEntry> _currentlyEvaluatingCells;
         private readonly EvaluationCache _cache;
 
         public EvaluationTracker(EvaluationCache cache)
         {
             _cache = cache;
-            _evaluationFrames = new List<CellEvaluationFrame>();
-            _currentlyEvaluatingCells = new HashSet<FormulaCellCacheEntry>();
+            _evaluationFrames = [];
+            _currentlyEvaluatingCells = [];
         }
 
         /**

--- a/main/SS/Formula/FormulaCellCacheEntrySet.cs
+++ b/main/SS/Formula/FormulaCellCacheEntrySet.cs
@@ -125,7 +125,7 @@ namespace NPOI.SS.Formula
             throw new InvalidOperationException("No empty space found");
         }
 
-        public bool Remove(CellCacheEntry cce)
+        public bool Remove(FormulaCellCacheEntry cce)
         {
             FormulaCellCacheEntry[] arr = _arr;
 

--- a/main/SS/Formula/FormulaParser.cs
+++ b/main/SS/Formula/FormulaParser.cs
@@ -200,7 +200,7 @@ using Cysharp.Text;
         }
 
         /** Report What Was Expected */
-        private Exception expected(String s)
+        private FormulaParseException expected(String s)
         {
             String msg;
 
@@ -1518,7 +1518,7 @@ using Cysharp.Text;
          * If we have something that looks like [book]Sheet1: or
          *  Sheet1, see if it's actually a range eg Sheet1:Sheet2!
          */
-        private SheetIdentifier ParseSheetRange(String bookname, NameIdentifier sheet1Name)
+        private SheetRangeIdentifier ParseSheetRange(String bookname, NameIdentifier sheet1Name)
         {
             GetChar();
             SheetIdentifier sheet2 = ParseSheetName();
@@ -2316,7 +2316,7 @@ using Cysharp.Text;
             }
         }
 
-        private Ptg GetComparisonToken()
+        private ValueOperatorPtg GetComparisonToken()
         {
             if (look == '=')
             {

--- a/main/SS/Formula/FormulaShifter.cs
+++ b/main/SS/Formula/FormulaShifter.cs
@@ -15,13 +15,14 @@
    limitations under the License.
 ==================================================================== */
 
+using System;
+
+using NPOI.SS.Formula.PTG;
+
+using Cysharp.Text;
+
 namespace NPOI.SS.Formula
 {
-
-    using NPOI.SS.Formula.PTG;
-    using System;
-    using System.Text; 
-using Cysharp.Text;
     /**
      * @author Josh Micich
      */
@@ -540,7 +541,7 @@ using Cysharp.Text;
             return null;
         }
 
-        private Ptg AdjustPtgDueToSheetMove(Ptg ptg)
+        private Ref3DPtg AdjustPtgDueToSheetMove(Ptg ptg)
         {
             if (ptg is Ref3DPtg refPtg)
             {

--- a/main/SS/Formula/FormulaUsedBlankCellSet.cs
+++ b/main/SS/Formula/FormulaUsedBlankCellSet.cs
@@ -15,6 +15,8 @@
    limitations under the License.
 ==================================================================== */
 
+using System.Collections.Generic;
+
 namespace NPOI.SS.Formula
 {
 
@@ -55,7 +57,7 @@ namespace NPOI.SS.Formula
 
         private  class BlankCellSheetGroup
         {
-            private readonly IList _rectangleGroups;
+            private readonly List<BlankCellRectangleGroup> _rectangleGroups;
             private int _currentRowIndex;
             private int _firstColumnIndex;
             private int _lastColumnIndex;
@@ -63,7 +65,7 @@ namespace NPOI.SS.Formula
 
             public BlankCellSheetGroup()
             {
-                _rectangleGroups = new ArrayList();
+                _rectangleGroups = [];
                 _currentRowIndex = -1;
             }
 

--- a/main/SS/Formula/Functions/AggregateFunction.cs
+++ b/main/SS/Formula/Functions/AggregateFunction.cs
@@ -332,7 +332,7 @@ namespace NPOI.SS.Formula.Functions
      */
     public abstract class AggregateFunction : MultiOperandNumericFunction
     {
-        internal static Function SubtotalInstance(Function func, bool countHiddenRows)
+        internal static SubtotalInstance SubtotalInstance(Function func, bool countHiddenRows)
         {
             AggregateFunction arg = (AggregateFunction)func;
             return new SubtotalInstance(arg, countHiddenRows);

--- a/main/SS/Formula/Functions/Hlookup.cs
+++ b/main/SS/Formula/Functions/Hlookup.cs
@@ -16,10 +16,10 @@
    limitations Under the License.
 ==================================================================== */
 
+using NPOI.SS.Formula.Eval;
+
 namespace NPOI.SS.Formula.Functions
 {
-    using NPOI.SS.Formula.Eval;
-    using NPOI.SS.Formula.Functions;
     /**
      * Implementation of the HLOOKUP() function.<p/>
      * 
@@ -61,7 +61,7 @@ namespace NPOI.SS.Formula.Functions
                 bool IsRangeLookup = LookupUtils.ResolveRangeLookupArg(arg3, srcCellRow, srcCellCol);
                 int colIndex = LookupUtils.lookupFirstIndexOfValue(lookupValue, LookupUtils.CreateRowVector(tableArray, 0), IsRangeLookup);
                 int rowIndex = LookupUtils.ResolveRowOrColIndexArg(args[2], srcCellRow, srcCellCol);
-                ValueVector resultCol = CreateResultColumnVector(tableArray, rowIndex);
+                LookupUtils.RowVector resultCol = CreateResultColumnVector(tableArray, rowIndex);
                 return resultCol.GetItem(colIndex);
             }
             catch (EvaluationException e)
@@ -76,7 +76,7 @@ namespace NPOI.SS.Formula.Functions
          * 
          * @(#VALUE!) if colIndex Is negative, (#REF!) if colIndex Is too high
          */
-        private static ValueVector CreateResultColumnVector(AreaEval tableArray, int rowIndex)
+        private static LookupUtils.RowVector CreateResultColumnVector(AreaEval tableArray, int rowIndex)
         {
             if (rowIndex >= tableArray.Height)
             {

--- a/main/SS/Formula/Functions/LookupUtils.cs
+++ b/main/SS/Formula/Functions/LookupUtils.cs
@@ -184,15 +184,16 @@ namespace NPOI.SS.Formula.Functions
             }
         }
 
-
-        public static ValueVector CreateRowVector(TwoDEval tableArray, int relativeRowIndex)
+        public static RowVector CreateRowVector(TwoDEval tableArray, int relativeRowIndex)
         {
             return new RowVector((AreaEval)tableArray, relativeRowIndex);
         }
-        public static ValueVector CreateColumnVector(TwoDEval tableArray, int relativeColumnIndex)
+
+        public static ColumnVector CreateColumnVector(TwoDEval tableArray, int relativeColumnIndex)
         {
             return new ColumnVector((AreaEval)tableArray, relativeColumnIndex);
         }
+
         /**
          * @return <c>null</c> if the supplied area is neither a single row nor a single colum
          */

--- a/main/SS/Formula/Functions/Mode.cs
+++ b/main/SS/Formula/Functions/Mode.cs
@@ -1,27 +1,28 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) Under one or more
-* contributor license agreements.  See the NOTICE file distributed with
-* this work for Additional information regarding copyright ownership.
-* The ASF licenses this file to You Under the Apache License, Version 2.0
-* (the "License"); you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed Under the License is distributed on an "AS Is" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations Under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) Under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for Additional information regarding copyright ownership.
+ * The ASF licenses this file to You Under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed Under the License is distributed on an "AS Is" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations Under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+
+using NPOI.Util;
+using NPOI.SS.Formula.Eval;
 
 namespace NPOI.SS.Formula.Functions
 {
-    using System;
-    using System.Collections;
-    using NPOI.Util;
-    using NPOI.SS.Formula.Eval;
-    using NPOI.SS.Formula;
     /**
      * @author Amol S. Deshmukh &lt; amolweb at ya hoo dot com &gt;
      *
@@ -76,16 +77,12 @@ namespace NPOI.SS.Formula.Functions
             double result;
             try
             {
-                IList temp = new ArrayList();
+                List<double> temp = [];
                 for (int i = 0; i < args.Length; i++)
                 {
                     CollectValues(args[i], temp);
                 }
-                double[] values = new double[temp.Count];
-                for (int i = 0; i < values.Length; i++)
-                {
-                    values[i] = (Double)temp[i];
-                }
+                double[] values = temp.ToArray();
                 result = Evaluate(values);
             }
             catch (EvaluationException e)
@@ -95,7 +92,7 @@ namespace NPOI.SS.Formula.Functions
             return new NumberEval(result);
         }
 
-        private static void CollectValues(ValueEval arg, IList temp)
+        private static void CollectValues(ValueEval arg, List<double> temp)
         {
             if (arg is TwoDEval ae)
             {
@@ -125,7 +122,7 @@ namespace NPOI.SS.Formula.Functions
 
         }
 
-        private static void CollectValue(ValueEval arg, IList temp, bool mustBeNumber)
+        private static void CollectValue(ValueEval arg, List<double> temp, bool mustBeNumber)
         {
             if (arg is ErrorEval eval)
             {

--- a/main/SS/Formula/Functions/Rank.cs
+++ b/main/SS/Formula/Functions/Rank.cs
@@ -104,7 +104,7 @@ namespace NPOI.SS.Formula.Functions
             }
         }
 
-        private static ValueEval eval(double arg0, AreaEval aeRange, bool descending_order)
+        private static NumberEval eval(double arg0, AreaEval aeRange, bool descending_order)
         {
             int rank = 1;
             int height = aeRange.Height;
@@ -123,7 +123,8 @@ namespace NPOI.SS.Formula.Functions
             }
             return new NumberEval(rank);
         }
-        private static ValueEval eval(double arg0, RefListEval aeRange, bool descending_order)
+
+        private static NumberEval eval(double arg0, RefListEval aeRange, bool descending_order)
         {
             int rank = 1;
 
@@ -160,9 +161,9 @@ namespace NPOI.SS.Formula.Functions
 
             return new NumberEval(rank);
         }
+
         private static Double GetValue(AreaEval aeRange, int relRowIndex, int relColIndex)
         {
-
             ValueEval addend = aeRange.GetRelativeValue(relRowIndex, relColIndex);
             if (addend is NumberEval numberEval)
             {
@@ -184,7 +185,5 @@ namespace NPOI.SS.Formula.Functions
             }
             throw new EvaluationException(ErrorEval.VALUE_INVALID);
         }
-
     }
-
 }

--- a/main/SS/Formula/Functions/Subtotal.cs
+++ b/main/SS/Formula/Functions/Subtotal.cs
@@ -15,9 +15,8 @@
    limitations under the License.
 ==================================================================== */
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
+
 using NPOI.SS.Formula.Eval;
 using NPOI.Util;
 
@@ -111,15 +110,13 @@ namespace NPOI.SS.Formula.Functions
             }
 
             // ignore the first arg, this is the function-type, we check for the length above
-            IList<ValueEval> list = new List<ValueEval>(Arrays.AsList(args).GetRange(1, args.Length - 1));
-            IEnumerator<ValueEval> it = list.GetEnumerator();
+            List<ValueEval> list = new List<ValueEval>(Arrays.AsList(args).GetRange(1, args.Length - 1));
             // See https://support.office.com/en-us/article/SUBTOTAL-function-7b027003-f060-4ade-9040-e478765b9939
             // "If there are other subtotals within ref1, ref2,... (or nested subtotals), these nested subtotals are ignored to avoid double counting."
             // For array references it is handled in1 other evaluation steps, but we need to handle this here for references to subtotal-functions
-            IList<ValueEval> toRemove = new List<ValueEval>();
-            while (it.MoveNext())
+            List<ValueEval> toRemove = [];
+            foreach (var eval in list)
             {
-                ValueEval eval = it.Current;
                 if (eval is LazyRefEval lazyRefEval)
                 {
                     if (lazyRefEval.IsSubTotal)
@@ -129,8 +126,10 @@ namespace NPOI.SS.Formula.Functions
                 }
             }
 
-            foreach (var x in toRemove)
+            foreach(var x in toRemove)
+            {
                 list.Remove(x);
+            }
 
             return innerFunc.Evaluate(list.ToArray(), srcRowIndex, srcColumnIndex);
 

--- a/main/SS/Formula/Functions/Sumproduct.cs
+++ b/main/SS/Formula/Functions/Sumproduct.cs
@@ -87,7 +87,7 @@ namespace NPOI.SS.Formula.Functions
                     + firstArg.GetType().Name + ")");
         }
 
-        private static ValueEval EvaluateSingleProduct(ValueEval[] evalArgs)
+        private static NumberEval EvaluateSingleProduct(ValueEval[] evalArgs)
         {
             int maxN = evalArgs.Length;
 

--- a/main/SS/Formula/Functions/Vlookup.cs
+++ b/main/SS/Formula/Functions/Vlookup.cs
@@ -102,7 +102,7 @@ namespace NPOI.SS.Formula.Functions
                 bool isRangeLookup = LookupUtils.ResolveRangeLookupArg(range_lookup, srcRowIndex, srcColumnIndex);
                 int rowIndex = LookupUtils.lookupFirstIndexOfValue(lookupValue, LookupUtils.CreateColumnVector(tableArray, 0), isRangeLookup);
                 int colIndex = LookupUtils.ResolveRowOrColIndexArg(col_index, srcRowIndex, srcColumnIndex);
-                ValueVector resultCol = CreateResultColumnVector(tableArray, colIndex);
+                LookupUtils.ColumnVector resultCol = CreateResultColumnVector(tableArray, colIndex);
                 return resultCol.GetItem(rowIndex);
             }
             catch (EvaluationException e)
@@ -117,7 +117,7 @@ namespace NPOI.SS.Formula.Functions
          * 
          * @(#VALUE!) if colIndex Is negative, (#REF!) if colIndex Is too high
          */
-        private static ValueVector CreateResultColumnVector(TwoDEval tableArray, int colIndex)
+        private static LookupUtils.ColumnVector CreateResultColumnVector(TwoDEval tableArray, int colIndex)
         {
             if (colIndex >= tableArray.Width)
             {

--- a/main/SS/Formula/WorkbookEvaluator.cs
+++ b/main/SS/Formula/WorkbookEvaluator.cs
@@ -21,8 +21,6 @@ using NPOI.SS.Formula.Atp;
 namespace NPOI.SS.Formula
 {
     using System;
-    using System.Collections;
-    using NPOI.SS.Formula;
     using NPOI.SS.Formula.Eval;
     using NPOI.SS.Util;
     using NPOI.SS.Formula.Functions;
@@ -57,7 +55,7 @@ namespace NPOI.SS.Formula
         private readonly Dictionary<String, int> _sheetIndexesByName;
         private CollaboratingWorkbooksEnvironment _collaboratingWorkbookEnvironment;
         private readonly IStabilityClassifier _stabilityClassifier;
-        private readonly UDFFinder _udfFinder;
+        private readonly AggregatingUDFFinder _udfFinder;
 
         private bool _ignoreMissingWorkbooks = false;
 

--- a/main/SS/UserModel/DataFormatter.cs
+++ b/main/SS/UserModel/DataFormatter.cs
@@ -15,23 +15,21 @@
    limitations under the License.
 ==================================================================== */
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+
+using NPOI.SS.Util;
+using NPOI.SS.Format;
+using NPOI.SS.Formula;
+using NPOI.Util;
+
+using Cysharp.Text;
+
 namespace NPOI.SS.UserModel
 {
-    using System;
-    using System.Collections;
-    using System.Text; 
-using Cysharp.Text;
-    using System.Text.RegularExpressions;
-
-    using NPOI.SS.Util;
-    using System.Globalization;
-    using NPOI.SS.Format;
-    using NPOI.Util;
-    using System.Collections.Generic;
-    using NPOI.SS.Formula;
-    using System.Runtime.Serialization;
-
-
     /**
      * HSSFDataFormatter contains methods for Formatting the value stored in an
      * Cell. This can be useful for reports and GUI presentations when you
@@ -169,7 +167,7 @@ using Cysharp.Text;
         /**
          * A default date format, if no date format was given
          */
-        private readonly DateFormat defaultDateformat;
+        private readonly SimpleDateFormat defaultDateformat;
 
         /** <em>General</em> FormatBase for whole numbers. */
         //private static DecimalFormat generalWholeNumFormat = new DecimalFormat("0");
@@ -186,7 +184,7 @@ using Cysharp.Text;
          * A map to cache formats.
          *  Map<String,FormatBase> Formats
          */
-        private readonly Hashtable formats;
+        private readonly Dictionary<string, FormatBase> formats;
 
         /** whether CSV friendly adjustments should be made to the formatted text **/
         private readonly bool emulateCSV = false;
@@ -267,7 +265,7 @@ using Cysharp.Text;
             defaultDateformat = new SimpleDateFormat(dateSymbols.FullDateTimePattern, dateSymbols);
             defaultDateformat.TimeZone = TimeZoneInfo.Local;
 
-            formats = new Hashtable();
+            formats = new Dictionary<string, FormatBase>();
 
             // init built-in Formats
             FormatBase zipFormat = ZipPlusFourFormat.Instance;
@@ -403,7 +401,8 @@ using Cysharp.Text;
             {
                 formatStr = formatStr.Replace("#", "");
             }
-            FormatBase format = (FormatBase)formats[formatStr];
+
+            formats.TryGetValue(formatStr, out FormatBase format);
             if (format != null)
             {
                 return format;
@@ -1170,10 +1169,8 @@ using Cysharp.Text;
          */
         public void SetDefaultNumberFormat(FormatBase format)
         {
-            IEnumerator itr = formats.Keys.GetEnumerator();
-            while (itr.MoveNext())
+            foreach (var key in formats.Keys)
             {
-                string key = (string)itr.Current;
                 if (formats[key] == generalNumberFormat)
                 {
                     formats[key] = format;

--- a/main/SS/UserModel/Helpers/RowShifter.cs
+++ b/main/SS/UserModel/Helpers/RowShifter.cs
@@ -47,8 +47,8 @@ namespace NPOI.SS.UserModel.Helpers
         /// <returns>an array of affected merged regions, doesn't contain deleted ones</returns>
         public List<CellRangeAddress> ShiftMergedRegions(int startRow, int endRow, int n)
         {
-            var ShiftedRegions = new List<CellRangeAddress>();
-            ISet<int> removedIndices = new HashSet<int>();
+            List<CellRangeAddress> ShiftedRegions = [];
+            HashSet<int> removedIndices = [];
             var size = sheet.NumMergedRegions;
 
             for (var i = 0; i < size; i++)

--- a/main/SS/Util/CellUtil.cs
+++ b/main/SS/Util/CellUtil.cs
@@ -58,42 +58,36 @@ namespace NPOI.SS.Util
         public const string VERTICAL_ALIGNMENT = "verticalAlignment";
         public const string WRAP_TEXT = "wrapText";
 
-        private static ISet<String> shortValues = new HashSet<string>(new string[]{
-                    BOTTOM_BORDER_COLOR,
-                    LEFT_BORDER_COLOR,
-                    RIGHT_BORDER_COLOR,
-                    TOP_BORDER_COLOR,
-                    FILL_FOREGROUND_COLOR,
-                    FILL_BACKGROUND_COLOR,
-                    INDENTION,
-                    DATA_FORMAT,
-                    ROTATION
-            });
-        private static ISet<String> intValues = new HashSet<string>(new string[]{
-                        FONT
-        });
-        private static ISet<String> booleanValues = new HashSet<string>(new string[]{
-                        LOCKED,
-                        HIDDEN,
-                        WRAP_TEXT
-        });
-        private static ISet<String> borderTypeValues = new HashSet<string>(new string[]{
-                        BORDER_BOTTOM,
-                        BORDER_LEFT,
-                        BORDER_RIGHT,
-                        BORDER_TOP
-        });
+        private static readonly HashSet<string> shortValues =
+        [
+            BOTTOM_BORDER_COLOR,
+            LEFT_BORDER_COLOR,
+            RIGHT_BORDER_COLOR,
+            TOP_BORDER_COLOR,
+            FILL_FOREGROUND_COLOR,
+            FILL_BACKGROUND_COLOR,
+            INDENTION,
+            DATA_FORMAT,
+            ROTATION
+        ];
 
+        private static readonly HashSet<string> intValues = [FONT];
 
-        private static UnicodeMapping[] unicodeMappings;
+        private static readonly HashSet<string> booleanValues = [LOCKED, HIDDEN, WRAP_TEXT];
+
+        private static readonly HashSet<string> borderTypeValues =
+        [
+            BORDER_BOTTOM, BORDER_LEFT, BORDER_RIGHT, BORDER_TOP
+        ];
+
+        private static readonly UnicodeMapping[] unicodeMappings;
 
         private sealed class UnicodeMapping
         {
+            public readonly string entityName;
+            public readonly string resolvedValue;
 
-            public String entityName;
-            public String resolvedValue;
-
-            public UnicodeMapping(String pEntityName, String pResolvedValue)
+            public UnicodeMapping(string pEntityName, string pResolvedValue)
             {
                 entityName = "&" + pEntityName + ";";
                 resolvedValue = pResolvedValue;

--- a/main/Util/RLEDecompressingInputStream.cs
+++ b/main/Util/RLEDecompressingInputStream.cs
@@ -323,7 +323,7 @@ namespace NPOI.Util
             return (b0 & 0xFF) | ((b1 & 0xFF) << 8);
         }
 
-        private static int ReadInt(InputStream stream)
+        private static int ReadInt(RLEDecompressingInputStream stream)
         {
             int b0, b1, b2, b3;
             if ((b0 = stream.Read()) == -1)
@@ -352,9 +352,9 @@ namespace NPOI.Util
 
         public static byte[] Decompress(byte[] compressed, int offset, int length)
         {
-            MemoryStream out1 = new MemoryStream();
-            Stream instream = new MemoryStream(compressed, offset, length);
-            InputStream stream = new RLEDecompressingInputStream(instream);
+            using MemoryStream out1 = new MemoryStream();
+            using Stream instream = new MemoryStream(compressed, offset, length);
+            using RLEDecompressingInputStream stream = new RLEDecompressingInputStream(instream);
             IOUtils.Copy(stream, out1);
             stream.Close();
             out1.Close();

--- a/ooxml/POIFS/Crypt/Agile/AgileEncryptionVerifier.cs
+++ b/ooxml/POIFS/Crypt/Agile/AgileEncryptionVerifier.cs
@@ -47,7 +47,7 @@ namespace NPOI.POIFS.Crypt.Agile
 
         protected internal AgileEncryptionVerifier(EncryptionDocument ed)
         {
-            IEnumerator<CT_KeyEncryptor> encList = ed.GetEncryption().keyEncryptors.keyEncryptor.GetEnumerator();
+            List<CT_KeyEncryptor>.Enumerator encList = ed.GetEncryption().keyEncryptors.keyEncryptor.GetEnumerator();
             CT_PasswordKeyEncryptor keyData;
             try
             {

--- a/ooxml/XSSF/Extractor/XSSFExportToXml.cs
+++ b/ooxml/XSSF/Extractor/XSSFExportToXml.cs
@@ -335,7 +335,7 @@ namespace NPOI.XSSF.Extractor
 
         private static String GetFormattedDate(XSSFCell cell)
         {
-            DateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
             sdf.TimeZone= LocaleUtil.GetUserTimeZoneInfo();
             return sdf.Format(cell.DateCellValue);
         }

--- a/ooxml/XSSF/Streaming/SXSSFCell.cs
+++ b/ooxml/XSSF/Streaming/SXSSFCell.cs
@@ -595,7 +595,7 @@ namespace NPOI.XSSF.Streaming
                 case CellType.Numeric:
                     if (DateUtil.IsCellDateFormatted(this))
                     {
-                        FormatBase sdf = new SimpleDateFormat("dd-MMM-yyyy");
+                        SimpleDateFormat sdf = new SimpleDateFormat("dd-MMM-yyyy");
                         //sdf.setTimeZone(LocaleUtil.getUserTimeZone());
                         return sdf.Format(DateCellValue);
                     }

--- a/ooxml/XSSF/Streaming/SheetDataWriter.cs
+++ b/ooxml/XSSF/Streaming/SheetDataWriter.cs
@@ -136,7 +136,7 @@ namespace NPOI.XSSF.Streaming
          */
         public Stream GetWorksheetXmlInputStream()
         {
-            Stream fis = new FileStream(TemporaryFileInfo.FullName, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+            FileStream fis = new FileStream(TemporaryFileInfo.FullName, FileMode.OpenOrCreate, FileAccess.ReadWrite);
             try
             {
                 return DecorateInputStream(fis);

--- a/ooxml/XSSF/UserModel/Helpers/ColumnShifter.cs
+++ b/ooxml/XSSF/UserModel/Helpers/ColumnShifter.cs
@@ -15,12 +15,12 @@
    limitations under the License.
 ==================================================================== */
 
+using System.Collections.Generic;
+using System.Linq;
+
 using NPOI.SS.Formula;
 using NPOI.SS.UserModel;
 using NPOI.SS.Util;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace NPOI.XSSF.UserModel.Helpers
 {
@@ -53,8 +53,8 @@ namespace NPOI.XSSF.UserModel.Helpers
             int endColumn,
             int n)
         {
-            List<CellRangeAddress> shiftedRegions = new List<CellRangeAddress>();
-            ISet<int> removedIndices = new HashSet<int>();
+            List<CellRangeAddress> shiftedRegions = [];
+            HashSet<int> removedIndices = [];
             //move merged regions completely if they fall within the new region
             //boundaries when they are Shifted
             int size = sheet.NumMergedRegions;

--- a/ooxml/XSSF/UserModel/Helpers/XSSFIgnoredErrorHelper.cs
+++ b/ooxml/XSSF/UserModel/Helpers/XSSFIgnoredErrorHelper.cs
@@ -103,10 +103,10 @@ namespace NPOI.XSSF.UserModel.Helpers
 
         public static ISet<IgnoredErrorType> GetErrorTypes(CT_IgnoredError err)
         {
-            ISet<IgnoredErrorType> result = new HashSet<IgnoredErrorType>();
+            HashSet<IgnoredErrorType> result = [];
             foreach (IgnoredErrorType errType in IgnoredErrorTypeValues.Values)
             {
-                if (XSSFIgnoredErrorHelper.IsSet(errType, err))
+                if (IsSet(errType, err))
                 {
                     result.Add(errType);
                 }

--- a/ooxml/XSSF/UserModel/XSSFCell.cs
+++ b/ooxml/XSSF/UserModel/XSSFCell.cs
@@ -660,7 +660,8 @@ namespace NPOI.XSSF.UserModel
             //un-register the single-cell array formula from the parent sheet through public interface
             Row.Sheet.RemoveArrayFormula(this);
         }
-        private ICell SetFormula(String formula, FormulaType formulaType)
+
+        private XSSFCell SetFormula(String formula, FormulaType formulaType)
         {
             XSSFWorkbook wb = (XSSFWorkbook)_row.Sheet.Workbook;
             if (formula == null)
@@ -1090,7 +1091,7 @@ namespace NPOI.XSSF.UserModel
                 case CellType.Numeric:
                     if (DateUtil.IsCellDateFormatted(this))
                     {
-                        FormatBase sdf = new SimpleDateFormat("dd-MMM-yyyy");
+                        SimpleDateFormat sdf = new SimpleDateFormat("dd-MMM-yyyy");
                         return sdf.Format(DateCellValue, CultureInfo.CurrentCulture);
                     }
                     return NumericCellValue.ToString();
@@ -1140,7 +1141,7 @@ namespace NPOI.XSSF.UserModel
         /**
          * Used to help format error messages
          */
-        private static Exception TypeMismatch(CellType expectedTypeCode, CellType actualTypeCode, bool isFormulaCell)
+        private static InvalidOperationException TypeMismatch(CellType expectedTypeCode, CellType actualTypeCode, bool isFormulaCell)
         {
             String msg = "Cannot get a "
                 + GetCellTypeName(expectedTypeCode) + " value from a "

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -1591,7 +1591,7 @@ namespace NPOI.XSSF.UserModel
             }
         }
 
-        internal bool IsCellInArrayFormulaContext(ICell cell)
+        internal bool IsCellInArrayFormulaContext(XSSFCell cell)
         {
             foreach(CellRangeAddress range in arrayFormulas)
             {
@@ -1604,7 +1604,7 @@ namespace NPOI.XSSF.UserModel
             return false;
         }
 
-        internal XSSFCell GetFirstCellInArrayFormula(ICell cell)
+        internal XSSFCell GetFirstCellInArrayFormula(XSSFCell cell)
         {
             foreach(CellRangeAddress range in arrayFormulas)
             {
@@ -2996,8 +2996,8 @@ namespace NPOI.XSSF.UserModel
                 throw new ArgumentException("No rows to copy");
             }
 
-            IRow srcStartRow = srcRows[0];
-            IRow srcEndRow = srcRows[srcRows.Count - 1];
+            XSSFRow srcStartRow = srcRows[0];
+            XSSFRow srcEndRow = srcRows[srcRows.Count - 1];
 
             if(srcStartRow == null)
             {
@@ -3012,7 +3012,7 @@ namespace NPOI.XSSF.UserModel
             int size = srcRows.Count;
             for(int index = 1; index < size; index++)
             {
-                IRow curRow = srcRows[index];
+                XSSFRow curRow = srcRows[index];
                 if(curRow == null)
                 {
                     throw new ArgumentException(
@@ -3565,8 +3565,7 @@ namespace NPOI.XSSF.UserModel
 
         public ICellRange<ICell> SetArrayFormula(string formula, CellRangeAddress range)
         {
-
-            ICellRange<ICell> cr = GetCellRange(range);
+            SSCellRange<ICell> cr = GetCellRange(range);
 
             ICell mainArrayFormulaCell = cr.TopLeftCell;
             ((XSSFCell) mainArrayFormulaCell).SetCellArrayFormula(formula, range);
@@ -4181,7 +4180,7 @@ namespace NPOI.XSSF.UserModel
 
             XSSFSheet newSheet = (XSSFSheet) dest.CreateSheet(name);
             newSheet.sheet.state = sheet.state;
-            IDictionary<int, ICellStyle> styleMap = copyStyle ? new Dictionary<int, ICellStyle>() : null;
+            Dictionary<int, ICellStyle> styleMap = copyStyle ? new Dictionary<int, ICellStyle>() : null;
             for(int i = FirstRowNum; i <= LastRowNum; i++)
             {
                 XSSFRow srcRow = (XSSFRow) GetRow(i);
@@ -5669,7 +5668,7 @@ namespace NPOI.XSSF.UserModel
         /// </summary>
         /// <param name="range"></param>
         /// <returns></returns>
-        private ICellRange<ICell> GetCellRange(CellRangeAddress range)
+        private SSCellRange<ICell> GetCellRange(CellRangeAddress range)
         {
             int firstRow = range.FirstRow;
             int firstColumn = range.FirstColumn;
@@ -5955,7 +5954,7 @@ namespace NPOI.XSSF.UserModel
         }
 
         private static void CopyRow(XSSFSheet srcSheet, XSSFSheet destSheet, XSSFRow srcRow, XSSFRow destRow,
-            IDictionary<int, ICellStyle> styleMap, bool keepFormulas, bool keepMergedRegion)
+            Dictionary<int, ICellStyle> styleMap, bool keepFormulas, bool keepMergedRegion)
         {
             destRow.Height = srcRow.Height;
             if(!srcRow.GetCTRow().IsSetCustomHeight())
@@ -6017,8 +6016,7 @@ namespace NPOI.XSSF.UserModel
             }
         }
 
-        private static void CopyCell(ICell oldCell, ICell newCell, IDictionary<int, ICellStyle> styleMap,
-            bool keepFormulas)
+        private static void CopyCell(XSSFCell oldCell, XSSFCell newCell, Dictionary<int, ICellStyle> styleMap, bool keepFormulas)
         {
             if(styleMap != null)
             {
@@ -6206,9 +6204,9 @@ namespace NPOI.XSSF.UserModel
             XSSFIgnoredErrorHelper.AddIgnoredErrors(ctIgnoredError, ref1, ignoredErrorTypes);
         }
 
-        private static ISet<IgnoredErrorType> GetErrorTypes(CT_IgnoredError err)
+        private static HashSet<IgnoredErrorType> GetErrorTypes(CT_IgnoredError err)
         {
-            ISet<IgnoredErrorType> result = new HashSet<IgnoredErrorType>();
+            HashSet<IgnoredErrorType> result = [];
 
             foreach(IgnoredErrorType errType in IgnoredErrorTypeValues.Values)
             {

--- a/ooxml/XSSF/UserModel/XSSFWorkbook.cs
+++ b/ooxml/XSSF/UserModel/XSSFWorkbook.cs
@@ -2311,7 +2311,7 @@ namespace NPOI.XSSF.UserModel
          * @return wrapped instance of UDFFinder that allows seeking functions both by index and name
          */
         /*package*/
-        internal UDFFinder GetUDFFinder()
+        internal IndexedUDFFinder GetUDFFinder()
         {
             return _udfFinder;
         }

--- a/ooxml/XWPF/Usermodel/XWPFDocument.cs
+++ b/ooxml/XWPF/Usermodel/XWPFDocument.cs
@@ -19,18 +19,17 @@
 namespace NPOI.XWPF.UserModel
 {
     using System;
-    using System.IO;
-    using NPOI.Util;
     using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Xml;
+
+    using NPOI.Util;
     using NPOI.OpenXml4Net.OPC;
     using NPOI.OpenXmlFormats.Wordprocessing;
-    using System.Xml;
     using NPOI.WP.UserModel;
     using NPOI.XWPF.Model;
-    using System.Xml.Serialization;
-    using System.Diagnostics;
     using NPOI.OOXML.XWPF.Util;
-    using System.Linq;
     using NPOI.POIFS.Crypt;
 
     /**
@@ -449,10 +448,8 @@ namespace NPOI.XWPF.UserModel
 
         public XWPFHyperlink GetHyperlinkByID(String id)
         {
-            IEnumerator<XWPFHyperlink> iter = hyperlinks.GetEnumerator();
-            while (iter.MoveNext())
+            foreach (XWPFHyperlink link in hyperlinks)
             {
-                XWPFHyperlink link = iter.Current;
                 if (link.Id.Equals(id))
                     return link;
             }
@@ -462,16 +459,11 @@ namespace NPOI.XWPF.UserModel
 
         public XWPFFootnote GetFootnoteByID(int id)
         {
-            if (footnotes == null) return null;
-            return footnotes.GetFootnoteById(id);
+            return footnotes?.GetFootnoteById(id);
         }
-        public Dictionary<int, XWPFFootnote> Endnotes
-        {
-            get
-            {
-                return endnotes;
-            }
-        }
+
+        public Dictionary<int, XWPFFootnote> Endnotes => endnotes;
+
         public XWPFFootnote GetEndnoteByID(int id)
         {
             if (endnotes == null || !endnotes.TryGetValue(id, out XWPFFootnote byId)) 
@@ -483,7 +475,7 @@ namespace NPOI.XWPF.UserModel
         {
             if (footnotes == null)
             {
-                return new List<XWPFFootnote>();
+                return [];
             }
             return footnotes.GetFootnotesList();
         }
@@ -1589,18 +1581,15 @@ namespace NPOI.XWPF.UserModel
              * Try to find PictureData with this Checksum. Create new, if none
              * exists.
              */
-            List<XWPFPictureData> xwpfPicDataList = null;
-            if(packagePictures.TryGetValue(Checksum, out List<XWPFPictureData> picture))
-               xwpfPicDataList = picture;
-            if (xwpfPicDataList != null)
+
+            if (packagePictures.TryGetValue(Checksum, out List<XWPFPictureData> xwpfPicDataList))
             {
-                IEnumerator<XWPFPictureData> iter = xwpfPicDataList.GetEnumerator();
-                while (iter.MoveNext() && xwpfPicData == null)
+                foreach (XWPFPictureData curElem in xwpfPicDataList)
                 {
-                    XWPFPictureData curElem = iter.Current;
                     if (Arrays.Equals(pictureData, curElem.Data))
                     {
                         xwpfPicData = curElem;
+                        break;
                     }
                 }
             }

--- a/ooxml/XWPF/Usermodel/XWPFFooter.cs
+++ b/ooxml/XWPF/Usermodel/XWPFFooter.cs
@@ -175,10 +175,8 @@ namespace NPOI.XWPF.UserModel
 
         public XWPFHyperlink GetHyperlinkByID(string id)
         {
-            IEnumerator<XWPFHyperlink> iter = hyperlinks.GetEnumerator();
-            while (iter.MoveNext())
+            foreach (XWPFHyperlink link in hyperlinks)
             {
-                XWPFHyperlink link = iter.Current;
                 if (link.Id.Equals(id))
                     return link;
             }

--- a/ooxml/XWPF/Usermodel/XWPFFootnotes.cs
+++ b/ooxml/XWPF/Usermodel/XWPFFootnotes.cs
@@ -15,17 +15,16 @@
    limitations under the License.
 ==================================================================== */
 
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml;
+
+using NPOI.OpenXmlFormats.Wordprocessing;
+using NPOI.OpenXml4Net.OPC;
+
 namespace NPOI.XWPF.UserModel
 {
-    using System;
-    using System.Collections.Generic;
-    using NPOI.OpenXmlFormats.Wordprocessing;
-    using NPOI.OpenXml4Net.OPC;
-    using System.IO;
-    using System.Xml;
-    using System.Xml.Serialization;
-
-
     /**
      * Looks After the collection of Footnotes for a document
      *  
@@ -33,9 +32,9 @@ namespace NPOI.XWPF.UserModel
      */
     public class XWPFFootnotes : POIXMLDocumentPart
     {
-        private List<XWPFFootnote> listFootnote = new List<XWPFFootnote>();
+        private readonly List<XWPFFootnote> listFootnote = [];
         private CT_Footnotes ctFootnotes;
-        private List<XWPFHyperlink> hyperlinks = new List<XWPFHyperlink>();
+        private readonly List<XWPFHyperlink> hyperlinks = [];
 
         protected XWPFDocument document;
 
@@ -244,14 +243,14 @@ namespace NPOI.XWPF.UserModel
             }
         }
 
-        public XWPFHyperlink GetHyperlinkByID(String id)
+        public XWPFHyperlink GetHyperlinkByID(string id)
         {
-            IEnumerator<XWPFHyperlink> iter = hyperlinks.GetEnumerator();
-            while (iter.MoveNext())
+            foreach (XWPFHyperlink link in hyperlinks)
             {
-                XWPFHyperlink link = iter.Current;
-                if (link.Id.Equals(id))
+                if(link.Id.Equals(id))
+                {
                     return link;
+                }
             }
 
             return null;

--- a/openxml4Net/OPC/Internal/Unmarshallers/PackagePropertiesUnmarshaller.cs
+++ b/openxml4Net/OPC/Internal/Unmarshallers/PackagePropertiesUnmarshaller.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Xml;
+﻿using System.Collections;
 using System.IO;
-using System.Collections;
+using System.Xml;
+
 using NPOI.OpenXml4Net.Exceptions;
-using ICSharpCode.SharpZipLib.Zip;
 using NPOI.Util;
+
+using ICSharpCode.SharpZipLib.Zip;
+
 namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
 {
     /**
@@ -17,52 +17,51 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
      */
     public class PackagePropertiesUnmarshaller : PartUnmarshaller
     {
+        private const string namespaceDC = "http://purl.org/dc/elements/1.1/";
+
+        private const string namespaceCP = PackageNamespaces.CORE_PROPERTIES;
+
+        private const string namespaceDcTerms = "http://purl.org/dc/terms/";
+
+        private const string namespaceXML = "http://www.w3.org/XML/1998/namespace";
+
+        private const string namespaceXSI = "http://www.w3.org/2001/XMLSchema-instance";
+
+        protected static string KEYWORD_CATEGORY = "category";
+
+        protected static string KEYWORD_CONTENT_STATUS = "contentStatus";
+
+        protected static string KEYWORD_CONTENT_TYPE = "contentType";
+
+        protected static string KEYWORD_CREATED = "created";
+
+        protected static string KEYWORD_CREATOR = "creator";
+
+        protected static string KEYWORD_DESCRIPTION = "description";
+
+        protected static string KEYWORD_IDENTIFIER = "identifier";
+
+        protected static string KEYWORD_KEYWORDS = "keywords";
+
+        protected static string KEYWORD_LANGUAGE = "language";
+
+        protected static string KEYWORD_LAST_MODIFIED_BY = "lastModifiedBy";
+
+        protected static string KEYWORD_LAST_PRINTED = "lastPrinted";
+
+        protected static string KEYWORD_MODIFIED = "modified";
+
+        protected static string KEYWORD_REVISION = "revision";
+
+        protected static string KEYWORD_SUBJECT = "subject";
+
+        protected static string KEYWORD_TITLE = "title";
+
+        protected static string KEYWORD_VERSION = "version";
 
 
+        protected XmlNamespaceManager nsmgr;
 
-        private static string namespaceDC = "http://purl.org/dc/elements/1.1/";
-
-        private static string namespaceCP = PackageNamespaces.CORE_PROPERTIES;
-        private static string namespaceDcTerms = "http://purl.org/dc/terms/";
-
-        private static string namespaceXML = "http://www.w3.org/XML/1998/namespace";
-
-        private static string namespaceXSI = "http://www.w3.org/2001/XMLSchema-instance";
-
-        protected static String KEYWORD_CATEGORY = "category";
-
-        protected static String KEYWORD_CONTENT_STATUS = "contentStatus";
-
-        protected static String KEYWORD_CONTENT_TYPE = "contentType";
-
-        protected static String KEYWORD_CREATED = "created";
-
-        protected static String KEYWORD_CREATOR = "creator";
-
-        protected static String KEYWORD_DESCRIPTION = "description";
-
-        protected static String KEYWORD_IDENTIFIER = "identifier";
-
-        protected static String KEYWORD_KEYWORDS = "keywords";
-
-        protected static String KEYWORD_LANGUAGE = "language";
-
-        protected static String KEYWORD_LAST_MODIFIED_BY = "lastModifiedBy";
-
-        protected static String KEYWORD_LAST_PRINTED = "lastPrinted";
-
-        protected static String KEYWORD_MODIFIED = "modified";
-
-        protected static String KEYWORD_REVISION = "revision";
-
-        protected static String KEYWORD_SUBJECT = "subject";
-
-        protected static String KEYWORD_TITLE = "title";
-
-        protected static String KEYWORD_VERSION = "version";
-
-
-        protected XmlNamespaceManager nsmgr = null;
         // TODO Load element with XMLBeans or dynamic table
         // TODO Check every element/namespace for compliance
         public PackagePart Unmarshall(UnmarshallContext context, Stream in1)
@@ -158,7 +157,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return coreProps;
         }
 
-        private String LoadCategory(XmlDocument xmlDoc)
+        private string LoadCategory(XmlDocument xmlDoc)
         {
             XmlNode el = xmlDoc.DocumentElement.SelectNodes("cp:" + KEYWORD_CATEGORY, nsmgr)[0];
 
@@ -169,7 +168,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadContentStatus(XmlDocument xmlDoc)
+        private string LoadContentStatus(XmlDocument xmlDoc)
         {
             XmlNode el = xmlDoc.DocumentElement.SelectNodes("cp:" + KEYWORD_CONTENT_STATUS, nsmgr)[0];
             if (el == null)
@@ -179,7 +178,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadContentType(XmlDocument xmlDoc)
+        private string LoadContentType(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_CONTENT_TYPE, namespaceCP));
@@ -191,7 +190,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadCreated(XmlDocument xmlDoc)
+        private string LoadCreated(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_CREATED, namespaceDcTerms));
@@ -203,7 +202,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadCreator(XmlDocument xmlDoc)
+        private string LoadCreator(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_CREATOR, namespaceDC));
@@ -215,7 +214,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadDescription(XmlDocument xmlDoc)
+        private string LoadDescription(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_DESCRIPTION, namespaceDC));
@@ -227,7 +226,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadIdentifier(XmlDocument xmlDoc)
+        private string LoadIdentifier(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_IDENTIFIER, namespaceDC));
@@ -239,7 +238,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadKeywords(XmlDocument xmlDoc)
+        private string LoadKeywords(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_KEYWORDS, namespaceCP));
@@ -252,7 +251,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadLanguage(XmlDocument xmlDoc)
+        private string LoadLanguage(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_LANGUAGE, namespaceDC));
@@ -264,7 +263,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadLastModifiedBy(XmlDocument xmlDoc)
+        private string LoadLastModifiedBy(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_LAST_MODIFIED_BY, namespaceCP));
@@ -276,7 +275,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadLastPrinted(XmlDocument xmlDoc)
+        private string LoadLastPrinted(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_LAST_PRINTED, namespaceCP));
@@ -288,7 +287,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadModified(XmlDocument xmlDoc)
+        private string LoadModified(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_MODIFIED, namespaceDcTerms));
@@ -300,7 +299,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadRevision(XmlDocument xmlDoc)
+        private string LoadRevision(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_REVISION, namespaceCP));
@@ -312,7 +311,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadSubject(XmlDocument xmlDoc)
+        private string LoadSubject(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_SUBJECT, namespaceDC));
@@ -324,7 +323,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadTitle(XmlDocument xmlDoc)
+        private string LoadTitle(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_TITLE, namespaceDC));
@@ -336,7 +335,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
             return el.InnerText;
         }
 
-        private String LoadVersion(XmlDocument xmlDoc)
+        private string LoadVersion(XmlDocument xmlDoc)
         {
             //Element el = xmlDoc.getRootElement().element(
             //        new QName(KEYWORD_VERSION, namespaceCP));
@@ -415,7 +414,7 @@ namespace NPOI.OpenXml4Net.OPC.Internal.Unmarshallers
                             + PackageNamespaces.NAMESPACE_DCTERMS);
 
                 // Check for the 'xsi:type' attribute
-                XmlNode typeAtt = el.Attributes["type", XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI];// el.Attributes["xsi:type"];
+                XmlAttribute typeAtt = el.Attributes["type", XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI];// el.Attributes["xsi:type"];
                 if (typeAtt == null)
                     throw new InvalidFormatException("The element '" + elName
                             + "' must have the '" + nsmgr.LookupPrefix(namespaceXSI)

--- a/openxml4Net/OPC/Internal/ZipContentTypeManager.cs
+++ b/openxml4Net/OPC/Internal/ZipContentTypeManager.cs
@@ -1,71 +1,78 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.IO;
+﻿using System.IO;
 using System.Xml;
 using ICSharpCode.SharpZipLib.Zip;
 using NPOI.Util;
+
 namespace NPOI.OpenXml4Net.OPC.Internal
 {
-/**
- * Zip implementation of the ContentTypeManager.
- * 
- * @author Julien Chable
- * @version 1.0
- * @see ContentTypeManager
- */
-public class ZipContentTypeManager:ContentTypeManager {
-    
-    private static POILogger logger = POILogFactory.GetLogger(typeof(ZipContentTypeManager));
-	/**
-	 * Delegate constructor to the super constructor.
-	 * 
-	 * @param in
-	 *            The input stream to parse to fill internal content type
-	 *            collections.
-	 * @throws InvalidFormatException
-	 *             If the content types part content is not valid.
-	 */
-	public ZipContentTypeManager(Stream in1, OPCPackage pkg):base(in1, pkg)
-	{
-		
-	}
+    /**
+     * Zip implementation of the ContentTypeManager.
+     *
+     * @author Julien Chable
+     * @version 1.0
+     * @see ContentTypeManager
+     */
+    public class ZipContentTypeManager : ContentTypeManager
+    {
+        private static readonly POILogger logger = POILogFactory.GetLogger(typeof(ZipContentTypeManager));
 
-	
-	public override bool SaveImpl(XmlDocument content, Stream out1) {
-		ZipOutputStream zos = null;
-		if (out1 is ZipOutputStream stream)
-			zos = stream;
-		else
-			zos = new ZipOutputStream(out1);
+        /**
+         * Delegate constructor to the super constructor.
+         *
+         * @param in
+         *            The input stream to parse to fill internal content type
+         *            collections.
+         * @throws InvalidFormatException
+         *             If the content types part content is not valid.
+         */
+        public ZipContentTypeManager(Stream in1, OPCPackage pkg) : base(in1, pkg)
+        {
+        }
 
-        ZipEntry partEntry = new ZipEntry(CONTENT_TYPES_PART_NAME);
-		try {
-			// Referenced in ZIP
-            zos.PutNextEntry(partEntry);
-			// Saving data in the ZIP file
-			
-			StreamHelper.SaveXmlInStream(content, out1);
-            Stream ins =  new MemoryStream();
-            
-            byte[] buff = new byte[ZipHelper.READ_WRITE_FILE_BUFFER_SIZE];
-            while (true) {
-                int resultRead = ins.Read(buff, 0, ZipHelper.READ_WRITE_FILE_BUFFER_SIZE);
-                if (resultRead == 0) {
-                    // end of file reached
-                    break;
-                } else {
-                    zos.Write(buff, 0, resultRead);
+
+        public override bool SaveImpl(XmlDocument content, Stream out1)
+        {
+            ZipOutputStream zos = null;
+            if(out1 is ZipOutputStream stream)
+                zos = stream;
+            else
+                zos = new ZipOutputStream(out1);
+
+            ZipEntry partEntry = new ZipEntry(CONTENT_TYPES_PART_NAME);
+            try
+            {
+                // Referenced in ZIP
+                zos.PutNextEntry(partEntry);
+                // Saving data in the ZIP file
+
+                StreamHelper.SaveXmlInStream(content, out1);
+                using MemoryStream ins = new MemoryStream();
+
+                byte[] buff = new byte[ZipHelper.READ_WRITE_FILE_BUFFER_SIZE];
+                while(true)
+                {
+                    int resultRead = ins.Read(buff, 0, ZipHelper.READ_WRITE_FILE_BUFFER_SIZE);
+                    if(resultRead == 0)
+                    {
+                        // end of file reached
+                        break;
+                    }
+                    else
+                    {
+                        zos.Write(buff, 0, resultRead);
+                    }
                 }
-            }
-			zos.CloseEntry();
-		} catch (IOException ioe) {
-			logger.Log(POILogger.ERROR, "Cannot write: " + CONTENT_TYPES_PART_NAME
-				+ " in Zip !", ioe);
-			return false;
-		}
-		return true;
-	}
-}
 
+                zos.CloseEntry();
+            }
+            catch(IOException ioe)
+            {
+                logger.Log(POILogger.ERROR, "Cannot write: " + CONTENT_TYPES_PART_NAME
+                                                             + " in Zip !", ioe);
+                return false;
+            }
+
+            return true;
+        }
+    }
 }


### PR DESCRIPTION
It's better to return and use concrete types instead of abstract classes and interfaces as it performs better. Removed analysis ignore and fixed issues. Changes target non-public API so there should be no breaking changes to end users.

I also changed some iterator/enumerator usage more idiomatic foreach in places where analysis complained about using interface to iterate.