### PR TITLE
Bump System.Security.Cryptography.Xml and System.Formats.Asn1 to 10.0.10 (fixes CI)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,8 +23,8 @@
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.2" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
-    <PackageVersion Include="System.Formats.Asn1" Version="10.0.6" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.10" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageVersion Include="ZString" Version="2.6.0" />
   </ItemGroup>


### PR DESCRIPTION
CI is currently red on every PR, and the cause is not any of the code in them — the build never reaches compile.

`dotnet restore solution/NPOI.Core.Test.sln` fails with `NU1903`: five high-severity advisories against `System.Security.Cryptography.Xml 10.0.6`, promoted to errors by `Warning As Error` in `NPOI.Benchmarks`, which takes down restore for the whole test solution.

```
benchmarks/NPOI.Benchmarks/NPOI.Benchmarks.csproj : error NU1903: Warning As Error:
Package 'System.Security.Cryptography.Xml' 10.0.6 has a known high severity vulnerability
  GHSA-23rf-6693-g89p, GHSA-8q5v-6pqq-x66h, GHSA-cvvh-rhrc-wg4q,
  GHSA-g8r8-53c2-pm3f, GHSA-mmjf-rqrv-855v
```

The failure is time-based rather than change-based: the advisories were published after the last green run, so it began failing on its own. Reproduced on a clean checkout of `master` with no other modifications.

Bumping the crypto package alone trips `NU1109`, because `System.Formats.Asn1` is pinned at `10.0.6` while `Microsoft.Bcl.Cryptography 10.0.10` requires `>= 10.0.10` — so both pins move together. That is the entire change: two lines in `Directory.Packages.props`.

Verified on this branch with the audit **enabled** and no `NuGetAudit=false` override:

- `dotnet restore solution/NPOI.Core.Test.sln` — clean, no `NU1903` / `NU1109`
- `dotnet test solution/NPOI.Core.Test.sln -c Release -f net10.0` — 2803 + 1850 + 79, zero failures

Kept deliberately separate from #1825 so it can be reviewed and merged on its own. #1825's CI is red for this same reason and will go green once this lands.

---

*Submitted by Claude (an AI assistant) on behalf of @ken-swyfft. Analysis and verification by Claude, reviewed before submission.*
