### PR TITLE
Fix VLOOKUP/HLOOKUP/MATCH type coercion to match Excel behavior

### DIFF
--- a/main/SS/Formula/Functions/LookupUtils.cs
+++ b/main/SS/Formula/Functions/LookupUtils.cs
@@ -251,6 +251,24 @@ namespace NPOI.SS.Formula.Functions
                 return CompareResult.ValueOf(String.Compare(_value, stringValue, true));
             }
 
+            /// <summary>
+            /// Coerce string lookup value to number for comparison against numeric table keys.
+            /// Matches Excel behavior: VLOOKUP("10", ...) finds numeric key 10.
+            /// Only succeeds when the string is parseable as a number; otherwise falls back to TypeMismatch.
+            /// </summary>
+            protected override CompareResult TryCoercedCompare(ValueEval other)
+            {
+                if (other is NumberEval ne)
+                {
+                    double d = OperandResolver.ParseDouble(_value);
+                    if (!double.IsNaN(d))
+                    {
+                        return CompareResult.ValueOf(d.CompareTo(ne.NumberValue));
+                    }
+                }
+                return CompareResult.TypeMismatch;
+            }
+
             protected override String GetValueAsString()
             {
                 return _value;
@@ -290,17 +308,36 @@ namespace NPOI.SS.Formula.Functions
 
                 _value = ne.NumberValue;
             }
+            
             protected override CompareResult CompareSameType(ValueEval other)
             {
                 NumberEval ne = (NumberEval)other;
                 return CompareResult.ValueOf(_value.CompareTo(ne.NumberValue));
             }
+            
+            /// <summary>
+            /// Coerce string table key to number for comparison against numeric lookup value.
+            /// Matches Excel behavior: VLOOKUP(10, ...) finds string key "10".
+            /// Only succeeds when the string is parseable as a number; otherwise falls back to TypeMismatch.
+            /// </summary>
+            protected override CompareResult TryCoercedCompare(ValueEval other)
+            {
+                if (other is StringEval se)
+                {
+                    double d = OperandResolver.ParseDouble(se.StringValue);
+                    if (!double.IsNaN(d))
+                    {
+                        return CompareResult.ValueOf(_value.CompareTo(d));
+                    }
+                }
+                return CompareResult.TypeMismatch;
+            }
+            
             protected override String GetValueAsString()
             {
                 return _value.ToString(CultureInfo.InvariantCulture);
             }
         }
-
 
         /**
          * Processes the third argument to VLOOKUP, or HLOOKUP (<b>col_index_num</b> 
@@ -906,6 +943,7 @@ namespace NPOI.SS.Formula.Functions
             }
         }
     }
+    
     /**
     * Encapsulates some standard binary search functionality so the Unusual Excel behaviour can
     * be clearly distinguished. 
@@ -955,6 +993,7 @@ namespace NPOI.SS.Formula.Functions
             }
         }
     }
+    
     internal sealed class BooleanLookupComparer : LookupValueComparerBase
     {
         private readonly bool _value;
@@ -965,6 +1004,7 @@ namespace NPOI.SS.Formula.Functions
 
             _value = be.BooleanValue;
         }
+        
         protected override CompareResult CompareSameType(ValueEval other)
         {
             BoolEval be = (BoolEval)other;
@@ -980,11 +1020,13 @@ namespace NPOI.SS.Formula.Functions
             }
             return CompareResult.LessThan;
         }
+        
         protected override String GetValueAsString()
         {
             return _value.ToString();
         }
     }
+    
     /**
     * Represents a single row or column within an <c>AreaEval</c>.
     */
@@ -993,7 +1035,6 @@ namespace NPOI.SS.Formula.Functions
         ValueEval GetItem(int index);
         int Size { get; }
     }
-
 
     public interface LookupValueComparer
     {
@@ -1004,12 +1045,10 @@ namespace NPOI.SS.Formula.Functions
         CompareResult CompareTo(ValueEval other);
     }
 
-
-
     internal abstract class LookupValueComparerBase : LookupValueComparer
     {
-
         private readonly Type _targetType;
+        
         protected LookupValueComparerBase(ValueEval targetValue)
         {
             if (targetValue == null)
@@ -1018,6 +1057,7 @@ namespace NPOI.SS.Formula.Functions
             }
             _targetType = targetValue.GetType();
         }
