### PR TITLE
Cache XSSFRow.FirstCellNum/LastCellNum to avoid O(n) LINQ scans

### DIFF
--- a/benchmarks/NPOI.Benchmarks/XSSFRowCellNumBenchmark.cs
+++ b/benchmarks/NPOI.Benchmarks/XSSFRowCellNumBenchmark.cs
@@ -1,0 +1,76 @@
+using BenchmarkDotNet.Attributes;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.UserModel;
+
+namespace NPOI.Benchmarks;
+
+[ShortRunJob]
+[MemoryDiagnoser]
+public class XSSFRowCellNumBenchmark
+{
+    private XSSFWorkbook _workbook;
+    private IRow _sparseRow;
+    private IRow _denseRow;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _workbook = new XSSFWorkbook();
+        var sheet = _workbook.CreateSheet("test");
+
+        // Sparse row: cells at widely separated columns
+        _sparseRow = sheet.CreateRow(0);
+        _sparseRow.CreateCell(0).SetCellValue("first");
+        _sparseRow.CreateCell(500).SetCellValue("mid");
+        _sparseRow.CreateCell(1000).SetCellValue("last");
+
+        // Dense row: 200 contiguous cells (typical spreadsheet)
+        _denseRow = sheet.CreateRow(1);
+        for (int i = 0; i < 200; i++)
+        {
+            _denseRow.CreateCell(i).SetCellValue(i);
+        }
+    }
+
+    [Benchmark]
+    public int SparseRow_FirstLastCellNum_10000x()
+    {
+        // Simulates tight loop pattern: for (j = row.FirstCellNum; j <= row.LastCellNum; j++)
+        int sum = 0;
+        for (int i = 0; i < 10_000; i++)
+        {
+            sum += _sparseRow.FirstCellNum + _sparseRow.LastCellNum;
+        }
+        return sum;
+    }
+
+    [Benchmark]
+    public int DenseRow_FirstLastCellNum_10000x()
+    {
+        int sum = 0;
+        for (int i = 0; i < 10_000; i++)
+        {
+            sum += _denseRow.FirstCellNum + _denseRow.LastCellNum;
+        }
+        return sum;
+    }
+
+    [Benchmark]
+    public int DenseRow_IterateCellRange()
+    {
+        // Pattern seen in copy/shift operations: iterate FirstCellNum..LastCellNum
+        int count = 0;
+        for (int j = _denseRow.FirstCellNum; j < _denseRow.LastCellNum; j++)
+        {
+            ICell cell = _denseRow.GetCell(j);
+            if (cell != null) count++;
+        }
+        return count;
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _workbook?.Dispose();
+    }
+}

--- a/ooxml/XSSF/UserModel/XSSFRow.cs
+++ b/ooxml/XSSF/UserModel/XSSFRow.cs
@@ -56,6 +56,18 @@ namespace NPOI.XSSF.UserModel
         private readonly XSSFSheet _sheet;
 
         private readonly StylesTable _stylesSource;
+
+        /// <summary>
+        /// Cached first (minimum) column index, or -1 if unknown/dirty.
+        /// Avoids O(n) LINQ Min() scan on every FirstCellNum access.
+        /// </summary>
+        private int _cachedFirstCellNum = -1;
+
+        /// <summary>
+        /// Cached last (maximum) column index, or -1 if unknown/dirty.
+        /// Avoids O(n) LINQ Max() scan on every LastCellNum access.
+        /// </summary>
+        private int _cachedLastCellNum = -1;
         #endregion
 
         #region Public properties
@@ -79,7 +91,12 @@ namespace NPOI.XSSF.UserModel
         {
             get
             {
-                return (short)(_cells.Count == 0 ? -1 : GetFirstKey());
+                if (_cells.Count == 0) return -1;
+                if (_cachedFirstCellNum < 0)
+                {
+                    _cachedFirstCellNum = GetFirstKey();
+                }
+                return (short)_cachedFirstCellNum;
             }
         }
 
@@ -94,7 +111,12 @@ namespace NPOI.XSSF.UserModel
         {
             get
             {
-                return (short)(_cells.Count == 0 ? -1 : (GetLastKey() + 1));
+                if (_cells.Count == 0) return -1;
+                if (_cachedLastCellNum < 0)
+                {
+                    _cachedLastCellNum = GetLastKey();
+                }
+                return (short)(_cachedLastCellNum + 1);
             }
         }
 
@@ -284,6 +306,7 @@ namespace NPOI.XSSF.UserModel
                 {
                     XSSFCell cell = new XSSFCell(this, c);
                     _cells.Add(cell.ColumnIndex, cell);
+                    UpdateCacheOnAdd(cell.ColumnIndex);
                     sheet.OnReadCell(cell);
                 }
             }
