### PR TITLE
Fix: Add oldStr to StringBuilder before Remove operation in Replace

### DIFF
--- a/main/SS/Formula/Functions/Text/Replace.cs
+++ b/main/SS/Formula/Functions/Text/Replace.cs
@@ -57,6 +57,7 @@ using Cysharp.Text;
                 return ErrorEval.VALUE_INVALID;
             }
             using var strBuff = ZString.CreateStringBuilder();
+            strBuff.Append(oldStr);
             // remove any characters that should be replaced
             if (startNum <= oldStr.Length && numChars != 0)
             {


### PR DESCRIPTION

- The Replace function was creating an empty StringBuilder and immediately trying to remove characters from it, causing formula calculation to fail
- Added strBuff.Append(oldStr) to populate the buffer before modification
- Fixes issue with REPLACE formula in Excel spreadsheets