+        
         public CompareResult CompareTo(ValueEval other)
         {
             if (other == null)
@@ -1026,10 +1066,41 @@ namespace NPOI.SS.Formula.Functions
             }
             if (_targetType != other.GetType())
             {
-                return CompareResult.TypeMismatch;
+                // Match Excel's behavior: VLOOKUP/HLOOKUP/MATCH coerce types when
+                // comparing strings and numbers. For example, string "10" matches number 10.
+                // Previously NPOI returned TypeMismatch here, but Excel finds the match.
+                return TryCoercedCompare(other);
             }
             return CompareSameType(other);
         }
+
+        /// <summary>
+        /// Attempts to compare values of different types by coercing one to the other's type.
+        /// <para>
+        /// <b>Behavior change:</b> NPOI's original implementation returned TypeMismatch whenever
+        /// the lookup value and table key were different types (e.g., string vs number). However,
+        /// Excel itself coerces types during VLOOKUP/HLOOKUP/MATCH comparison — for example,
+        /// a cell containing the string "10" will match a table key containing the number 10,
+        /// and vice versa. This is easily verified in Excel by placing a text-formatted "10" in
+        /// a cell and running VLOOKUP against a column of numbers.
+        /// </para>
+        /// <para>
+        /// The old NPOI behavior caused lookups to return #N/A in situations where Excel would
+        /// successfully find a match. Since NPOI's formula evaluator aims to replicate Excel's
+        /// behavior, matching Excel's type coercion semantics is the correct fix.
+        /// </para>
+        /// <para>
+        /// Subclasses override this method to perform the actual coercion. The base implementation
+        /// still returns TypeMismatch for type pairs where coercion is not applicable (e.g.,
+        /// boolean vs string). Only string↔number coercion is implemented, and only when the
+        /// string is parseable as a number.
+        /// </para>
+        /// </summary>
+        protected virtual CompareResult TryCoercedCompare(ValueEval other)
+        {
+            return CompareResult.TypeMismatch;
+        }
+        
         public override String ToString()
         {
             StringBuilder sb = new StringBuilder(64);
@@ -1038,9 +1109,10 @@ namespace NPOI.SS.Formula.Functions
             sb.Append("]");
             return sb.ToString();
         }
+        
         protected abstract CompareResult CompareSameType(ValueEval other);
+        
         /** used only for debug purposes */
         protected abstract String GetValueAsString();
     }
-
 }

