### PR TITLE
Fix culture-sensitive numeric conversion in XDDF Chart data

### DIFF
--- a/ooxml/XDDF/UserModel/Chart/XDDFChart.cs
+++ b/ooxml/XDDF/UserModel/Chart/XDDFChart.cs
@@ -826,10 +826,21 @@ namespace NPOI.XDDF.UserModel.Chart
             {
                 XSSFRow row = GetRow(sheet, i + 1); // first row is for title
                 object val = categoryData.GetPointAt(i);
-                // OpenXML numeric values must be culture-invariant (using '.' as decimal separator).
-                // Since val is object, we check for IConvertible to use the culture-aware ToString overload.
-                string value = (val is IConvertible convertible) ? convertible.ToString(CultureInfo.InvariantCulture) : val?.ToString();
-                GetCell(row, categoryData.ColIndex).SetCellValue(value);
+                var categoryCell = GetCell(row, categoryData.ColIndex);
+
+                // If the value is numeric, write it as a numeric cell (double).
+                // This lets Excel handle the culture-sensitive display while 
+                // keeping the underlying data numeric.
+                // TypeCode 5 (SByte) through 15 (Decimal) are the numeric types.
+                if (val is IConvertible conv && conv.GetTypeCode() >= TypeCode.SByte && conv.GetTypeCode() <= TypeCode.Decimal)
+                {
+                    categoryCell.SetCellValue(conv.ToDouble(CultureInfo.InvariantCulture));
+                }
+                else
+                {
+                    categoryCell.SetCellValue(val?.ToString());
+                }
+
                 GetCell(row, valuesData.ColIndex).SetCellValue(Convert.ToDouble(valuesData.GetPointAt(i)));
             }
         }

--- a/ooxml/XDDF/UserModel/Chart/XDDFChart.cs
+++ b/ooxml/XDDF/UserModel/Chart/XDDFChart.cs
@@ -20,6 +20,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 using NPOI.Openxml4Net.Exceptions;
@@ -824,7 +825,11 @@ namespace NPOI.XDDF.UserModel.Chart
             for(int i = 0; i < numOfPoints; i++)
             {
                 XSSFRow row = GetRow(sheet, i + 1); // first row is for title
-                GetCell(row, categoryData.ColIndex).SetCellValue(categoryData.GetPointAt(i).ToString());
+                object val = categoryData.GetPointAt(i);
+                // OpenXML numeric values must be culture-invariant (using '.' as decimal separator).
+                // Since val is object, we check for IConvertible to use the culture-aware ToString overload.
+                string value = (val is IConvertible convertible) ? convertible.ToString(CultureInfo.InvariantCulture) : val?.ToString();
+                GetCell(row, categoryData.ColIndex).SetCellValue(value);
                 GetCell(row, valuesData.ColIndex).SetCellValue(Convert.ToDouble(valuesData.GetPointAt(i)));
             }
         }

--- a/ooxml/XDDF/UserModel/Chart/XDDFChartData.cs
+++ b/ooxml/XDDF/UserModel/Chart/XDDFChartData.cs
@@ -343,12 +343,9 @@ namespace NPOI.XDDF.UserModel.Chart
                 }
                 for(int i = 0; i < numOfPoints; ++i)
                 {
-                    object val = data.GetPointAt(i);
-                    if (val != null)
+                    string value = data.GetPointAt(i).ToString();
+                    if(value != null)
                     {
-                        // OpenXML numeric values must be culture-invariant (using '.' as decimal separator).
-                        // Since val is object, we check for IConvertible to use the culture-aware ToString overload.
-                        string value = (val is IConvertible convertible) ? convertible.ToString(CultureInfo.InvariantCulture) : val.ToString();
                         CT_StrVal ctStrVal = cache.AddNewPt();
                         ctStrVal.idx = (uint)i;
                         ctStrVal.v = value;
@@ -388,7 +385,10 @@ namespace NPOI.XDDF.UserModel.Chart
                         ctNumVal.idx = (uint)i;
                         // OpenXML numeric values must be culture-invariant (using '.' as decimal separator).
                         // Since value is object, we check for IConvertible to use the culture-aware ToString overload.
-                        ctNumVal.v = (value is IConvertible convertible) ? convertible.ToString(CultureInfo.InvariantCulture) : value.ToString();
+                        // TypeCode 5 (SByte) through 15 (Decimal) are the numeric types.
+                        ctNumVal.v = (value is IConvertible conv && conv.GetTypeCode() >= TypeCode.SByte && conv.GetTypeCode() <= TypeCode.Decimal) 
+                            ? conv.ToString(CultureInfo.InvariantCulture) 
+                            : value.ToString();
                     }
                 }
             }

