### PR TITLE
Fix: remove UTF-8 BOM from SheetDataWriter output

### DIFF
--- a/ooxml/XSSF/Streaming/SheetDataWriter.cs
+++ b/ooxml/XSSF/Streaming/SheetDataWriter.cs
@@ -48,12 +48,12 @@ namespace NPOI.XSSF.Streaming
          */
         private readonly SharedStringsTable _sharedStringSource;
         private readonly StreamWriter _out;
-
+        private static readonly Encoding Utf8WithoutBom = new UTF8Encoding(false);
         public SheetDataWriter()
         {
             TemporaryFileInfo = CreateTempFile();
             OutputStream = CreateWriter(TemporaryFileInfo);
-            _out = new StreamWriter(OutputStream, Encoding.UTF8, DefaultBufferSize);
+            _out = new StreamWriter(OutputStream, Utf8WithoutBom, DefaultBufferSize);
         }
         public SheetDataWriter(SharedStringsTable sharedStringsTable) : this()
         {


### PR DESCRIPTION
### Purpose
The standard `Encoding.UTF8` in .NET adds a BOM (Byte Order Mark) by default. This causes garbled characters or parsing errors in environments that expect a clean UTF-8 stream (like certain Linux systems or XML parsers).

### Changes
- In `SheetDataWriter` constructor, replaced `Encoding.UTF8` with `new UTF8Encoding(false)` to ensure the output stream is BOM-less.

### Verification
- Verified that the output temporary file does not start with `0xEF, 0xBB, 0xBF`.