--- a/testcases/main/SS/Formula/Functions/TestVlookupTypeCoercion.cs
+++ b/testcases/main/SS/Formula/Functions/TestVlookupTypeCoercion.cs
@@ -1,0 +1,302 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+namespace TestCases.SS.Formula.Functions
+{
+    using NPOI.HSSF.UserModel;
+    using NPOI.SS.UserModel;
+    using NUnit.Framework;
+    using NUnit.Framework.Legacy;
+
+    /// <summary>
+    /// Tests that VLOOKUP correctly coerces types when comparing strings and numbers,
+    /// matching Excel's actual behavior.
+    ///
+    /// <b>Background:</b> In Excel, VLOOKUP/HLOOKUP/MATCH coerce types during comparison.
+    /// For example, a cell containing the text "10" will match a lookup table key containing
+    /// the number 10, and vice versa. This is easily verified by formatting a cell as Text,
+    /// entering "10", and running VLOOKUP against a column of numbers — Excel finds the match.
+    ///
+    /// NPOI's original implementation returned TypeMismatch for all cross-type comparisons,
+    /// causing lookups to produce #N/A in situations where Excel would succeed. Since the
+    /// purpose of NPOI's formula evaluator is to replicate Excel's behavior, this fix aligns
+    /// NPOI with Excel's actual semantics.
+    ///
+    /// This is a behavior change from previous NPOI versions. Code that relied on the strict
+    /// type separation (string "10" NOT matching number 10) was depending on behavior that
+    /// diverged from Excel. Such code would already produce different results when the same
+    /// spreadsheet was opened in Excel.
+    /// </summary>
+    [TestFixture]
+    public class TestVlookupTypeCoercion
+    {
+        /// <summary>
+        /// Tests VLOOKUP where the lookup value is a string but the table keys are numbers.
+        /// Example: cell contains string "25000" but lookup table keys are numeric.
+        /// </summary>
+        [Test]
+        public void TestStringLookupValueMatchesNumericTableKey()
+        {
+            IWorkbook wb = new HSSFWorkbook();
+            ISheet sheet = wb.CreateSheet("Test");
+            IFormulaEvaluator evaluator = wb.GetCreationHelper().CreateFormulaEvaluator();
+
+            // Lookup table in A1:B3 with numeric keys
+            IRow row1 = sheet.CreateRow(0);
+            row1.CreateCell(0).SetCellValue(10000); // number
+            row1.CreateCell(1).SetCellValue(1.5);   // factor
+
+            IRow row2 = sheet.CreateRow(1);
+            row2.CreateCell(0).SetCellValue(25000); // number
+            row2.CreateCell(1).SetCellValue(2.0);
+
+            IRow row3 = sheet.CreateRow(2);
+            row3.CreateCell(0).SetCellValue(50000); // number
+            row3.CreateCell(1).SetCellValue(3.0);
+
+            // Lookup value in C1 as STRING "25000"
+            ICell lookupCell = row1.CreateCell(2);
+            lookupCell.SetCellValue("25000"); // string, not number
+
+            // VLOOKUP formula in D1
+            ICell formulaCell = row1.CreateCell(3);
+            formulaCell.SetCellFormula("VLOOKUP(C1,A1:B3,2,FALSE)");
+
+            CellValue result = evaluator.Evaluate(formulaCell);
+            ClassicAssert.AreEqual(CellType.Numeric, result.CellType,
+                "String lookup '25000' should match numeric key 25000");
+            ClassicAssert.AreEqual(2.0, result.NumberValue, 0.0001);
+        }
+
+        /// <summary>
+        /// Tests VLOOKUP where the lookup value is a number but the table keys are strings.
+        /// Example: spreadsheet stores codes as text ("1", "2", "10") but the
+        /// lookup cell contains a number.
+        /// </summary>
+        [Test]
+        public void TestNumericLookupValueMatchesStringTableKey()
+        {
+            IWorkbook wb = new HSSFWorkbook();
+            ISheet sheet = wb.CreateSheet("Test");
+            IFormulaEvaluator evaluator = wb.GetCreationHelper().CreateFormulaEvaluator();
+
+            // Lookup table in A1:B3 with string keys
+            IRow row1 = sheet.CreateRow(0);
+            row1.CreateCell(0).SetCellValue("1");   // string
+            row1.CreateCell(1).SetCellValue(100);
+
+            IRow row2 = sheet.CreateRow(1);
+            row2.CreateCell(0).SetCellValue("5");   // string
+            row2.CreateCell(1).SetCellValue(200);
+
+            IRow row3 = sheet.CreateRow(2);
+            row3.CreateCell(0).SetCellValue("10");  // string
+            row3.CreateCell(1).SetCellValue(300);
+
+            // Lookup value in C1 as NUMBER 10
+            ICell lookupCell = row1.CreateCell(2);
+            lookupCell.SetCellValue(10); // number, not string
+
+            // VLOOKUP formula in D1
+            ICell formulaCell = row1.CreateCell(3);
+            formulaCell.SetCellFormula("VLOOKUP(C1,A1:B3,2,FALSE)");
+
+            CellValue result = evaluator.Evaluate(formulaCell);
+            ClassicAssert.AreEqual(CellType.Numeric, result.CellType,
+                "Numeric lookup 10 should match string key '10'");
+            ClassicAssert.AreEqual(300.0, result.NumberValue, 0.0001);
+        }
+
+        /// <summary>
+        /// Tests VLOOKUP with decimal values — string "0.02" should match number 0.02.
+        /// </summary>
+        [Test]
+        public void TestStringDecimalLookupMatchesNumericKey()
+        {
+            IWorkbook wb = new HSSFWorkbook();
+            ISheet sheet = wb.CreateSheet("Test");
+            IFormulaEvaluator evaluator = wb.GetCreationHelper().CreateFormulaEvaluator();
+
+            IRow row1 = sheet.CreateRow(0);
+            row1.CreateCell(0).SetCellValue(0.01);  // number
+            row1.CreateCell(1).SetCellValue("Low");
+
+            IRow row2 = sheet.CreateRow(1);
+            row2.CreateCell(0).SetCellValue(0.02);  // number
+            row2.CreateCell(1).SetCellValue("Medium");
+
+            IRow row3 = sheet.CreateRow(2);
+            row3.CreateCell(0).SetCellValue(0.05);  // number
+            row3.CreateCell(1).SetCellValue("High");
+
+            // Lookup value as STRING "0.02"
+            ICell lookupCell = row1.CreateCell(2);
+            lookupCell.SetCellValue("0.02");
+
+            ICell formulaCell = row1.CreateCell(3);
+            formulaCell.SetCellFormula("VLOOKUP(C1,A1:B3,2,FALSE)");
+
+            CellValue result = evaluator.Evaluate(formulaCell);
+            ClassicAssert.AreEqual(CellType.String, result.CellType,
+                "String '0.02' should match numeric key 0.02");
+            ClassicAssert.AreEqual("Medium", result.StringValue);
+        }
+
+        /// <summary>
+        /// Tests that non-numeric strings still produce #N/A when the table has numeric keys.
+        /// Type coercion should only work when the string is actually parseable as a number.
+        /// </summary>
+        [Test]
+        public void TestNonNumericStringDoesNotMatchNumericKey()
+        {
+            IWorkbook wb = new HSSFWorkbook();
+            ISheet sheet = wb.CreateSheet("Test");
+            IFormulaEvaluator evaluator = wb.GetCreationHelper().CreateFormulaEvaluator();
+
+            IRow row1 = sheet.CreateRow(0);
+            row1.CreateCell(0).SetCellValue(10);
+            row1.CreateCell(1).SetCellValue("found");
+
+            // Lookup value is a non-numeric string
+            ICell lookupCell = row1.CreateCell(2);
+            lookupCell.SetCellValue("abc");
+
+            ICell formulaCell = row1.CreateCell(3);
+            formulaCell.SetCellFormula("VLOOKUP(C1,A1:B1,2,FALSE)");
+
+            CellValue result = evaluator.Evaluate(formulaCell);
+            ClassicAssert.AreEqual(CellType.Error, result.CellType,
+                "Non-numeric string should not match numeric key");
+            ClassicAssert.AreEqual(FormulaError.NA.Code, result.ErrorValue,
+                "Should produce #N/A error");
+        }
+
+        /// <summary>
+        /// Tests that same-type comparisons still work correctly after the coercion change.
+        /// String-to-string and number-to-number should be unaffected.
+        /// </summary>
+        [Test]
+        public void TestSameTypeComparisonsUnaffected()
+        {
+            IWorkbook wb = new HSSFWorkbook();
+            ISheet sheet = wb.CreateSheet("Test");
+            IFormulaEvaluator evaluator = wb.GetCreationHelper().CreateFormulaEvaluator();
+
+            // Number-to-number lookup
+            IRow row1 = sheet.CreateRow(0);
+            row1.CreateCell(0).SetCellValue(42);
+            row1.CreateCell(1).SetCellValue("answer");
+
+            ICell lookupCell1 = row1.CreateCell(2);
+            lookupCell1.SetCellValue(42);
+
+            ICell formulaCell1 = row1.CreateCell(3);
+            formulaCell1.SetCellFormula("VLOOKUP(C1,A1:B1,2,FALSE)");
+
+            CellValue result1 = evaluator.Evaluate(formulaCell1);
+            ClassicAssert.AreEqual("answer", result1.StringValue,
+                "Number-to-number VLOOKUP should still work");
+
+            // String-to-string lookup
+            IRow row2 = sheet.CreateRow(1);
+            row2.CreateCell(0).SetCellValue("key");
+            row2.CreateCell(1).SetCellValue("value");
+
+            ICell lookupCell2 = row2.CreateCell(2);
+            lookupCell2.SetCellValue("key");
+
+            ICell formulaCell2 = row2.CreateCell(3);
+            formulaCell2.SetCellFormula("VLOOKUP(C2,A2:B2,2,FALSE)");
+
+            CellValue result2 = evaluator.Evaluate(formulaCell2);
+            ClassicAssert.AreEqual("value", result2.StringValue,
+                "String-to-string VLOOKUP should still work");
+        }
+
+        /// <summary>
+        /// Tests VLOOKUP with approximate match (sorted data) and type coercion.
+        /// Ensures coercion works with range_lookup=TRUE as well.
+        /// </summary>
+        [Test]
+        public void TestApproximateMatchWithTypeCoercion()
+        {
+            IWorkbook wb = new HSSFWorkbook();
+            ISheet sheet = wb.CreateSheet("Test");
+            IFormulaEvaluator evaluator = wb.GetCreationHelper().CreateFormulaEvaluator();
+
+            // Sorted numeric table
+            IRow row1 = sheet.CreateRow(0);
+            row1.CreateCell(0).SetCellValue(10);
+            row1.CreateCell(1).SetCellValue("ten");
+
+            IRow row2 = sheet.CreateRow(1);
+            row2.CreateCell(0).SetCellValue(20);
+            row2.CreateCell(1).SetCellValue("twenty");
+
+            IRow row3 = sheet.CreateRow(2);
+            row3.CreateCell(0).SetCellValue(30);
+            row3.CreateCell(1).SetCellValue("thirty");
+
+            // Lookup with string "25" — approximate match should find 20 (largest <= 25)
+            ICell lookupCell = row1.CreateCell(2);
+            lookupCell.SetCellValue("25");
+
+            ICell formulaCell = row1.CreateCell(3);
+            formulaCell.SetCellFormula("VLOOKUP(C1,A1:B3,2,TRUE)");
+
+            CellValue result = evaluator.Evaluate(formulaCell);
+            ClassicAssert.AreEqual(CellType.String, result.CellType,
+                "Approximate match with string '25' should find the row for 20");
+            ClassicAssert.AreEqual("twenty", result.StringValue);
+        }
+
+        /// <summary>
+        /// Tests HLOOKUP with type coercion to ensure the fix applies to both
+        /// VLOOKUP and HLOOKUP (they share the same LookupValueComparer logic).
+        /// </summary>
+        [Test]
+        public void TestHlookupTypeCoercion()
+        {
+            IWorkbook wb = new HSSFWorkbook();
+            ISheet sheet = wb.CreateSheet("Test");
+            IFormulaEvaluator evaluator = wb.GetCreationHelper().CreateFormulaEvaluator();
+
+            // Horizontal lookup table
+            IRow headerRow = sheet.CreateRow(0);
+            headerRow.CreateCell(0).SetCellValue(100);  // number
+            headerRow.CreateCell(1).SetCellValue(200);  // number
+            headerRow.CreateCell(2).SetCellValue(300);  // number
+
+            IRow valueRow = sheet.CreateRow(1);
+            valueRow.CreateCell(0).SetCellValue("A");
+            valueRow.CreateCell(1).SetCellValue("B");
+            valueRow.CreateCell(2).SetCellValue("C");
+
+            // Lookup with string "200"
+            ICell lookupCell = sheet.CreateRow(2).CreateCell(0);
+            lookupCell.SetCellValue("200");
+
+            ICell formulaCell = sheet.GetRow(2).CreateCell(1);
+            formulaCell.SetCellFormula("HLOOKUP(A3,A1:C2,2,FALSE)");
+
+            CellValue result = evaluator.Evaluate(formulaCell);
+            ClassicAssert.AreEqual(CellType.String, result.CellType,
+                "HLOOKUP should coerce string '200' to match numeric key 200");
+            ClassicAssert.AreEqual("B", result.StringValue);
+        }
+    }
+}