--- a/ooxml/XDDF/UserModel/Chart/XDDFChartData.cs
+++ b/ooxml/XDDF/UserModel/Chart/XDDFChartData.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using NPOI.SS.Util;
 using NPOI.OpenXmlFormats.Dml.Chart;
 
@@ -342,9 +343,12 @@ namespace NPOI.XDDF.UserModel.Chart
                 }
                 for(int i = 0; i < numOfPoints; ++i)
                 {
-                    string value = data.GetPointAt(i).ToString();
-                    if(value != null)
+                    object val = data.GetPointAt(i);
+                    if (val != null)
                     {
+                        // OpenXML numeric values must be culture-invariant (using '.' as decimal separator).
+                        // Since val is object, we check for IConvertible to use the culture-aware ToString overload.
+                        string value = (val is IConvertible convertible) ? convertible.ToString(CultureInfo.InvariantCulture) : val.ToString();
                         CT_StrVal ctStrVal = cache.AddNewPt();
                         ctStrVal.idx = (uint)i;
                         ctStrVal.v = value;
@@ -382,7 +386,9 @@ namespace NPOI.XDDF.UserModel.Chart
                     {
                         CT_NumVal ctNumVal = cache.AddNewPt();
                         ctNumVal.idx = (uint)i;
-                        ctNumVal.v = value.ToString();
+                        // OpenXML numeric values must be culture-invariant (using '.' as decimal separator).
+                        // Since value is object, we check for IConvertible to use the culture-aware ToString overload.
+                        ctNumVal.v = (value is IConvertible convertible) ? convertible.ToString(CultureInfo.InvariantCulture) : value.ToString();
                     }
                 }
             }

