### PR TITLE
Bump NuGetizer from 1.1.0 to 1.4.7

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="NuGetizer" Version="1.1.0" />
+    <PackageVersion Include="NuGetizer" Version="1.4.7" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />


### PR DESCRIPTION
## Summary
- Bumps NuGetizer from 1.1.0 to 1.4.7 in `Directory.Packages.props`
- NuGetizer is a build-time only tool (`PrivateAssets=all`) with no runtime impact on consumers
- Resolves IDE vulnerability warnings (Rider) flagged against the older version

## Test plan
- [x] `dotnet restore` succeeds
- [x] `dotnet build -c Release` succeeds with 0 warnings, 0 errors across all four target frameworks (net472, netstandard2.0, netstandard2.1, net8.0)
- [ ] Verify `dotnet pack` output produces equivalent `.nupkg` contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)