### PR TITLE
Avoid empty custDash node in theme.xml

### DIFF
--- a/OpenXmlFormats/Drawing/ShapeLineProperties.cs
+++ b/OpenXmlFormats/Drawing/ShapeLineProperties.cs
@@ -435,7 +435,6 @@ namespace NPOI.OpenXmlFormats.Dml
         internal static CT_DashStopList Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             CT_DashStopList ctObj = new CT_DashStopList();
-            //ctObj.dsField = new List<CT_DashStop>();
             foreach(XmlNode childNode in node.ChildNodes)
             {
                 ctObj.ds.Add(CT_DashStop.Parse(childNode, namespaceManager));
@@ -473,12 +472,15 @@ namespace NPOI.OpenXmlFormats.Dml
 
         internal void Write(StreamWriter sw, string nodeName)
         {
-            sw.Write(string.Format("<a:{0}>", nodeName));
-            foreach(var child in this.ds)
+            if(this.ds.Count != 0)
             {
-                child.Write(sw, "ds");
+                sw.Write(string.Format("<a:{0}>", nodeName));
+                foreach(var child in this.ds)
+                {
+                    child.Write(sw, "ds");
+                }
+                sw.Write(string.Format("</a:{0}>", nodeName));
             }
-            sw.Write(string.Format("</a:{0}>", nodeName));
         }
     }
 


### PR DESCRIPTION
fix #1824

Before fix: 
```
	<a:lnStyleLst>
		<a:ln w="6350" cap="flat" cmpd="sng" algn="ctr">
			<a:solidFill>
				<a:schemeClr val="phClr"/>
			</a:solidFill>
			<a:prstDash val="solid"/>
			<a:custDash/>
			<a:miter lim="800000"/>
		</a:ln>
		<a:ln w="12700" cap="flat" cmpd="sng" algn="ctr">
			<a:solidFill>
				<a:schemeClr val="phClr"/>
			</a:solidFill>
			<a:prstDash val="solid"/>
			<a:custDash/>
			<a:miter lim="800000"/>
		</a:ln>
		<a:ln w="19050" cap="flat" cmpd="sng" algn="ctr">
			<a:solidFill>
				<a:schemeClr val="phClr"/>
			</a:solidFill>
			<a:prstDash val="solid"/>
			<a:custDash/>
			<a:miter lim="800000"/>
		</a:ln>
	</a:lnStyleLst>
```

After fix:
```
	<a:lnStyleLst>
		<a:ln w="6350" cap="flat" cmpd="sng" algn="ctr">
			<a:solidFill>
				<a:schemeClr val="phClr"/>
			</a:solidFill>
			<a:prstDash val="solid"/>
			<a:miter lim="800000"/>
		</a:ln>
		<a:ln w="12700" cap="flat" cmpd="sng" algn="ctr">
			<a:solidFill>
				<a:schemeClr val="phClr"/>
			</a:solidFill>
			<a:prstDash val="solid"/>
			<a:miter lim="800000"/>
		</a:ln>
		<a:ln w="19050" cap="flat" cmpd="sng" algn="ctr">
			<a:solidFill>
				<a:schemeClr val="phClr"/>
			</a:solidFill>
			<a:prstDash val="solid"/>
			<a:miter lim="800000"/>
		</a:ln>
	</a:lnStyleLst>
```