@@ -355,6 +378,7 @@ namespace NPOI.XSSF.UserModel
             }
 
             _cells[columnIndex] = xcell;
+            UpdateCacheOnAdd(columnIndex);
             return xcell;
         }
 
@@ -421,7 +445,9 @@ namespace NPOI.XSSF.UserModel
                 ((XSSFWorkbook)_sheet.Workbook).OnDeleteFormula(xcell);
             }
 
-            _cells.Remove(cell.ColumnIndex);
+            int removedIndex = cell.ColumnIndex;
+            _cells.Remove(removedIndex);
+            InvalidateCacheOnRemove(removedIndex);
         }
 
         /// <summary>
@@ -625,6 +651,10 @@ namespace NPOI.XSSF.UserModel
 
             // Sort CT_Cols by index asc.
             _row.c.Sort((col1, col2) => col1.r.CompareTo(col2.r));
+
+            // Cache is invalid after rebuild — keys may have changed
+            _cachedFirstCellNum = -1;
+            _cachedLastCellNum = -1;
         }
         #endregion
 
@@ -804,6 +834,45 @@ namespace NPOI.XSSF.UserModel
         private int GetLastKey()
         {
             return _cells.Keys.Max();
+        }
+
+        /// <summary>
+        /// Update cached min/max on cell addition. O(1) — just compare with current bounds.
+        /// </summary>
+        private void UpdateCacheOnAdd(int columnIndex)
+        {
+            if (_cachedFirstCellNum < 0 || columnIndex < _cachedFirstCellNum)
+            {
+                _cachedFirstCellNum = columnIndex;
+            }
+            if (_cachedLastCellNum < 0 || columnIndex > _cachedLastCellNum)
+            {
+                _cachedLastCellNum = columnIndex;
+            }
+        }
+
+        /// <summary>
+        /// Invalidate cached min/max when a cell at a boundary is removed.
+        /// Only forces re-scan when the removed cell was at an edge.
+        /// </summary>
+        private void InvalidateCacheOnRemove(int removedIndex)
+        {
+            if (_cells.Count == 0)
+            {
+                _cachedFirstCellNum = -1;
+                _cachedLastCellNum = -1;
+            }
+            else
+            {
+                if (removedIndex == _cachedFirstCellNum)
+                {
+                    _cachedFirstCellNum = -1; // will re-scan on next access
+                }
+                if (removedIndex == _cachedLastCellNum)
+                {
+                    _cachedLastCellNum = -1; // will re-scan on next access
+                }
+            }
         }
         #endregion
     }

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFRow.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFRow.cs
@@ -15,6 +15,9 @@
    limitations under the License.
 ==================================================================== */
 
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using NPOI.SS.UserModel;
 using NPOI.XSSF;
 using NPOI.XSSF.UserModel;
@@ -187,6 +190,195 @@ namespace TestCases.XSSF.UserModel
             ClassicAssert.AreEqual("Sheet1!A2", externObserverRow.GetCell(0).CellFormula, "references to overwritten cells are unmodified");
 
             workbook.Close();
