### PR TITLE
Fix two windows-latest test flakes: TestNPOI1469 rounding and POIDataSamples.GetFile sharing mode

### DIFF
--- a/testcases/main/HSSF/UserModel/TestCellStyle.cs
+++ b/testcases/main/HSSF/UserModel/TestCellStyle.cs
@@ -529,7 +529,10 @@ namespace TestCases.HSSF.UserModel
             const int rows = 1_000;
             const int dop = 2;
 
-            var time = DateTime.UtcNow.AddYears(-1);
+            // Truncate to whole seconds so that ToString("HH:mm:ss") (which truncates)
+            // and DataFormatter (which rounds the Excel OLE date double) agree.
+            var raw = DateTime.UtcNow.AddYears(-1);
+            var time = new DateTime(raw.Ticks - raw.Ticks % TimeSpan.TicksPerSecond, raw.Kind);
 
             Console.WriteLine($"Start time: {time:yyyy/MM/dd} {time:HH:mm:ss}");
 

--- a/testcases/main/POIDataSamples.cs
+++ b/testcases/main/POIDataSamples.cs
@@ -231,7 +231,10 @@ namespace TestCases
             //{
             //    throw new RuntimeException(e);
             //}
-            return new FileStream(path,FileMode.OpenOrCreate);
+            // Read-only with ReadWrite sharing: the net472 and net10.0 test hosts run in parallel and
+            // read the same sample files, and a ReadWrite handle here makes every concurrent
+            // reader fail with "being used by another process" on Windows.
+            return new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         }
         public string[] GetFiles()
         {


### PR DESCRIPTION
`windows-latest` on master has been red on its last two pushes (runs 33473168767 on 2026-09-01 and 34364474895 on 2026-09-09) for a single test each time, `TestNPOI1469`, and a fork of this repo hit a second single-test failure on the same job. Both are test-infrastructure races, not library bugs. This PR fixes both. Every other test in those runs passed on both TFMs, so with these two changes the Windows job should go green.

**1. `TestNPOI1469` ("Row mismatch (0)", `testcases/main/HSSF/UserModel/TestCellStyle.cs`)**

The test formats its start time with `ToString("HH:mm:ss")`, which truncates, and compares against `DataFormatter`, which rounds the Excel OLE-date double. Whenever `DateTime.UtcNow` lands in the upper half of a second the two disagree by one second. Truncating the start time to whole seconds makes both paths agree. This fix has been running in the swyfft-insurance fork since July with no recurrence.

**2. `TestDetectAsPOIFS` (`IOException: SampleSS.xls ... being used by another process`)**

`POIDataSamples.GetFile()` opens sample files with `FileMode.OpenOrCreate`, which means `FileAccess.ReadWrite` plus `FileShare.Read`. Nuke runs the net472 and net10.0 test hosts in parallel, so while `TestHSSFWorkbook.CloseDoesNotModifyWorkbook` holds `SampleSS.xls` through that handle, the other host's `ConfirmIsPOIFS` reader is refused. Linux has no such sharing rule, which is why `ubuntu-latest` never sees it. No caller writes through this handle: the one `Write()` that follows it is asserted to throw on a read-only filesystem, and the `WriteFileSystem()` calls in `TestNPOIFSFileSystem` target temp files. Opening read-only with `FileShare.ReadWrite` removes the race without changing any test's behaviour. Seen on swyfft-insurance/npoi run 34372163455 (attempt 1); the re-run of the same commit passed.

Verified locally on this branch: `NPOI.TestCases` builds on net10.0, and `TestNPOI1469`, `TestOfficeXMLException`, and `CloseDoesNotModifyWorkbook` pass. Both changes are confined to `testcases/main`.

_(PR opened by Claude, an AI assistant, on Ken's behalf.)_
