### PR TITLE
Optimize Number.BitCount() on newer runtimes

### DIFF
--- a/main/Util/Number.cs
+++ b/main/Util/Number.cs
@@ -1,6 +1,7 @@
 ﻿using ExtendedNumerics;
 using System;
 using System.Collections;
+using System.Numerics;
 
 namespace NPOI.Util
 {
@@ -8,6 +9,9 @@ namespace NPOI.Util
     {
         public static int BitCount(int i)
         {
+#if NET8_0_OR_GREATER
+            return BitOperations.PopCount((uint)i);
+#else
             BitArray bitArray = new BitArray(BitConverter.GetBytes(i));
             int count = 0;
             for (int idx = 0; idx < bitArray.Count; idx++)
@@ -22,13 +26,15 @@ namespace NPOI.Util
             //i = i + (i >>> 8);
             //i = i + (i >>> 16);
             //return i & 0x3f;
+#endif
+
         }
-        private static Type BoolType = typeof(bool);
-        private static Type CharType = typeof(char);
-        private static Type IntPtrType = typeof(IntPtr);
-        private static Type UIntPtrType = typeof(UIntPtr);
-        private static Type DecimalType = typeof(decimal);
-        private static Type BigDecimalType = typeof(BigDecimal);
+        private static readonly Type BoolType = typeof(bool);
+        private static readonly Type CharType = typeof(char);
+        private static readonly Type IntPtrType = typeof(IntPtr);
+        private static readonly Type UIntPtrType = typeof(UIntPtr);
+        private static readonly Type DecimalType = typeof(decimal);
+        private static readonly Type BigDecimalType = typeof(BigDecimal);
         public static bool IsNumber(object value)
         {
             if (value == null)

--- a/main/Util/Number.cs
+++ b/main/Util/Number.cs
@@ -1,7 +1,9 @@
 ﻿using ExtendedNumerics;
 using System;
 using System.Collections;
+#if NET8_0_OR_GREATER
 using System.Numerics;
+#endif
 
 namespace NPOI.Util
 {

--- a/testcases/main/Util/TestNumber.cs
+++ b/testcases/main/Util/TestNumber.cs
@@ -1,0 +1,16 @@
+﻿using NPOI.Util;
+using NUnit.Framework;
+
+namespace TestCases.Util
+{
+    internal class TestNumber
+    {
+        [TestCase(1, ExpectedResult = 1)]
+        [TestCase(16, ExpectedResult = 1)]
+        [TestCase(31, ExpectedResult = 5)]
+        [TestCase(-1, ExpectedResult = 32)]
+        [TestCase(int.MaxValue, ExpectedResult = 31)]
+        [TestCase(int.MinValue, ExpectedResult = 1)]
+        public static int TestBitCount(int value) => Number.BitCount(value);
+    }
+}

--- a/testcases/main/Util/TestNumber.cs
+++ b/testcases/main/Util/TestNumber.cs
@@ -5,6 +5,7 @@ namespace TestCases.Util
 {
     internal class TestNumber
     {
+        [TestCase(0, ExpectedResult = 0)]
         [TestCase(1, ExpectedResult = 1)]
         [TestCase(16, ExpectedResult = 1)]
         [TestCase(31, ExpectedResult = 5)]

--- a/testcases/main/Util/TestNumber.cs
+++ b/testcases/main/Util/TestNumber.cs
@@ -3,7 +3,8 @@ using NUnit.Framework;
 
 namespace TestCases.Util
 {
-    internal class TestNumber
+    [TestFixture]
+    internal static class TestNumber
     {
         [TestCase(0, ExpectedResult = 0)]
         [TestCase(1, ExpectedResult = 1)]


### PR DESCRIPTION
Use an intrinsic operation to count the number of set bits for builds whose runtimes support it.

Benchmarks:
| Method    | Mean       | Error     | StdDev    | Median     | Ratio | Code Size | Gen0   | Allocated | Alloc Ratio |
|---------- |-----------:|----------:|----------:|-----------:|------:|----------:|-------:|----------:|------------:|
| Original  | 22.6572 ns | 0.1990 ns | 0.1553 ns | 22.6226 ns | 1.000 |   1,697 B | 0.0102 |      64 B |        1.00 |
| Optimized |  0.0177 ns | 0.0222 ns | 0.0185 ns |  0.0097 ns | 0.001 |      11 B |      - |         - |        0.00 |