--- a/testcases/ooxml/XDDF/UserModel/Chart/TestXDDFChartCulture.cs
+++ b/testcases/ooxml/XDDF/UserModel/Chart/TestXDDFChartCulture.cs
@@ -1,0 +1,99 @@
+/*
+ *  ====================================================================
+ *    Licensed to the Apache Software Foundation (ASF) under one or more
+ *    contributor license agreements.  See the NOTICE file distributed with
+ *    this work for additional information regarding copyright ownership.
+ *    The ASF licenses this file to You under the Apache License, Version 2.0
+ *    (the "License"); you may not use this file except in compliance with
+ *    the License.  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ * ====================================================================
+ */
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.UserModel;
+using NPOI.XDDF.UserModel.Chart;
+using NUnit.Framework;
+using NUnit.Framework.Legacy;
+using System.Xml;
+
+namespace TestCases.XDDF.UserModel.Chart
+{
+    [TestFixture]
+    public class TestXDDFChartCulture
+    {
+        [Test]
+        public void TestNumericConversionInNonUSCulture()
+        {
+            CultureInfo originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                // Set culture to one that uses comma as decimal separator
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+
+                XSSFWorkbook wb = new XSSFWorkbook();
+                XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("Sheet1");
+                
+                // Create some data
+                IRow row = sheet.CreateRow(0);
+                row.CreateCell(0).SetCellValue("Category");
+                row.CreateCell(1).SetCellValue("Value");
+                
+                row = sheet.CreateRow(1);
+                row.CreateCell(0).SetCellValue("A");
+                row.CreateCell(1).SetCellValue(1200.5); // 1200.5 should be 1200,5 in de-DE
+
+                XSSFDrawing drawing = (XSSFDrawing)sheet.CreateDrawingPatriarch();
+                XSSFClientAnchor anchor = (XSSFClientAnchor)drawing.CreateAnchor(0, 0, 0, 0, 2, 2, 10, 10);
+                XSSFChart chart = (XSSFChart)drawing.CreateChart(anchor);
+
+                XDDFCategoryAxis bottomAxis = chart.CreateCategoryAxis(AxisPosition.Bottom);
+                XDDFValueAxis leftAxis = chart.CreateValueAxis(AxisPosition.Left);
+
+                XDDFChartData<string, double> data = chart.CreateData<string, double>(ChartTypes.BAR, bottomAxis, leftAxis);
+                
+                var cat = XDDFDataSourcesFactory.FromStringCellRange(sheet, new NPOI.SS.Util.CellRangeAddress(1, 1, 0, 0));
+                var val = XDDFDataSourcesFactory.FromNumericCellRange(sheet, new NPOI.SS.Util.CellRangeAddress(1, 1, 1, 1));
+                
+                data.AddSeries(cat, val);
+                chart.Plot(data);
+
+                // Export to XML and check values
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    wb.Write(ms);
+                    
+                    // We need to look into the chart XML. 
+                    // Instead of full unzip, we can inspect the XDDFChart's internal CT_ChartSpace
+                    var chartSpace = chart.GetCTChartSpace();
+                    string xml;
+                    using (var xmlStream = new MemoryStream())
+                    {
+                        chartSpace.Save(xmlStream);
+                        xml = System.Text.Encoding.UTF8.GetString(xmlStream.ToArray());
+                    }
+
+                    // Check if the value 1200.5 is present with a dot, not a comma
+                    // In XML it should look like <c:v>1200.5</c:v>
+                    ClassicAssert.IsTrue(xml.Contains("<c:v>1200.5</c:v>"), "XML should contain '1200.5' with a dot separator, found: " + xml);
+                    ClassicAssert.IsFalse(xml.Contains("<c:v>1200,5</c:v>"), "XML should NOT contain '1200,5' with a comma separator");
+                }
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
+        }
+    }
+}

--- a/testcases/ooxml/XDDF/UserModel/Chart/TestXDDFChartCulture.cs
+++ b/testcases/ooxml/XDDF/UserModel/Chart/TestXDDFChartCulture.cs
@@ -51,8 +51,8 @@ namespace TestCases.XDDF.UserModel.Chart
                 row.CreateCell(1).SetCellValue("Value");
                 
                 row = sheet.CreateRow(1);
-                row.CreateCell(0).SetCellValue("A");
-                row.CreateCell(1).SetCellValue(1200.5); // 1200.5 should be 1200,5 in de-DE
+                row.CreateCell(0).SetCellValue(1200.5); // Numeric category
+                row.CreateCell(1).SetCellValue(2400.1); // Numeric value
 
                 XSSFDrawing drawing = (XSSFDrawing)sheet.CreateDrawingPatriarch();
                 XSSFClientAnchor anchor = (XSSFClientAnchor)drawing.CreateAnchor(0, 0, 0, 0, 2, 2, 10, 10);
@@ -61,9 +61,9 @@ namespace TestCases.XDDF.UserModel.Chart
                 XDDFCategoryAxis bottomAxis = chart.CreateCategoryAxis(AxisPosition.Bottom);
                 XDDFValueAxis leftAxis = chart.CreateValueAxis(AxisPosition.Left);
 
-                XDDFChartData<string, double> data = chart.CreateData<string, double>(ChartTypes.BAR, bottomAxis, leftAxis);
+                XDDFChartData<double, double> data = chart.CreateData<double, double>(ChartTypes.BAR, bottomAxis, leftAxis);
                 
