### PR TITLE
Mark Microsoft.SourceLink.GitHub PrivateAssets=all so it is not a consumer dependency in the nuspec

### DIFF
--- a/OpenXmlFormats/NPOI.OpenXmlFormats.Core.csproj
+++ b/OpenXmlFormats/NPOI.OpenXmlFormats.Core.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <PackageReference Include="ZString" />
   </ItemGroup>
 

--- a/main/NPOI.Core.csproj
+++ b/main/NPOI.Core.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="ExtendedNumerics.BigDecimal" />
     <PackageReference Include="MathNet.Numerics.Signed" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <PackageReference Include="BouncyCastle.Cryptography" />
     <PackageReference Include="SharpZipLib" />
     <PackageReference Include="SkiaSharp"/>

--- a/ooxml/NPOI.OOXML.Core.csproj
+++ b/ooxml/NPOI.OOXML.Core.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <PackageReference Include="SkiaSharp"/>
     <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>

--- a/openxml4Net/NPOI.OpenXml4Net.Core.csproj
+++ b/openxml4Net/NPOI.OpenXml4Net.Core.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/solution/NPOI.Pack.csproj
+++ b/solution/NPOI.Pack.csproj
@@ -23,7 +23,8 @@
     <PackageReference Include="ExtendedNumerics.BigDecimal" />
     <PackageReference Include="MathNet.Numerics.Signed" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" />
+    <!-- Build-time only. Without PrivateAssets it is written into the nuspec as a consumer dependency. -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
     <PackageReference Include="SharpZipLib" />
     <PackageReference Include="SkiaSharp" ExcludeAssets="runtime" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" ExcludeAssets="runtime" />


### PR DESCRIPTION
`NPOI 2.8.0` on nuget.org declares `Microsoft.SourceLink.GitHub 8.0.0` as a dependency in all five TFM groups of its nuspec. SourceLink is a build-time-only package (it and `Microsoft.Build.Tasks.Git` both mark themselves `developmentDependency=true`), and NPOI even declares the edge with `exclude="Build,Analyzers"`, so consumers never import anything from it. But `dotnet restore` audits the whole resolved graph regardless of asset exclusion. So on 2026-09-08, when GHSA-23fw-v26w-5fgq (CVE-2026-62900) was published against `Microsoft.Build.Tasks.Git 8.0.0`, every NPOI consumer that promotes NuGet audit warnings to errors went red on NU1902 through a node it never asked for and cannot use. #1866 moved this repo to 10.0.401, which clears today's advisory for the next release; this PR removes the root cause so the next advisory on that package line cannot reach consumers at all.

The leak comes from the umbrella `solution/NPOI.Pack.csproj`: its `ProjectReference`s are `PrivateAssets="all"`, so the library projects contribute nothing to the nuspec, and every `PackageReference` in the Pack project itself becomes a consumer dependency unless it carries `PrivateAssets="all"`. This PR adds that to the SourceLink reference there, and to the same reference in the four library projects for consistency, so a future change to how the package is assembled cannot reintroduce it.

**Before / after**, comparing the published 2.8.0 nuspec with `dotnet pack solution/NPOI.Pack.csproj -c Release` on this branch:

| TFM group | published 2.8.0 | this branch |
|---|---|---|
| net472, netstandard2.0, netstandard2.1, net8.0, net10.0 | `Microsoft.SourceLink.GitHub 8.0.0` present | absent |

Every other dependency in every group is unchanged. SourceLink itself keeps working exactly as before: the package is still restored and its build assets still apply to each project; only the nuspec dependency entry disappears.

The same change has been in the swyfft-insurance fork since 2026-09-09 (swyfft-insurance/npoi#5), where the rebuilt package was verified against a consumer solution of about 180 projects: neither SourceLink package nor `Microsoft.Build.Tasks.Git` appears anywhere in the resolved graph any more.

_(PR opened by Claude, an AI assistant, on Ken's behalf.)_
