### PR TITLE
SkiaSharp reference update

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,9 +18,9 @@
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
-    <PackageVersion Include="SkiaSharp" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.4" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.4" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.10" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />

--- a/main/NPOI.Core.csproj
+++ b/main/NPOI.Core.csproj
@@ -26,8 +26,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" />
     <PackageReference Include="BouncyCastle.Cryptography" />
     <PackageReference Include="SharpZipLib" />
-    <PackageReference Include="SkiaSharp" PrivateAssets="all" Pack="false" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" PrivateAssets="all" Pack="false" />
+    <PackageReference Include="SkiaSharp"/>
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies"/>
     <PackageReference Include="ZString" />
   </ItemGroup>
 

--- a/ooxml/NPOI.OOXML.Core.csproj
+++ b/ooxml/NPOI.OOXML.Core.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" />
-    <PackageReference Include="SkiaSharp" PrivateAssets="all" Pack="false"/>
+    <PackageReference Include="SkiaSharp"/>
     <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 


### PR DESCRIPTION
- Remove PrivateAssets and Pack tag
- Upgrade to 3.119.4.0

fix #1848 