### PR TITLE
Restore sorted cell iteration order with lazy cache

### DIFF
--- a/main/HSSF/UserModel/HSSFRow.cs
+++ b/main/HSSF/UserModel/HSSFRow.cs
@@ -42,6 +42,7 @@ namespace NPOI.HSSF.UserModel
 
         private int rowNum;
         private Dictionary<int, ICell> cells = new Dictionary<int, ICell>();
+        private List<ICell> _sortedCellCache;
          
         /**
          * reference to low level representation
@@ -177,7 +178,7 @@ namespace NPOI.HSSF.UserModel
                 ((HSSFCell)cell).NotifyArrayFormulaChanging();
             }
             cells.Remove(column);
-
+            _sortedCellCache = null;
 
             if (alsoRemoveRecords)
             {
@@ -402,6 +403,7 @@ namespace NPOI.HSSF.UserModel
             //    Array.Copy(oldCells, 0, cells, 0, oldCells.Length);
             //}
             cells[column] = cell;
+            _sortedCellCache = null;
 
             // fix up firstCol and lastCol indexes
             if (row.IsEmpty|| column < row.FirstCol)
@@ -680,7 +682,7 @@ namespace NPOI.HSSF.UserModel
         public List<ICell> Cells
         {
             get {
-                return new List<ICell>(this.cells.Values);
+                return new List<ICell>(GetSortedCells());
             }
         }
 
@@ -720,7 +722,7 @@ namespace NPOI.HSSF.UserModel
         /// </remarks>
         public IEnumerator<ICell> GetEnumerator()
         {
-            return this.cells.Values.GetEnumerator();
+            return GetSortedCells().GetEnumerator();
         }
  
         /// <summary>
@@ -788,6 +790,15 @@ namespace NPOI.HSSF.UserModel
         public bool HasCustomHeight()
         {
             throw new NotImplementedException();
+        }
+
+        private List<ICell> GetSortedCells()
+        {
+            if (_sortedCellCache == null)
+            {
+                _sortedCellCache = cells.OrderBy(kv => kv.Key).Select(kv => kv.Value).ToList();
+            }
+            return _sortedCellCache;
         }
     }
 }

--- a/ooxml/XSSF/Streaming/SXSSFRow.cs
+++ b/ooxml/XSSF/Streaming/SXSSFRow.cs
@@ -27,6 +27,7 @@ namespace NPOI.XSSF.Streaming
     {
         private readonly SXSSFSheet _sheet; // parent sheet
         private readonly Dictionary<int, SXSSFCell> _cells = new Dictionary<int, SXSSFCell>();
+        private List<ICell> _sortedCellCache;
         private short _style = -1; // index of cell style in style table
         private bool _zHeight; // row zero-height (this is somehow different than being hidden)
         private float _height = -1;
@@ -53,7 +54,7 @@ namespace NPOI.XSSF.Streaming
 
         public List<ICell> Cells
         {
-            get { return _cells.Values.Select(cell => (ICell) cell).ToList(); }
+            get { return new List<ICell>(GetSortedCells()); }
         }
 
         public short FirstCellNum
@@ -235,6 +236,7 @@ namespace NPOI.XSSF.Streaming
             CheckBounds(column);
             SXSSFCell cell = new SXSSFCell(this, type);
             _cells[column] = cell;
+            _sortedCellCache = null;
             UpdateIndexWhenAdd(column);
             return cell;
         }
@@ -299,7 +301,7 @@ namespace NPOI.XSSF.Streaming
         }
         public IEnumerator<ICell> GetEnumerator()
         {
-            return _cells.Values.GetEnumerator();
+            return GetSortedCells().GetEnumerator();
         }
 
         public void MoveCell(ICell cell, int newColumn)
@@ -311,6 +313,7 @@ namespace NPOI.XSSF.Streaming
         {
             int index = GetCellIndex((SXSSFCell)cell);
             _cells.Remove(index);
+            _sortedCellCache = null;
             if (index == _firstCellNum)
             {
                 InvalidateFirstCellNum();
@@ -371,6 +374,15 @@ namespace NPOI.XSSF.Streaming
         IEnumerator IEnumerable.GetEnumerator()
         {
             return this.GetEnumerator();
+        }
+
+        private List<ICell> GetSortedCells()
+        {
+            if (_sortedCellCache == null)
+            {
+                _sortedCellCache = _cells.OrderBy(kv => kv.Key).Select(kv => (ICell)kv.Value).ToList();
+            }
+            return _sortedCellCache;
         }
 
         /**

--- a/ooxml/XSSF/UserModel/XSSFRow.cs
+++ b/ooxml/XSSF/UserModel/XSSFRow.cs
@@ -67,6 +67,12 @@ namespace NPOI.XSSF.UserModel
         /// Avoids O(n) LINQ Max() scan on every LastCellNum access.
         /// </summary>
         private int _cachedLastCellNum = -1;
+
+        /// <summary>
+        /// Lazily-built list of cells sorted by column index.
+        /// Null when invalidated; rebuilt on first read access.
+        /// </summary>
+        private List<ICell> _sortedCellCache;
         #endregion
 
         #region Public properties
@@ -561,8 +567,8 @@ namespace NPOI.XSSF.UserModel
         /// </summary>
         internal void OnDocumentWrite()
         {
-            var orderedCells = _cells.OrderBy(kv => kv.Key).Select(kv => (XSSFCell)kv.Value).ToList();
-            
+            var sortedCells = GetSortedCells();
+
             bool isOrdered = true;
             if (_row.SizeOfCArray() != _cells.Count)
             {
@@ -571,9 +577,9 @@ namespace NPOI.XSSF.UserModel
             else
             {
                 int i = 0;
-                foreach (XSSFCell cell in orderedCells)
+                foreach (ICell cell in sortedCells)
                 {
-                    CT_Cell c1 = cell.GetCTCell();
+                    CT_Cell c1 = ((XSSFCell)cell).GetCTCell();
                     CT_Cell c2 = _row.GetCArray(i++);
 
                     string r1 = c1.r;
@@ -590,7 +596,7 @@ namespace NPOI.XSSF.UserModel
             {
                 CT_Cell[] cArray = new CT_Cell[_cells.Count];
                 int i = 0;
-                foreach (XSSFCell c in orderedCells)
+                foreach (XSSFCell c in sortedCells.Cast<XSSFCell>())
                 {
                     cArray[i++] = c.GetCTCell();
                 }
@@ -653,6 +659,7 @@ namespace NPOI.XSSF.UserModel
             _row.c.Sort((col1, col2) => col1.r.CompareTo(col2.r));
 
             // Cache is invalid after rebuild — keys may have changed
+            _sortedCellCache = null;
             _cachedFirstCellNum = -1;
             _cachedLastCellNum = -1;
         }
@@ -660,21 +667,21 @@ namespace NPOI.XSSF.UserModel
 
         #region IEnumerable and IComparable members
         /// <summary>
-        /// Cell iterator over the physically defined cell
+        /// Cell iterator over the physically defined cells, sorted by column index.
         /// </summary>
-        /// <returns>an iterator over cells in this row.</returns>
-        public Dictionary<int, ICell>.ValueCollection.Enumerator CellIterator()
+        /// <returns>an iterator over cells in this row in ascending column order.</returns>
+        public IEnumerator<ICell> CellIterator()
         {
-            return _cells.Values.GetEnumerator();
+            return GetSortedCells().GetEnumerator();
         }
 
         /// <summary>
         /// Alias for <see cref="CellIterator"/> to allow  foreach loops
         /// </summary>
-        /// <returns>an iterator over cells in this row.</returns>
+        /// <returns>an iterator over cells in this row in ascending column order.</returns>
         public IEnumerator<ICell> GetEnumerator()
         {
-            return _cells.Values.GetEnumerator();
+            return GetSortedCells().GetEnumerator();
         }
 
         /// <summary>
@@ -723,13 +730,7 @@ namespace NPOI.XSSF.UserModel
         {
             get
             {
-                List<ICell> cells = new List<ICell>();
-                foreach (ICell cell in _cells.Values)
-                {
-                    cells.Add(cell);
-                }
-
-                return cells;
+                return new List<ICell>(GetSortedCells());
             }
         }
 
@@ -837,10 +838,24 @@ namespace NPOI.XSSF.UserModel
         }
 
         /// <summary>
+        /// Returns cells sorted by column index, using a lazily-built cache.
+        /// The cache is invalidated on any cell mutation (add/remove/rebuild).
+        /// </summary>
+        private List<ICell> GetSortedCells()
+        {
+            if (_sortedCellCache == null)
+            {
+                _sortedCellCache = _cells.OrderBy(kv => kv.Key).Select(kv => kv.Value).ToList();
+            }
+            return _sortedCellCache;
+        }
+
+        /// <summary>
         /// Update cached min/max on cell addition. O(1) — just compare with current bounds.
         /// </summary>
         private void UpdateCacheOnAdd(int columnIndex)
         {
+            _sortedCellCache = null;
             if (_cachedFirstCellNum < 0 || columnIndex < _cachedFirstCellNum)
             {
                 _cachedFirstCellNum = columnIndex;
@@ -857,6 +872,7 @@ namespace NPOI.XSSF.UserModel
         /// </summary>
         private void InvalidateCacheOnRemove(int removedIndex)
         {
+            _sortedCellCache = null;
             if (_cells.Count == 0)
             {
                 _cachedFirstCellNum = -1;


### PR DESCRIPTION
## Summary
- After #1753 replaced `SortedDictionary` with `Dictionary` in `XSSFRow`, `GetEnumerator()` and `Cells` no longer returned cells in ascending column order — a breaking change for existing consumers who `foreach` over rows
- Add a lazily-built sorted cell cache (`List<ICell>`) that is populated on first read and invalidated on mutation (add/remove/rebuild)
- Preserves the `Dictionary` O(1) insert/lookup performance win while restoring the sorted iteration contract
- Applied consistently to `XSSFRow`, `HSSFRow`, and `SXSSFRow`

## Context
Raised by @tonyqus in https://github.com/nissl-lab/npoi/pull/1742#issuecomment-4114684899 — the `SortedDictionary` → `Dictionary` change in #1753 means cells returned from `GetEnumerator` are no longer sorted by column index, which could break existing NPOI-based logic that assumes sorted iteration.

## Design
- **Reads dominate writes** (sheets are built once, iterated many times), so the sort is cached and reused across multiple iterations
- Cache is invalidated (`null`-ed) on any cell mutation — `CreateCell`, `RemoveCell`, `RebuildCells`
- In-flight enumerators see a stable snapshot (the old list), which is safer than the old `SortedDictionary` behavior that would throw `InvalidOperationException` on concurrent modification
- `XSSFRow.OnDocumentWrite()` also reuses the cache instead of re-sorting

## Test plan
- [x] `TestCellIterationOrderWithSparseColumns` passes (net8.0 + net472)
- [x] All XSSFRow tests pass: 34/34
- [x] All HSSFRow tests pass: 13/13
- [x] All SXSSFRow tests pass: 16/16

🤖 Generated with [Claude Code](https://claude.com/claude-code)