### PR TITLE
Update Microsoft.SourceLink.GitHub package version to fix security issue

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="MathNet.Numerics.Signed" Version="5.0.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.401" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="NUnit" Version="4.5.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />


### PR DESCRIPTION
The Microsoft.Build.Tasks.Git dependency on Microsoft.SourceLink.GitHub package got an Security Advisory (https://github.com/advisories/GHSA-23fw-v26w-5fgq).

Update the Microsoft.SourceLink.GitHub with the fixed one.

The package version is compatible with .NET 8.0 and .NET Fx 4.7.2, it should not be an issue for builds.