### PR TITLE
Add VML support for OLE embedded objects in XSSF

### DIFF
--- a/OpenXmlFormats/Vml/Main.cs
+++ b/OpenXmlFormats/Vml/Main.cs
@@ -653,6 +653,8 @@ namespace NPOI.OpenXmlFormats.Vml
             ctObj.adj = XmlHelper.ReadString(node.Attributes["adj"]);
             ctObj.equationxml = XmlHelper.ReadString(node.Attributes["equationxml"]);
             ctObj.style = XmlHelper.ReadString(node.Attributes["style"]);
+            if (node.Attributes["o:ole"] != null)
+                ctObj.ole = node.Attributes["o:ole"].Value;
             ctObj.ClientData = new List<CT_ClientData>();
             foreach (XmlNode childNode in node.ChildNodes)
             {
@@ -730,6 +732,7 @@ namespace NPOI.OpenXmlFormats.Vml
             XmlHelper.WriteAttribute(sw, "o:insetmode", this.insetmode.ToString());
             XmlHelper.WriteAttribute(sw, "adj", this.adj);
             XmlHelper.WriteAttribute(sw, "equationxml", this.equationxml);
+            XmlHelper.WriteAttribute(sw, "o:ole", this.ole, true);
             sw.Write('>');
 
             if (this.iscomment != null)
@@ -840,6 +843,15 @@ namespace NPOI.OpenXmlFormats.Vml
         private CT_Fill fillField;
         private CT_Formulas formulasField;
         private CT_Handles handlesField;
+        private string oleField;
+
+        [XmlAttribute(Namespace = "urn:schemas-microsoft-com:office:office")]
+        public string ole
+        {
+            get { return this.oleField; }
+            set { this.oleField = value; }
+        }
+
         private CT_ImageData imagedataField;
         private CT_Stroke strokeField;
         private CT_Shadow shadowField;

--- a/OpenXmlFormats/Vml/SpreadsheetDrawing.cs
+++ b/OpenXmlFormats/Vml/SpreadsheetDrawing.cs
@@ -192,6 +192,8 @@ namespace NPOI.OpenXmlFormats.Vml.Spreadsheet
                     ctObj.column.Add(Int32.Parse(childNode.InnerText));
                 else if (childNode.LocalName == "Row")
                     ctObj.row.Add(Int32.Parse(childNode.InnerText));
+                else if (childNode.LocalName == "FmlaPict")
+                    ctObj.fmlaPictField = childNode.InnerText;
             }
             return ctObj;
         }
@@ -231,6 +233,8 @@ namespace NPOI.OpenXmlFormats.Vml.Spreadsheet
                     sw.Write("</x:Column>");
                 }
             }
+            if (this.fmlaPictField != null)
+                sw.WriteElementAndContent("x:FmlaPict", this.fmlaPictField);
             sw.WriteEndElement("x", nodeName);
         }
 
@@ -337,6 +341,15 @@ namespace NPOI.OpenXmlFormats.Vml.Spreadsheet
         {
             return sizeWithCellsFieldSpecified ? 1 : 0;
         }
+        private string fmlaPictField;
+
+        [XmlElement(ElementName = "FmlaPict")]
+        public string FmlaPict
+        {
+            get { return this.fmlaPictField; }
+            set { this.fmlaPictField = value; }
+        }
+
         ST_TrueFalseBlank sizeWithCellsField = ST_TrueFalseBlank.NONE;
         bool sizeWithCellsFieldSpecified = false;
 

--- a/ooxml/XSSF/UserModel/XSSFDrawing.cs
+++ b/ooxml/XSSF/UserModel/XSSFDrawing.cs
@@ -532,7 +532,7 @@ namespace NPOI.XSSF.UserModel
             ctShape.Set(XSSFObjectData.Prototype());
             ctShape.spPr.xfrm = (CreateXfrm((XSSFClientAnchor) anchor));
 
-            // workaround for not having the vmlDrawing filled
+            // add image fill to drawingML shape for preview icon in Excel
             NPOI.OpenXmlFormats.Dml.Spreadsheet.CT_BlipFillProperties blipFill = ctShape.spPr.AddNewBlipFill();
             blipFill.AddNewBlip().embed = imgDrawPR.Id;
             blipFill.AddNewStretch().AddNewFillRect();
