### PR TITLE
Fix SortCondition XML to match spec rules

### DIFF
--- a/OpenXmlFormats/Spreadsheet/AutoFilter.cs
+++ b/OpenXmlFormats/Spreadsheet/AutoFilter.cs
@@ -1333,9 +1333,15 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "sortBy", this.sortBy.ToString());
             XmlHelper.WriteAttribute(sw, "ref", this.@ref);
             XmlHelper.WriteAttribute(sw, "customList", this.customList);
-            XmlHelper.WriteAttribute(sw, "dxfId", this.dxfId);
-            XmlHelper.WriteAttribute(sw, "iconSet",  this.iconSet.AsString(EnumFormat.Description));
-            XmlHelper.WriteAttribute(sw, "iconId", this.iconId);
+
+            if (this.sortBy is ST_SortBy.cellColor or ST_SortBy.fontColor)
+                XmlHelper.WriteAttribute(sw, "dxfId", this.dxfId);
+
+            if (this.sortBy == ST_SortBy.icon)
+            {
+                XmlHelper.WriteAttribute(sw, "iconSet", this.iconSet.AsString(EnumFormat.Description));
+                XmlHelper.WriteAttribute(sw, "iconId", this.iconId);
+            }
             sw.Write("/>");
         }
 


### PR DESCRIPTION
#1616 - Fixes invalid XML for CT_SortCondition.

As per the [spec](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-xlsx/af08b870-9b06-4812-a4d6-7bc80d819e62) this only writes: 

- `dxfId `when the `sortBy `is either a `fontColor `or `cellColor`
- `iconSet` when the `sortBy` is `icon`
- `iconId` when the `sortBy` is `icon`