+        }
+
+        [Test]
+        public void TestSparseRowCellBounds()
+        {
+            // Test with cells at distant column indices (sparse row)
+            using var workbook = new XSSFWorkbook();
+            var sheet = workbook.CreateSheet("test");
+            var row = sheet.CreateRow(0);
+
+            row.CreateCell(0).SetCellValue("first");
+            row.CreateCell(1000).SetCellValue("distant");
+
+            ClassicAssert.AreEqual(0, row.FirstCellNum);
+            ClassicAssert.AreEqual(1001, row.LastCellNum);
+            ClassicAssert.AreEqual(2, row.PhysicalNumberOfCells);
+
+            // Add a cell in the middle — bounds should not change
+            row.CreateCell(500).SetCellValue("middle");
+            ClassicAssert.AreEqual(0, row.FirstCellNum);
+            ClassicAssert.AreEqual(1001, row.LastCellNum);
+            ClassicAssert.AreEqual(3, row.PhysicalNumberOfCells);
+
+            // Remove the first cell — FirstCellNum should update
+            row.RemoveCell(row.GetCell(0));
+            ClassicAssert.AreEqual(500, row.FirstCellNum);
+            ClassicAssert.AreEqual(1001, row.LastCellNum);
+            ClassicAssert.AreEqual(2, row.PhysicalNumberOfCells);
+
+            // Remove the last cell — LastCellNum should update
+            row.RemoveCell(row.GetCell(1000));
+            ClassicAssert.AreEqual(500, row.FirstCellNum);
+            ClassicAssert.AreEqual(501, row.LastCellNum);
+            ClassicAssert.AreEqual(1, row.PhysicalNumberOfCells);
+        }
+
+        [Test]
+        public void TestCellIterationOrderWithSparseColumns()
+        {
+            // Create cells in reverse order, verify iteration is always column-ascending
+            using var workbook = new XSSFWorkbook();
+            var sheet = workbook.CreateSheet("test");
+            var row = sheet.CreateRow(0);
+
+            row.CreateCell(5000).SetCellValue("E");
+            row.CreateCell(100).SetCellValue("B");
+            row.CreateCell(10000).SetCellValue("F");
+            row.CreateCell(0).SetCellValue("A");
+            row.CreateCell(500).SetCellValue("C");
+            row.CreateCell(1000).SetCellValue("D");
+
+            // Verify GetEnumerator returns cells in ascending column order
+            var cells = new List<ICell>();
+            foreach (ICell cell in row)
+            {
+                cells.Add(cell);
+            }
+
+            ClassicAssert.AreEqual(6, cells.Count);
+            ClassicAssert.AreEqual(0, cells[0].ColumnIndex);
+            ClassicAssert.AreEqual(100, cells[1].ColumnIndex);
+            ClassicAssert.AreEqual(500, cells[2].ColumnIndex);
+            ClassicAssert.AreEqual(1000, cells[3].ColumnIndex);
+            ClassicAssert.AreEqual(5000, cells[4].ColumnIndex);
+            ClassicAssert.AreEqual(10000, cells[5].ColumnIndex);
+
+            // Verify .Cells property also returns in column order
+            List<ICell> cellsProp = row.Cells;
+            ClassicAssert.AreEqual(6, cellsProp.Count);
+            for (int i = 0; i < cells.Count; i++)
+            {
+                ClassicAssert.AreEqual(cells[i].ColumnIndex, cellsProp[i].ColumnIndex);
+            }
+        }
+
+        [Test]
+        public void TestFirstLastCellNumAfterInterleavedAddRemove()
+        {
+            // Interleaved add/remove operations should always yield correct bounds
+            using var workbook = new XSSFWorkbook();
+            var sheet = workbook.CreateSheet("test");
+            var row = sheet.CreateRow(0);
+
+            ClassicAssert.AreEqual(-1, row.FirstCellNum);
+            ClassicAssert.AreEqual(-1, row.LastCellNum);
+
+            // Add cells in non-sequential order
+            row.CreateCell(5);
+            ClassicAssert.AreEqual(5, row.FirstCellNum);
+            ClassicAssert.AreEqual(6, row.LastCellNum);
+
+            row.CreateCell(2);
+            ClassicAssert.AreEqual(2, row.FirstCellNum);
+            ClassicAssert.AreEqual(6, row.LastCellNum);
+
+            row.CreateCell(8);
+            ClassicAssert.AreEqual(2, row.FirstCellNum);
+            ClassicAssert.AreEqual(9, row.LastCellNum);
+
+            // Remove the middle cell — bounds unchanged
+            row.RemoveCell(row.GetCell(5));
+            ClassicAssert.AreEqual(2, row.FirstCellNum);
+            ClassicAssert.AreEqual(9, row.LastCellNum);
+
+            // Remove the first cell — FirstCellNum updates
+            row.RemoveCell(row.GetCell(2));
+            ClassicAssert.AreEqual(8, row.FirstCellNum);
+            ClassicAssert.AreEqual(9, row.LastCellNum);
+
+            // Add a new cell that becomes the new first
+            row.CreateCell(1);
+            ClassicAssert.AreEqual(1, row.FirstCellNum);
+            ClassicAssert.AreEqual(9, row.LastCellNum);
+
+            // Remove the last cell — LastCellNum updates
+            row.RemoveCell(row.GetCell(8));
+            ClassicAssert.AreEqual(1, row.FirstCellNum);
+            ClassicAssert.AreEqual(2, row.LastCellNum);
+
+            // Remove all cells
+            row.RemoveCell(row.GetCell(1));
+            ClassicAssert.AreEqual(-1, row.FirstCellNum);
+            ClassicAssert.AreEqual(-1, row.LastCellNum);
+        }
+
+        [Test]
+        public void TestCellOrderingPersistsAfterSaveAndLoad()
+        {
+            // Create cells out of order, save, reload, verify order is preserved
+            using var workbook = new XSSFWorkbook();
+            var sheet = workbook.CreateSheet("test");
+            var row = sheet.CreateRow(0);
+
+            row.CreateCell(10).SetCellValue("C");
+            row.CreateCell(0).SetCellValue("A");
+            row.CreateCell(5).SetCellValue("B");
+
+            ClassicAssert.AreEqual(0, row.FirstCellNum);
+            ClassicAssert.AreEqual(11, row.LastCellNum);
+
+            // Save and reload
+            using var ms = new MemoryStream();
+            workbook.Write(ms, leaveOpen: true);
+            ms.Position = 0;
+
+            using var loaded = new XSSFWorkbook(ms);
+            var loadedRow = loaded.GetSheetAt(0).GetRow(0);
+
+            // Verify bounds
+            ClassicAssert.AreEqual(0, loadedRow.FirstCellNum);
+            ClassicAssert.AreEqual(11, loadedRow.LastCellNum);
+            ClassicAssert.AreEqual(3, loadedRow.PhysicalNumberOfCells);
+
+            // Verify iteration order
+            var cells = loadedRow.Cells;
+            ClassicAssert.AreEqual(0, cells[0].ColumnIndex);
+            ClassicAssert.AreEqual(5, cells[1].ColumnIndex);
+            ClassicAssert.AreEqual(10, cells[2].ColumnIndex);
+
+            // Verify cell values
+            ClassicAssert.AreEqual("A", loadedRow.GetCell(0).StringCellValue);
+            ClassicAssert.AreEqual("B", loadedRow.GetCell(5).StringCellValue);
+            ClassicAssert.AreEqual("C", loadedRow.GetCell(10).StringCellValue);
+        }
+
+        [Test]
+        public void TestLargeColumnIndex()
+        {
+            // Excel supports up to column 16383 (XFD)
+            using var workbook = new XSSFWorkbook();
+            var sheet = workbook.CreateSheet("test");
+            var row = sheet.CreateRow(0);
+
+            row.CreateCell(0).SetCellValue("first");
+            row.CreateCell(16383).SetCellValue("last");
+
+            ClassicAssert.AreEqual(0, row.FirstCellNum);
+            ClassicAssert.AreEqual(16384, row.LastCellNum);
+            ClassicAssert.AreEqual(2, row.PhysicalNumberOfCells);
+
+            // Verify both cells are accessible
+            ClassicAssert.AreEqual("first", row.GetCell(0).StringCellValue);
+            ClassicAssert.AreEqual("last", row.GetCell(16383).StringCellValue);
+
+            // Verify iteration includes both
+            var cells = row.Cells;
+            ClassicAssert.AreEqual(2, cells.Count);
+            ClassicAssert.AreEqual(0, cells[0].ColumnIndex);
+            ClassicAssert.AreEqual(16383, cells[1].ColumnIndex);
         }
 
     }


