### PR TITLE
Remove unnecessary array allocations for Split etc

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -87,7 +87,6 @@
     <NoWarn>$(NoWarn);CA1834</NoWarn> <!-- Member XXX is explicitly initialized to its default value -->
     <NoWarn>$(NoWarn);CA1845</NoWarn> <!-- Use span-based 'string.Concat' and 'AsSpan' instead of 'Substring' -->
     <NoWarn>$(NoWarn);CA1850</NoWarn> <!-- Prefer static 'System.Security.Cryptography.MD5.HashData' method over 'ComputeHash' -->
-    <NoWarn>$(NoWarn);CA1861</NoWarn> <!-- Prefer 'static readonly' fields over constant array arguments -->
     <NoWarn>$(NoWarn);CA1862</NoWarn> <!-- Prefer the string comparison method overload -->
     <NoWarn>$(NoWarn);CA1872</NoWarn> <!-- Prefer 'System.Convert.ToHexString(byte[])' over call chains based on 'System.BitConverter.ToString(byte[])' -->
     <NoWarn>$(NoWarn);CA2019</NoWarn> <!-- 'ThreadStatic' fields should not use inline initialization -->

--- a/main/POIFS/Crypt/DataSpaceMapUtils.cs
+++ b/main/POIFS/Crypt/DataSpaceMapUtils.cs
@@ -32,14 +32,14 @@ namespace NPOI.POIFS.Crypt
         public static void AddDefaultDataSpace(DirectoryEntry dir)
         {
             DataSpaceMapEntry dsme = new DataSpaceMapEntry(
-                    new int[] { 0 }
-                  , new String[] { Decryptor.DEFAULT_POIFS_ENTRY }
-                  , "StrongEncryptionDataSpace"
+                [0]
+                , [Decryptor.DEFAULT_POIFS_ENTRY]
+                , "StrongEncryptionDataSpace"
               );
-            DataSpaceMap dsm = new DataSpaceMap(new DataSpaceMapEntry[] { dsme });
+            DataSpaceMap dsm = new DataSpaceMap([dsme]);
             CreateEncryptionEntry(dir, "\u0006DataSpaces/DataSpaceMap", dsm);
 
-            DataSpaceDefInition dsd = new DataSpaceDefInition(new String[] { "StrongEncryptionTransform" });
+            DataSpaceDefInition dsd = new DataSpaceDefInition(["StrongEncryptionTransform"]);
             CreateEncryptionEntry(dir, "\u0006DataSpaces/DataSpaceInfo/StrongEncryptionDataSpace", dsd);
 
             TransformInfoHeader tih = new TransformInfoHeader(

--- a/main/POIFS/FileSystem/NPOIFSDocument.cs
+++ b/main/POIFS/FileSystem/NPOIFSDocument.cs
@@ -173,7 +173,7 @@ namespace NPOI.POIFS.FileSystem
 
             Stream innerOs = _stream.GetOutputStream();
             DocumentOutputStream os = new DocumentOutputStream(innerOs, size);
-            POIFSDocumentPath path = new POIFSDocumentPath(name.Split(new string[] { "\\\\" }, StringSplitOptions.RemoveEmptyEntries));
+            POIFSDocumentPath path = new POIFSDocumentPath(name.Split([@"\\"], StringSplitOptions.RemoveEmptyEntries));
             String docName = path.GetComponent(path.Length - 1);
             POIFSWriterEvent event1 = new POIFSWriterEvent(os, path, docName, size);
             Writer.ProcessPOIFSWriterEvent(event1);

--- a/ooxml/XSSF/Extractor/XSSFExportToXml.cs
+++ b/ooxml/XSSF/Extractor/XSSFExportToXml.cs
@@ -330,7 +330,7 @@ namespace NPOI.XSSF.Extractor
 
         private static String RemoveNamespace(String elementName)
         {
-            return Regex.IsMatch(elementName,".*:.*") ? elementName.Split(new char[]{':'})[1] : elementName;
+            return Regex.IsMatch(elementName,".*:.*") ? elementName.Split(':')[1] : elementName;
         }
 
         private static String GetFormattedDate(XSSFCell cell)
@@ -342,7 +342,7 @@ namespace NPOI.XSSF.Extractor
 
         private XmlNode GetNodeByXPath(String xpath, XmlNode rootNode, XmlDocument doc, bool CreateMultipleInstances)
         {
-            String[] xpathTokens = xpath.Split(new char[]{'/'});
+            String[] xpathTokens = xpath.Split('/');
 
 
             XmlNode currentNode = rootNode;
@@ -451,8 +451,8 @@ namespace NPOI.XSSF.Extractor
             doc.LoadXml(xmlSchema);
 
 
-            String[] leftTokens = leftXpath.Split(new char[]{'/'});
-            String[] rightTokens = rightXpath.Split(new char[] { '/' });
+            String[] leftTokens = leftXpath.Split('/');
+            String[] rightTokens = rightXpath.Split('/');
 
             int minLength = leftTokens.Length < rightTokens.Length ? leftTokens.Length : rightTokens.Length;
 

--- a/ooxml/XSSF/UserModel/Helpers/XSSFRowColShifter.cs
+++ b/ooxml/XSSF/UserModel/Helpers/XSSFRowColShifter.cs
@@ -284,7 +284,7 @@ namespace NPOI.OOXML.XSSF.UserModel.Helpers
             {
                 CT_ConditionalFormatting cf = conditionalFormattingArray[j];
                 List<CellRangeAddress> cellRanges = new List<CellRangeAddress>();
-                string[] regions = cf.sqref.ToString().Split(new char[] { ' ' });
+                string[] regions = cf.sqref.Split(' ');
 
                 for (int i = 0; i < regions.Length; i++)
                 {

--- a/ooxml/XSSF/UserModel/Helpers/XSSFXmlColumnPr.cs
+++ b/ooxml/XSSF/UserModel/Helpers/XSSFXmlColumnPr.cs
@@ -90,9 +90,9 @@ namespace NPOI.XSSF.UserModel.Helpers
             get
             {
                 using var localXPath = ZString.CreateStringBuilder();
-                int numberOfCommonXPathAxis = table.GetCommonXpath().Split(new char[] { '/' }).Length - 1;
+                int numberOfCommonXPathAxis = table.GetCommonXpath().Split('/').Length - 1;
 
-                String[] xPathTokens = ctXmlColumnPr.xpath.Split(new char[] { '/' });
+                String[] xPathTokens = ctXmlColumnPr.xpath.Split('/');
                 for (int i = numberOfCommonXPathAxis; i < xPathTokens.Length; i++)
                 {
                     localXPath.Append("/" + xPathTokens[i]);

--- a/ooxml/XSSF/UserModel/XSSFConditionalFormatting.cs
+++ b/ooxml/XSSF/UserModel/XSSFConditionalFormatting.cs
@@ -64,7 +64,7 @@ namespace NPOI.XSSF.UserModel
         public CellRangeAddress[] GetFormattingRanges()
         {
             List<CellRangeAddress> lst = new List<CellRangeAddress>();
-            String[] regions = _cf.sqref.Split(new char[] { ' ' });
+            String[] regions = _cf.sqref.Split(' ');
             for (int i = 0; i < regions.Length; i++)
             {
                 lst.Add(CellRangeAddress.ValueOf(regions[i]));

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -3617,7 +3617,7 @@ namespace NPOI.XSSF.UserModel
                 {
                     CellRangeAddressList addressList = new CellRangeAddressList();
 
-                    string[] regions = ctDataValidation.sqref.Split(new char[] { ' ' });
+                    string[] regions = ctDataValidation.sqref.Split(' ');
                     for(int i = 0; i < regions.Length; i++)
                     {
                         if(regions[i].Length == 0)
@@ -3625,7 +3625,7 @@ namespace NPOI.XSSF.UserModel
                             continue;
                         }
 
-                        string[] parts = regions[i].Split(new char[] { ':' });
+                        string[] parts = regions[i].Split(':');
                         CellReference begin = new CellReference(parts[0]);
                         CellReference end = parts.Length > 1
                             ? new CellReference(parts[1])

--- a/ooxml/XSSF/UserModel/XSSFTable.cs
+++ b/ooxml/XSSF/UserModel/XSSFTable.cs
@@ -161,7 +161,7 @@ namespace NPOI.XSSF.UserModel
                     if (column.GetXmlColumnPr() != null)
                     {
                         String xpath = column.GetXmlColumnPr().XPath;
-                        String[] tokens = xpath.Split(new char[] { '/' });
+                        String[] tokens = xpath.Split('/');
                         if (commonTokens==null)
                         {
                             commonTokens = tokens;
@@ -532,7 +532,7 @@ namespace NPOI.XSSF.UserModel
         {
             string ref1 = ctTable.@ref;
             if (ref1 != null) {
-                string[] boundaries = ref1.Split(new char[] { ':' }, 2);
+                string[] boundaries = ref1.Split([':'], 2);
                 string from = boundaries[0];
                 string to = boundaries.Length == 2 ? boundaries[1] : boundaries[0];
                 startCellReference = new CellReference(from);

--- a/openxml4Net/OPC/PackagingUriHelper.cs
+++ b/openxml4Net/OPC/PackagingUriHelper.cs
@@ -288,8 +288,8 @@ namespace NPOI.OpenXml4Net.OPC
         public static Uri RelativizeUri(Uri sourceURI, Uri targetURI, bool msCompatible)
         {
             StringBuilder retVal = new StringBuilder();
-            String[] segmentsSource = sourceURI.ToString().Split(new char[] { '/' });
-            String[] segmentsTarget = targetURI.ToString().Split(new char[] { '/' });
+            String[] segmentsSource = sourceURI.ToString().Split('/');
+            String[] segmentsTarget = targetURI.ToString().Split('/');
 
             // If the source Uri is empty
             if (segmentsSource.Length == 0)
@@ -481,7 +481,7 @@ namespace NPOI.OpenXml4Net.OPC
             }
             else if (targetPath.StartsWith("../"))
             {
-                string[] segments = path.Split(new char[] { '/' });
+                string[] segments = path.Split('/');
 
                 int segmentEnd = segments.Length - 1;
                 while (targetPath.StartsWith("../"))
@@ -493,8 +493,10 @@ namespace NPOI.OpenXml4Net.OPC
 
                 for (int i = 0; i <= segmentEnd;i++ )
                 {
-                    if(segments[i]!=string.Empty)
-                    path += segments[i]+"/";
+                    if(segments[i] != string.Empty)
+                    {
+                        path += segments[i]+"/";
+                    }
                 }
                 path += targetPath;
             }

--- a/testcases/main/App.config
+++ b/testcases/main/App.config
@@ -1,48 +1,33 @@
 <?xml version="1.0"?>
 <configuration>
-  <configSections>
-    <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <section name="TestCases.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
-    </sectionGroup>
-  </configSections>
-  <appSettings>
-    <!-- Default POILogger class defined in the assembly
-    if it is not set, NPOI.Util.NullLogger will be used
-    -->
-    <add key="loggername" value="TestCases.Util.DummyPOILogger,NPOI.TestCases"/>
-    <add key="HSSF.testdata.path" value="..\..\..\TestCases\test-data\hssf"/>
-    <add key="POIFS.testdata.path" value="..\..\..\TestCases\test-data\poifs"/>
-    <add key="POI.testdata.path" value="..\..\..\TestCases\test-data"/>
-    <add key="java.io.tmpdir" value="..\..\..\TestCases\test-data\"/>
-    <add key="poi.keep.tmp.files" value="..\..\..\TestCases\test-data\"/>
-    <add key="escher.data.path" value="..\..\..\TestCases\test-data\ddf\"/>
-    
-  </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup><userSettings>
-    <TestCases.Properties.Settings>
-      <setting name="TEST_PROPERTY" serializeAs="String">
-        <value>..\..\..\test-data</value>
-      </setting>
-    </TestCases.Properties.Settings>
-  </userSettings>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="5.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.1.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
+    <configSections>
+        <sectionGroup name="userSettings"
+                      type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+            <section name="TestCases.Properties.Settings"
+                     type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
+                     allowExeDefinition="MachineToLocalUser" requirePermission="false" />
+        </sectionGroup>
+    </configSections>
+    <appSettings>
+        <!-- Default POILogger class defined in the assembly
+        if it is not set, NPOI.Util.NullLogger will be used
+        -->
+        <add key="loggername" value="TestCases.Util.DummyPOILogger,NPOI.TestCases" />
+        <add key="HSSF.testdata.path" value="..\..\..\TestCases\test-data\hssf" />
+        <add key="POIFS.testdata.path" value="..\..\..\TestCases\test-data\poifs" />
+        <add key="POI.testdata.path" value="..\..\..\TestCases\test-data" />
+        <add key="java.io.tmpdir" value="..\..\..\TestCases\test-data\" />
+        <add key="poi.keep.tmp.files" value="..\..\..\TestCases\test-data\" />
+        <add key="escher.data.path" value="..\..\..\TestCases\test-data\ddf\" />
+
+    </appSettings>
+
+    <userSettings>
+        <TestCases.Properties.Settings>
+            <setting name="TEST_PROPERTY" serializeAs="String">
+                <value>..\..\..\test-data</value>
+            </setting>
+        </TestCases.Properties.Settings>
+    </userSettings>
+
 </configuration>

--- a/testcases/ooxml/App.config
+++ b/testcases/ooxml/App.config
@@ -15,25 +15,4 @@
          </setting>
       </ooxml.Testcases.Properties.Settings>
    </userSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="5.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.1.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/testcases/openxml4net/App.config
+++ b/testcases/openxml4net/App.config
@@ -3,25 +3,4 @@
 	<appSettings>
 		<add key="POI.testdata.path" value="..\..\..\..\test-data"/>
 	</appSettings>
-	<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="5.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-99.9.9.9" newVersion="4.1.4.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>


### PR DESCRIPTION
Also removed some unnecessary binding redirects that were causing annoying warnings while building.