@@ -563,7 +563,7 @@ namespace NPOI.XSSF.UserModel
             {
                 vmlImgRel = vmlPart.AddRelationship(imgPN, TargetMode.Internal, PackageRelationshipTypes.IMAGE_PART);
             }
-            vml.newOleShape(anchor.Row1, anchor.Col1, vmlImgRel?.Id);
+            vml.newOleShape(anchor.Row1, anchor.Col1, anchor.Row2, anchor.Col2, vmlImgRel?.Id, "_x0000_s" + shapeId);
 
             return shape;
         }

--- a/ooxml/XSSF/UserModel/XSSFDrawing.cs
+++ b/ooxml/XSSF/UserModel/XSSFDrawing.cs
@@ -502,6 +502,17 @@ namespace NPOI.XSSF.UserModel
             ole1.objectPr.defaultSize = false;
             ole1.objectPr.anchor.moveWithCells = true;
 
+            // Set oleObject anchor coordinates from the client anchor
+            XSSFClientAnchor ca = (XSSFClientAnchor)anchor;
+            ole1.objectPr.anchor.from.col = ca.Col1;
+            ole1.objectPr.anchor.from.colOff = ca.Dx1;
+            ole1.objectPr.anchor.from.row = ca.Row1;
+            ole1.objectPr.anchor.from.rowOff = ca.Dy1;
+            ole1.objectPr.anchor.to.col = ca.Col2;
+            ole1.objectPr.anchor.to.colOff = ca.Dx2;
+            ole1.objectPr.anchor.to.row = ca.Row2;
+            ole1.objectPr.anchor.to.rowOff = ca.Dy2;
+
             CT_TwoCellAnchor ctAnchor = CreateTwoCellAnchor((XSSFClientAnchor)anchor);
 
             //XmlCursor cur2 = ctAnchor.newCursor();
@@ -543,6 +554,16 @@ namespace NPOI.XSSF.UserModel
 
             XSSFObjectData shape = new XSSFObjectData(this, ctShape);
             shape.anchor = (XSSFClientAnchor) anchor;
+
+            // create VML shape for OLE object visibility in Excel
+            XSSFVMLDrawing vml = sheet.GetVMLDrawing(true);
+            PackagePart vmlPart = vml.GetPackagePart();
+            PackageRelationship vmlImgRel = null;
+            if (vmlPart != null)
+            {
+                vmlImgRel = vmlPart.AddRelationship(imgPN, TargetMode.Internal, PackageRelationshipTypes.IMAGE_PART);
+            }
+            vml.newOleShape(anchor.Row1, anchor.Col1, vmlImgRel?.Id);
 
             return shape;
         }

--- a/ooxml/XSSF/UserModel/XSSFVMLDrawing.cs
+++ b/ooxml/XSSF/UserModel/XSSFVMLDrawing.cs
@@ -320,13 +320,13 @@ namespace NPOI.XSSF.UserModel
             _items.Insert(1, doc.DocumentElement); // insert after shapelayout, before comment shapetype
         }
 