### PR DESCRIPTION
## Summary

- `XSSFRow.GetFirstKey()` and `GetLastKey()` used LINQ `Min()`/`Max()` which enumerate all dictionary keys on every call — O(n) per access
- `FirstCellNum` and `LastCellNum` are called in tight loops throughout the codebase (cell range iteration during copy, shift, auto-size, formula evaluation)
- Added cached min/max column indices, updated O(1) on `CreateCell()`, with lazy invalidation on `RemoveCell()` (only re-scans when a boundary cell is removed)
- Also adds 5 safety-net tests for previously uncovered patterns: sparse rows with distant columns, large column indices (16383), interleaved add/remove sequences, `.Cells` property ordering, and save/reload ordering persistence

### Benchmark results (10,000 repeated `FirstCellNum` + `LastCellNum` accesses)

| Scenario | Before | After | Speedup | Alloc Before | Alloc After |
|---|---|---|---|---|---|
| Sparse row (3 cells) | 799 μs | 11 μs | **71×** | 2,813 KB | **0 B** |
| Dense row (200 cells) | 25,724 μs | 11 μs | **2,276×** | 4,375 KB | **0 B** |
| Full cell range iteration (200 cells) | 277 μs | 3.1 μs | **89×** | 44 KB | **0 B** |

All 4,542 existing tests pass (OOXML: 1,792, Main: 2,750).

## Test plan

- [x] All existing XSSFRow tests pass (inherited from BaseTestRow + BaseTestXRow)
- [x] New tests cover sparse rows, large column indices, interleaved add/remove, ordering after save/reload
- [x] Benchmarks confirm significant speedup and zero allocation
- [x] Builds clean on both net8.0 and net472

🤖 Generated with [Claude Code](https://claude.com/claude-code)