### PR TITLE
Added start and end enum values to ST_Jc

### DIFF
--- a/OpenXmlFormats/Wordprocessing/Run.cs
+++ b/OpenXmlFormats/Wordprocessing/Run.cs
@@ -1641,13 +1641,12 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
     public enum ST_Jc
     {
     
-        left,
+        start,
 
     
         center,
 
-    
-        right,
+        end,
 
     
         both,
@@ -1669,6 +1668,12 @@ namespace NPOI.OpenXmlFormats.Wordprocessing
 
     
         thaiDistribute,
+
+        
+        left,
+
+        
+        right
     }
 
 

--- a/ooxml/Util/EnumConverter.cs
+++ b/ooxml/Util/EnumConverter.cs
@@ -21,6 +21,9 @@ namespace NPOI.Util
                 case ParagraphAlignment.MEDIUM_KASHIDA: return ST_Jc.mediumKashida;
                 case ParagraphAlignment.NUM_TAB: return ST_Jc.numTab;
                 case ParagraphAlignment.RIGHT: return ST_Jc.right;
+                case ParagraphAlignment.LEFT: return ST_Jc.left;
+                case ParagraphAlignment.START: return ST_Jc.start;
+                case ParagraphAlignment.END: return ST_Jc.end;
                 case ParagraphAlignment.THAI_DISTRIBUTE: return ST_Jc.thaiDistribute;
                 default: return ST_Jc.left;
             }

--- a/ooxml/XWPF/Usermodel/ParagraphAlignment.cs
+++ b/ooxml/XWPF/Usermodel/ParagraphAlignment.cs
@@ -32,16 +32,18 @@ namespace NPOI.XWPF.UserModel
     {
         //YK: TODO document each alignment option
 
-        LEFT = (1),
+        START = (1),
         CENTER = (2),
-        RIGHT = (3),
+        END = (3),
         BOTH = (4),
         MEDIUM_KASHIDA = (5),
         DISTRIBUTE = (6),
         NUM_TAB = (7),
         HIGH_KASHIDA = (8),
         LOW_KASHIDA = (9),
-        THAI_DISTRIBUTE = (10)
+        THAI_DISTRIBUTE = (10),
+        LEFT = (11),
+        RIGHT = (12)
 
         //private int value;
 


### PR DESCRIPTION
Added `start` and `end` enum values while keeping `left` and `right` for compatibility.

Fix #1653 