-        internal CT_Shape newOleShape(int row, int col, string imageRelId)
+        internal CT_Shape newOleShape(int row1, int col1, int row2, int col2, string imageRelId, string shapeId)
         {
             EnsureOleShapetype();
 
             CT_Shape shape = new CT_Shape();
 
-            shape.id = "_x0000_s" + (++_shapeId);
+            shape.id = shapeId;
             shape.type = "#" + OLE_SHAPE_TYPE_ID;
             shape.style = "position:absolute;margin-left:0;margin-top:0;width:72pt;height:72pt;z-index:1";
             shape.ole = "";
@@ -339,7 +339,7 @@ namespace NPOI.XSSF.UserModel
             cldata.ObjectType = ST_ObjectType.Pict;
             cldata.FmlaPict = "=EMBED(\"Packager Shell Object\",\"\")";
             // VML Anchor format: col1, dx1, row1, dy1, col2, dx2, row2, dy2
-            cldata.AddNewAnchor(col + ", 0, " + row + ", 0, " + (col + 2) + ", 0, " + (row + 3) + ", 0");
+            cldata.AddNewAnchor(col1 + ", 0, " + row1 + ", 0, " + col2 + ", 0, " + row2 + ", 0");
             cldata.AddNewSizeWithCells();
             cldata.AddNewMoveWithCells();
             cldata.AddNewAutoFill(ST_TrueFalseBlank.@false);

--- a/ooxml/XSSF/UserModel/XSSFVMLDrawing.cs
+++ b/ooxml/XSSF/UserModel/XSSFVMLDrawing.cs
@@ -65,6 +65,7 @@ namespace NPOI.XSSF.UserModel
         private static XmlQualifiedName QNAME_SHAPE_TYPE = new XmlQualifiedName("shapetype", "urn:schemas-microsoft-com:vml");
         private static XmlQualifiedName QNAME_SHAPE = new XmlQualifiedName("shape", "urn:schemas-microsoft-com:vml");
         private static string COMMENT_SHAPE_TYPE_ID = "_x0000_t202"; // this ID value seems to have significance to Excel >= 2010; see https://issues.apache.org/bugzilla/show_bug.cgi?id=55409
+        private static string OLE_SHAPE_TYPE_ID = "_x0000_t75";  // shapetype for embedded OLE objects / pictures
         /**
          * regexp to parse shape ids, in VML they have weird form of id="_x0000_s1026"
          */
@@ -278,6 +279,70 @@ namespace NPOI.XSSF.UserModel
             cldata.AddNewAutoFill(ST_TrueFalseBlank.@false);
             cldata.AddNewRow(0);
             cldata.AddNewColumn(0);
+            _items.Add(shape);
+
+            return shape;
+        }
+
+        private void EnsureOleShapetype()
+        {
+            // Check if _x0000_t75 already exists
+            foreach (object item in _items)
+            {
+                if (item is CT_Shapetype st && OLE_SHAPE_TYPE_ID == st.id)
+                    return;
+            }
+
+            // Create the standard picture/OLE shapetype _x0000_t75
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(
+                "<v:shapetype id=\"" + OLE_SHAPE_TYPE_ID + "\" coordsize=\"21600,21600\" o:spt=\"75\"" +
+                " o:preferrelative=\"t\" path=\"m@4@5l@4@11@9@11@9@5xe\" filled=\"f\" stroked=\"f\"" +
+                " xmlns:v=\"urn:schemas-microsoft-com:vml\" xmlns:o=\"urn:schemas-microsoft-com:office:office\">" +
+                "<v:stroke joinstyle=\"miter\"/>" +
+                "<v:formulas>" +
+                "<v:f eqn=\"if lineDrawn pixelLineWidth 0\"/>" +
+                "<v:f eqn=\"sum @0 1 0\"/>" +
+                "<v:f eqn=\"sum 0 0 @1\"/>" +
+                "<v:f eqn=\"prod @2 1 2\"/>" +
+                "<v:f eqn=\"prod @3 21600 pixelWidth\"/>" +
+                "<v:f eqn=\"prod @3 21600 pixelHeight\"/>" +
+                "<v:f eqn=\"sum @0 0 1\"/>" +
+                "<v:f eqn=\"prod @6 1 2\"/>" +
+                "<v:f eqn=\"prod @7 21600 pixelWidth\"/>" +
+                "<v:f eqn=\"sum @8 21600 0\"/>" +
+                "<v:f eqn=\"prod @7 21600 pixelHeight\"/>" +
+                "<v:f eqn=\"sum @10 21600 0\"/>" +
+                "</v:formulas>" +
+                "<v:path o:extrusionok=\"f\" gradientshapeok=\"t\" o:connecttype=\"rect\"/>" +
+                "<o:lock v:ext=\"edit\" aspectratio=\"t\"/>" +
+                "</v:shapetype>");
+            _items.Insert(1, doc.DocumentElement); // insert after shapelayout, before comment shapetype
+        }
+
+        internal CT_Shape newOleShape(int row, int col, string imageRelId)
+        {
+            EnsureOleShapetype();
+
+            CT_Shape shape = new CT_Shape();
+
+            shape.id = "_x0000_s" + (++_shapeId);
+            shape.type = "#" + OLE_SHAPE_TYPE_ID;
+            shape.style = "position:absolute;margin-left:0;margin-top:0;width:72pt;height:72pt;z-index:1";
+            shape.ole = "";
+            shape.fillcolor = ("window [65]");
+            shape.AddNewFill().color2 = ("window [65]");
+            shape.imagedata = new CT_ImageData();
+            shape.imagedata.relid = imageRelId;
+            shape.imagedata.title = "";
+            CT_ClientData cldata = shape.AddNewClientData();
+            cldata.ObjectType = ST_ObjectType.Pict;
+            cldata.FmlaPict = "=EMBED(\"Packager Shell Object\",\"\")";
+            // VML Anchor format: col1, dx1, row1, dy1, col2, dx2, row2, dy2
+            cldata.AddNewAnchor(col + ", 0, " + row + ", 0, " + (col + 2) + ", 0, " + (row + 3) + ", 0");
+            cldata.AddNewSizeWithCells();
+            cldata.AddNewMoveWithCells();
+            cldata.AddNewAutoFill(ST_TrueFalseBlank.@false);
             _items.Add(shape);
 
             return shape;

--- a/testcases/ooxml/SS/UserModel/TestEmbedOLEPackage.cs
+++ b/testcases/ooxml/SS/UserModel/TestEmbedOLEPackage.cs
@@ -20,12 +20,15 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace TestCases.SS.UserModel
 {
     using NPOI.HSSF;
     using NPOI.HSSF.UserModel;
+    using NPOI.OpenXmlFormats.Vml;
+    using NPOI.OpenXmlFormats.Vml.Spreadsheet;
     using NPOI.SS.Extractor;
     using NPOI.SS.UserModel;
     using NPOI.Util;
@@ -100,6 +103,95 @@ namespace TestCases.SS.UserModel
             EmbeddedExtractor ee = new EmbeddedExtractor();
             EmbeddedData ed = ee.ExtractAll(wb2.GetSheetAt(0))[0];
             CollectionAssert.AreEqual(samplePPT, ed.GetEmbeddedData());
+
+            wb2.Close();
+            wb1.Close();
+        }
+
+        [Test]
+        public void EmbedXSSF_VMLShapeCreated()
+        {
+            IWorkbook wb1 = new XSSFWorkbook();
+            ISheet sh = wb1.CreateSheet();
+            int picIdx = wb1.AddPicture(GetSamplePng(), PictureType.PNG);
+            byte[] samplePPTX = GetSamplePPT(true);
+            int oleIdx = wb1.AddOlePackage(samplePPTX, "dummy.pptx", "dummy.pptx", "dummy.pptx");
+
+            IDrawing<IShape> pat = sh.CreateDrawingPatriarch();
+            IClientAnchor anchor = pat.CreateAnchor(0, 0, 0, 0, 2, 3, 5, 8);
+            pat.CreateObjectData(anchor, oleIdx, picIdx);
+
+            IWorkbook wb2 = XSSFTestDataSamples.WriteOutAndReadBack(wb1);
+
+            // Verify VML drawing contains an OLE shape with proper metadata
+            XSSFSheet xssfSheet = (XSSFSheet)wb2.GetSheetAt(0);
+            XSSFVMLDrawing vml = xssfSheet.GetVMLDrawing(false);
+            ClassicAssert.IsNotNull(vml, "VML drawing should exist after CreateObjectData");
+
+            CT_ClientData oleClientData = null;
+            foreach (object item in vml.GetItems())
+            {
+                if (item is CT_Shape shape && shape.sizeOfClientDataArray() > 0)
+                {
+                    CT_ClientData cd = shape.GetClientDataArray(0);
+                    if (cd.ObjectType == ST_ObjectType.Pict)
+                    {
+                        oleClientData = cd;
+                        break;
+                    }
+                }
+            }
+            ClassicAssert.IsNotNull(oleClientData, "VML must contain a Pict ClientData for the OLE object");
+            ClassicAssert.AreEqual("=EMBED(\"Packager Shell Object\",\"\")", oleClientData.FmlaPict);
+            ClassicAssert.IsNotNull(oleClientData.anchor, "VML ClientData should have an Anchor");
+
+            // Embedded data must survive round-trip
+            EmbeddedExtractor ee = new EmbeddedExtractor();
+            EmbeddedData ed = ee.ExtractAll(wb2.GetSheetAt(0))[0];
+            CollectionAssert.AreEqual(samplePPTX, ed.GetEmbeddedData());
+
+            wb2.Close();
+            wb1.Close();
+        }
+
+        [Test]
+        public void EmbedXSSF_MultipleOleObjects()
+        {
+            IWorkbook wb1 = new XSSFWorkbook();
+            ISheet sh = wb1.CreateSheet();
+            int picIdx = wb1.AddPicture(GetSamplePng(), PictureType.PNG);
+
+            byte[] data1 = Encoding.UTF8.GetBytes("File one content");
+            byte[] data2 = Encoding.UTF8.GetBytes("File two content");
+            byte[] data3 = Encoding.UTF8.GetBytes("File three content");
+            int oleIdx1 = wb1.AddOlePackage(data1, "one.txt", "one.txt", "one.txt");
+            int oleIdx2 = wb1.AddOlePackage(data2, "two.txt", "two.txt", "two.txt");
+            int oleIdx3 = wb1.AddOlePackage(data3, "three.txt", "three.txt", "three.txt");
+
+            IDrawing<IShape> pat = sh.CreateDrawingPatriarch();
+            pat.CreateObjectData(pat.CreateAnchor(0, 0, 0, 0, 0, 1, 2, 4), oleIdx1, picIdx);
+            pat.CreateObjectData(pat.CreateAnchor(0, 0, 0, 0, 3, 1, 5, 4), oleIdx2, picIdx);
+            pat.CreateObjectData(pat.CreateAnchor(0, 0, 0, 0, 6, 1, 8, 4), oleIdx3, picIdx);
+
+            IWorkbook wb2 = XSSFTestDataSamples.WriteOutAndReadBack(wb1);
+
+            // All three files extractable
+            EmbeddedExtractor ee = new EmbeddedExtractor();
+            IList<EmbeddedData> all = ee.ExtractAll(wb2.GetSheetAt(0));
+            ClassicAssert.AreEqual(3, all.Count, "Should have 3 embedded objects");
+            foreach (EmbeddedData ed in all)
+                ClassicAssert.IsNotNull(ed.GetEmbeddedData(), "Each embedded object should have data");
+
+            // VML has 3 OLE shapes
+            XSSFSheet xssfSheet = (XSSFSheet)wb2.GetSheetAt(0);
+            int oleShapeCount = 0;
+            foreach (object item in xssfSheet.GetVMLDrawing(false).GetItems())
+            {
+                if (item is CT_Shape shape && shape.sizeOfClientDataArray() > 0
+                    && shape.GetClientDataArray(0).ObjectType == ST_ObjectType.Pict)
+                    oleShapeCount++;
+            }
+            ClassicAssert.AreEqual(3, oleShapeCount, "VML should contain 3 OLE shapes");
 
             wb2.Close();
             wb1.Close();


### PR DESCRIPTION
### Problem
`XSSFDrawing.CreateObjectData()` creates the DrawingML layer but skips
the VML layer entirely. The code acknowledged this with a comment:
"workaround for not having the vmlDrawing filled". As a result,
embedded OLE objects are invisible in Excel — data is stored correctly
but nothing renders on the sheet.

### Root Cause
Three missing pieces in the VML rendering layer:

1. **CT_ClientData lacked FmlaPict** — the `=EMBED()` formula Excel
   uses to link a VML shape to its OLE package data.
2. **CT_Shape lacked the o:ole attribute** — without it, Excel doesn't
   recognize the shape as an OLE container.
3. **Only `_x0000_t202` (comment) shapetype was registered** — comments
   are invisible by default. OLE objects need `_x0000_t75` (the
   standard picture/embedded-object type with 12 path formulas).

### Changes
- `OpenXmlFormats/Vml/SpreadsheetDrawing.cs`: Add FmlaPict to CT_ClientData
- `OpenXmlFormats/Vml/Main.cs`: Add o:ole attribute to CT_Shape
- `ooxml/XSSF/UserModel/XSSFVMLDrawing.cs`: Register `_x0000_t75`
  shapetype + newOleShape() method
- `ooxml/XSSF/UserModel/XSSFDrawing.cs`: Wire VML shape creation into
  CreateObjectData() with image relationships and anchor coordinates

### Testing
- `EmbedXSSF_VMLShapeCreated`: round-trip verifies VML contains Pict
  ClientData with FmlaPict formula and Anchor
- `EmbedXSSF_MultipleOleObjects`: verifies 3 OLE objects produce 3
  correct VML shapes
- All existing OLE tests continue to pass
- Manually verified in Excel — embedded objects are visible and
  double-click opens the embedded file

Fixes #845