-                var cat = XDDFDataSourcesFactory.FromStringCellRange(sheet, new NPOI.SS.Util.CellRangeAddress(1, 1, 0, 0));
+                var cat = XDDFDataSourcesFactory.FromNumericCellRange(sheet, new NPOI.SS.Util.CellRangeAddress(1, 1, 0, 0));
                 var val = XDDFDataSourcesFactory.FromNumericCellRange(sheet, new NPOI.SS.Util.CellRangeAddress(1, 1, 1, 1));
                 
                 data.AddSeries(cat, val);
@@ -84,10 +84,116 @@ namespace TestCases.XDDF.UserModel.Chart
                         xml = System.Text.Encoding.UTF8.GetString(xmlStream.ToArray());
                     }
 
-                    // Check if the value 1200.5 is present with a dot, not a comma
-                    // In XML it should look like <c:v>1200.5</c:v>
-                    ClassicAssert.IsTrue(xml.Contains("<c:v>1200.5</c:v>"), "XML should contain '1200.5' with a dot separator, found: " + xml);
-                    ClassicAssert.IsFalse(xml.Contains("<c:v>1200,5</c:v>"), "XML should NOT contain '1200,5' with a comma separator");
+                    // Robust check: Parse XML and look for <v> elements in the chart namespace
+                    XmlDocument doc = new XmlDocument();
+                    doc.LoadXml(xml);
+                    XmlNamespaceManager nsmgr = new XmlNamespaceManager(doc.NameTable);
+                    // OpenXML Chart namespace
+                    nsmgr.AddNamespace("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+
+                    XmlNodeList vElements = doc.SelectNodes("//c:v", nsmgr);
+                    bool foundCorrectCat = false;
+                    bool foundIncorrectCat = false;
+                    bool foundCorrectVal = false;
+                    bool foundIncorrectVal = false;
+
+                    foreach (XmlNode v in vElements)
+                    {
+                        if (v.InnerText == "1200.5") foundCorrectCat = true;
+                        if (v.InnerText == "1200,5") foundIncorrectCat = true;
+                        if (v.InnerText == "2400.1") foundCorrectVal = true;
+                        if (v.InnerText == "2400,1") foundIncorrectVal = true;
+                    }
+
+                    ClassicAssert.IsTrue(foundCorrectCat, "Category '1200.5' should be present in XML with a dot separator.");
+                    ClassicAssert.IsFalse(foundIncorrectCat, "Category '1200,5' should NOT be present in XML with a comma separator.");
+                    ClassicAssert.IsTrue(foundCorrectVal, "Value '2400.1' should be present in XML with a dot separator.");
+                    ClassicAssert.IsFalse(foundIncorrectVal, "Value '2400,1' should NOT be present in XML with a comma separator.");
+
+                    // Also check the embedded workbook cells (FillSheet)
+                    XSSFWorkbook embeddedWb = chart.GetWorkbook();
+                    ISheet embeddedSheet = embeddedWb.GetSheetAt(0);
+                    IRow embeddedRow = embeddedSheet.GetRow(1); // Row 1 has data
+                    ICell categoryCell = embeddedRow.GetCell(0); // Col 0 is category
+
+                    ClassicAssert.AreEqual(CellType.Numeric, categoryCell.CellType, "Category cell in embedded workbook should be numeric");
+                    ClassicAssert.AreEqual(1200.5, categoryCell.NumericCellValue, 0.0001, "Category cell value should match");
+                }
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
+        }
+
+        [Test]
+        public void TestDateTimeCategoryPreservesCulture()
+        {
+            CultureInfo originalCulture = Thread.CurrentThread.CurrentCulture;
+            try
+            {
+                // Set culture to one that uses dots for dates and commas for decimals
+                Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+                DateTime testDate = new DateTime(2026, 4, 28);
+                string expectedDateString = testDate.ToString(); // "28.04.2026 ..." in de-DE
+
+                XSSFWorkbook wb = new XSSFWorkbook();
+                XSSFSheet sheet = (XSSFSheet)wb.CreateSheet("Sheet1");
+                
+                IRow row = sheet.CreateRow(0);
+                row.CreateCell(0).SetCellValue("Date");
+                row.CreateCell(1).SetCellValue("Value");
+                
+                row = sheet.CreateRow(1);
+                row.CreateCell(0).SetCellValue(testDate);
+                row.CreateCell(1).SetCellValue(1200.5);
+
+                XSSFDrawing drawing = (XSSFDrawing)sheet.CreateDrawingPatriarch();
+                XSSFClientAnchor anchor = (XSSFClientAnchor)drawing.CreateAnchor(0, 0, 0, 0, 2, 2, 10, 10);
+                XSSFChart chart = (XSSFChart)drawing.CreateChart(anchor);
+
+                XDDFCategoryAxis bottomAxis = chart.CreateCategoryAxis(AxisPosition.Bottom);
+                XDDFValueAxis leftAxis = chart.CreateValueAxis(AxisPosition.Left);
+
+                XDDFChartData<string, double> data = chart.CreateData<string, double>(ChartTypes.BAR, bottomAxis, leftAxis);
+                
+                // Use a manual data source to ensure we pass a string that should be preserved
+                var cat = XDDFDataSourcesFactory.FromArray(new string[] { expectedDateString }, null);
+                var val = XDDFDataSourcesFactory.FromNumericCellRange(sheet, new NPOI.SS.Util.CellRangeAddress(1, 1, 1, 1));
+                
+                data.AddSeries(cat, val);
+                chart.Plot(data);
+
+                using (MemoryStream ms = new MemoryStream())
+                {
+                    wb.Write(ms);
+                    
+                    var chartSpace = chart.GetCTChartSpace();
+                    string xml;
+                    using (var xmlStream = new MemoryStream())
+                    {
+                        chartSpace.Save(xmlStream);
+                        xml = System.Text.Encoding.UTF8.GetString(xmlStream.ToArray());
+                    }
+
+                    XmlDocument doc = new XmlDocument();
+                    doc.LoadXml(xml);
+                    XmlNamespaceManager nsmgr = new XmlNamespaceManager(doc.NameTable);
+                    nsmgr.AddNamespace("c", "http://schemas.openxmlformats.org/drawingml/2006/chart");
+
+                    // Check string cache (labels)
+                    XmlNodeList vElements = doc.SelectNodes("//c:v", nsmgr);
+                    bool foundDate = false;
+                    bool foundValue = false;
+
+                    foreach (XmlNode v in vElements)
+                    {
+                        if (v.InnerText == expectedDateString) foundDate = true;
+                        if (v.InnerText == "1200.5") foundValue = true;
+                    }
+
+                    ClassicAssert.IsTrue(foundDate, "DateTime label should use culture-sensitive formatting: " + expectedDateString);
+                    ClassicAssert.IsTrue(foundValue, "Numeric value should still use dots in XML: 1200.5");
                 }
             }
             finally


### PR DESCRIPTION
### Description
This PR fixes an issue where XDDF charts generate corrupt XLSX files when the application is running in a locale that uses a decimal separator other than a dot (e.g., German, French, or Dutch locales using a comma).

### Root Cause
The root cause was identified in XDDFChartData.cs and XDDFChart.cs, where ToString() was called on generic data objects (numeric values) without specifying CultureInfo.InvariantCulture. This caused the underlying .NET runtime to use the current thread's culture for string conversion, resulting in XML tags like <c:v>1200,5</c:v>. Since the OpenXML specification strictly requires dots as decimal separators, Excel would fail to open the file, reporting a corruption error and removing the drawing part.

### Changes
- Updated FillStringCache and FillNumCache in XDDFChartData.cs to cast data points to IConvertible and use ToString(CultureInfo.InvariantCulture).
- Updated FillSheet in XDDFChart.cs to use the same culture-invariant conversion logic.
- Added using System.Globalization; where missing.
 - Added a new unit test TestXDDFChartCulture that reproduces the bug by switching the Thread.CurrentCulture to de-DE and asserting that the generated chart XML contains dot separators.

### Verification
Verified by running the new unit test TestNumericConversionInNonUSCulture in TestXDDFChartCulture.cs across target frameworks.