### PR TITLE
CT_TableStyleElement.dxfIdFieldSpecified should be false if no dxfId attribute exists

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Styles/CT_TableStyles.cs
+++ b/OpenXmlFormats/Spreadsheet/Styles/CT_TableStyles.cs
@@ -542,7 +542,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 ctObj.type = (ST_TableStyleType)Enum.Parse(typeof(ST_TableStyleType), node.Attributes["type"].Value);
             ctObj.size = XmlHelper.ReadUInt(node.Attributes["size"]);
             ctObj.dxfIdFieldSpecified = node.Attributes["dxfId"] != null;
-            ctObj.dxfId = XmlHelper.ReadUInt(node.Attributes["dxfId"]);
+            if(ctObj.dxfIdFieldSpecified)
+                ctObj.dxfId = XmlHelper.ReadUInt(node.Attributes["dxfId"]);
             return ctObj;
         }
 


### PR DESCRIPTION
Fix #1675 