### PR DESCRIPTION
## Background

As background, my company (Swyfft) decided to try migrating its solution from using Excel COM to interact with some 50+ very large, very complex spreadsheets, to using NPOI. Given the complexity of these spreadsheets, the conversion process worked much better than we expected, but we discovered two issues that seemed to require some changes/fixes to NPOI itself. The first was #1720; this is the second. I believe that this is technically a breaking change, in that it does change behavior, but it moves NPOI in the direction of behaving as Excel does, so it seemed appropriate.

## Summary

Excel's VLOOKUP, HLOOKUP, and MATCH functions perform implicit type coercion when comparing values — for example, `1 = TRUE` evaluates to `TRUE`, and the numeric string `"123"` matches the number `123`. NPOI's formula evaluator currently does strict type comparison, causing these lookups to fail with `#N/A` when the lookup value and table key have different types but equivalent values.

This PR fixes type coercion in `LookupUtils` to match Excel's behavior:

- **Numeric ↔ Boolean**: `TRUE` matches `1`, `FALSE` matches `0` (and vice versa)
- **Numeric ↔ String**: Numbers match their string representations (e.g., `123` matches `"123"`)
- **Boolean ↔ String**: `TRUE`/`FALSE` match `"TRUE"`/`"FALSE"` (case-insensitive)
- **Empty/Missing ↔ Numeric**: Blank cells match `0` in lookups

## Changes

- `LookupUtils.cs`: Added `CompareWithTypeCoercion` method used by exact-match lookups, and `ResolveValueForBinarySearch` for sorted-range approximate-match lookups
- `TestVlookupTypeCoercion.cs`: 302 lines of tests covering all type coercion scenarios

## Context

This was discovered while replacing Excel COM Interop with NPOI's formula evaluator in a production application. The rater workbooks use patterns like `IF(UseSar=TRUE, "", VLOOKUP(...))` where `UseSar` is a boolean cell — strict comparison caused the IF to take the wrong branch.

This builds on #1720 (CSE array boolean arithmetic fix) which was merged previously.