### PR TITLE
Optimize PngUtils.MatchesPngHeader()

### DIFF
--- a/main/Util/PngUtils.cs
+++ b/main/Util/PngUtils.cs
@@ -15,6 +15,8 @@
    limitations Under the License.
 ==================================================================== */
 
+using System;
+
 namespace NPOI.Util
 {
     public class PngUtils
@@ -22,7 +24,7 @@ namespace NPOI.Util
         /**
      * File header for PNG format.
      */
-        private static byte[] PNG_FILE_HEADER =
+        private static readonly byte[] PNG_FILE_HEADER =
             new byte[] { (byte)0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
 
         private PngUtils()
@@ -44,15 +46,7 @@ namespace NPOI.Util
                 return false;
             }
 
-            for (int i = 0; i < PNG_FILE_HEADER.Length; i++)
-            {
-                if (PNG_FILE_HEADER[i] != data[i + offset])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return data.AsSpan(offset, PNG_FILE_HEADER.Length).SequenceEqual(PNG_FILE_HEADER);
         }
     }
 }

--- a/testcases/main/Util/TestPngUtils.cs
+++ b/testcases/main/Util/TestPngUtils.cs
@@ -1,0 +1,21 @@
+﻿using NPOI.Util;
+using NUnit.Framework;
+
+namespace TestCases.Util
+{
+    internal class TestPngUtils
+    {
+        [Test]
+        public void TestMatchesPngHeader()
+        {
+            byte[] pngData = new byte[] { (byte)0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+            Assert.IsTrue(PngUtils.MatchesPngHeader(pngData, 0));
+
+            byte[] nonPngData = new byte[] { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77 };
+            Assert.IsFalse(PngUtils.MatchesPngHeader(nonPngData, 0));
+
+            byte[] dataWithOffset = new byte[] { 0x00, (byte)0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+            Assert.IsTrue(PngUtils.MatchesPngHeader(dataWithOffset, 1));
+        }
+    }
+}


### PR DESCRIPTION
Optimize the `PngUtils.MatchesPngHeader()` by using `SequenceEquals()` instead of a dedicated loop

Benchmarks::

| Method    | Mean      | Error     | StdDev    | Ratio | Code Size | Allocated | Alloc Ratio |
|---------- |----------:|----------:|----------:|------:|----------:|----------:|------------:|
| Original  | 2.0034 ns | 0.0249 ns | 0.0208 ns |  1.00 |      95 B |         - |          NA |
| Optimized | 0.3293 ns | 0.0240 ns | 0.0212 ns |  0.16 |     105 B |         - |          NA |